### PR TITLE
Accept glob source to pluck and merge schemas from multiple files 

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -81105,13 +81105,19 @@ async function extractSchemaString(schemaDocumentNode) {
   return print(schemaDocumentNode);
 }
 
+// https://github.com/apollographql/federation/issues/1875
+async function handleQueryQueryFederation2Bug(schema) {
+  return schema.replace('query: Query', '');
+}
+
 const pluckSchema = flow(
   getFilepaths,
   map(getContent),
   map(pluckGQL),
   filter(Boolean),
   mergeGql,
-  extractSchemaString
+  extractSchemaString,
+  handleQueryQueryFederation2Bug
 );
 
 module.exports = pluckSchema;

--- a/dist/index.js
+++ b/dist/index.js
@@ -62125,8 +62125,16 @@ async function pluckGQL({ filePath, content }) {
  * @returns {Promise<string>}
  */
 async function mergeGql(schemas) {
-  console.log(schemas);
   return mergeTypeDefs(schemas);
+}
+
+/**
+ *
+ * @param {DocumentNode} schemaDocumentNode
+ * @returns {Promise<string>}
+ */
+async function extractSchemaString(schemaDocumentNode) {
+  return schemaDocumentNode.loc.source.body;
 }
 
 /**
@@ -62137,7 +62145,6 @@ async function mergeGql(schemas) {
 async function writeSchemaToOutput(schema) {
   const output = core.getInput('output');
   core.info(`Writing to file ${output}`);
-  console.log(schema);
   await fs.writeFile(output, schema);
 }
 
@@ -62149,6 +62156,7 @@ async function main() {
     asyncMap(pluckGQL),
     asyncFilter(Boolean),
     mergeGql,
+    extractSchemaString,
     writeSchemaToOutput
   );
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,7 +50,242 @@ module.exports =
 /******/ })
 /************************************************************************/
 /******/ ([
-/* 0 */,
+/* 0 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.visitResult = exports.visitErrors = exports.visitData = void 0;
+const getOperationASTFromRequest_js_1 = __webpack_require__(769);
+const graphql_1 = __webpack_require__(232);
+const collectFields_js_1 = __webpack_require__(481);
+function visitData(data, enter, leave) {
+    if (Array.isArray(data)) {
+        return data.map(value => visitData(value, enter, leave));
+    }
+    else if (typeof data === 'object') {
+        const newData = enter != null ? enter(data) : data;
+        if (newData != null) {
+            for (const key in newData) {
+                const value = newData[key];
+                Object.defineProperty(newData, key, {
+                    value: visitData(value, enter, leave),
+                });
+            }
+        }
+        return leave != null ? leave(newData) : newData;
+    }
+    return data;
+}
+exports.visitData = visitData;
+function visitErrors(errors, visitor) {
+    return errors.map(error => visitor(error));
+}
+exports.visitErrors = visitErrors;
+function visitResult(result, request, schema, resultVisitorMap, errorVisitorMap) {
+    const fragments = request.document.definitions.reduce((acc, def) => {
+        if (def.kind === graphql_1.Kind.FRAGMENT_DEFINITION) {
+            acc[def.name.value] = def;
+        }
+        return acc;
+    }, {});
+    const variableValues = request.variables || {};
+    const errorInfo = {
+        segmentInfoMap: new Map(),
+        unpathedErrors: new Set(),
+    };
+    const data = result.data;
+    const errors = result.errors;
+    const visitingErrors = errors != null && errorVisitorMap != null;
+    const operationDocumentNode = (0, getOperationASTFromRequest_js_1.getOperationASTFromRequest)(request);
+    if (data != null && operationDocumentNode != null) {
+        result.data = visitRoot(data, operationDocumentNode, schema, fragments, variableValues, resultVisitorMap, visitingErrors ? errors : undefined, errorInfo);
+    }
+    if (errors != null && errorVisitorMap) {
+        result.errors = visitErrorsByType(errors, errorVisitorMap, errorInfo);
+    }
+    return result;
+}
+exports.visitResult = visitResult;
+function visitErrorsByType(errors, errorVisitorMap, errorInfo) {
+    const segmentInfoMap = errorInfo.segmentInfoMap;
+    const unpathedErrors = errorInfo.unpathedErrors;
+    const unpathedErrorVisitor = errorVisitorMap['__unpathed'];
+    return errors.map(originalError => {
+        const pathSegmentsInfo = segmentInfoMap.get(originalError);
+        const newError = pathSegmentsInfo == null
+            ? originalError
+            : pathSegmentsInfo.reduceRight((acc, segmentInfo) => {
+                const typeName = segmentInfo.type.name;
+                const typeVisitorMap = errorVisitorMap[typeName];
+                if (typeVisitorMap == null) {
+                    return acc;
+                }
+                const errorVisitor = typeVisitorMap[segmentInfo.fieldName];
+                return errorVisitor == null ? acc : errorVisitor(acc, segmentInfo.pathIndex);
+            }, originalError);
+        if (unpathedErrorVisitor && unpathedErrors.has(originalError)) {
+            return unpathedErrorVisitor(newError);
+        }
+        return newError;
+    });
+}
+function getOperationRootType(schema, operationDef) {
+    switch (operationDef.operation) {
+        case 'query':
+            return schema.getQueryType();
+        case 'mutation':
+            return schema.getMutationType();
+        case 'subscription':
+            return schema.getSubscriptionType();
+    }
+}
+function visitRoot(root, operation, schema, fragments, variableValues, resultVisitorMap, errors, errorInfo) {
+    const operationRootType = getOperationRootType(schema, operation);
+    const collectedFields = (0, collectFields_js_1.collectFields)(schema, fragments, variableValues, operationRootType, operation.selectionSet, new Map(), new Set());
+    return visitObjectValue(root, operationRootType, collectedFields, schema, fragments, variableValues, resultVisitorMap, 0, errors, errorInfo);
+}
+function visitObjectValue(object, type, fieldNodeMap, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo) {
+    var _a;
+    const fieldMap = type.getFields();
+    const typeVisitorMap = resultVisitorMap === null || resultVisitorMap === void 0 ? void 0 : resultVisitorMap[type.name];
+    const enterObject = typeVisitorMap === null || typeVisitorMap === void 0 ? void 0 : typeVisitorMap.__enter;
+    const newObject = enterObject != null ? enterObject(object) : object;
+    let sortedErrors;
+    let errorMap = null;
+    if (errors != null) {
+        sortedErrors = sortErrorsByPathSegment(errors, pathIndex);
+        errorMap = sortedErrors.errorMap;
+        for (const error of sortedErrors.unpathedErrors) {
+            errorInfo.unpathedErrors.add(error);
+        }
+    }
+    for (const [responseKey, subFieldNodes] of fieldNodeMap) {
+        const fieldName = subFieldNodes[0].name.value;
+        let fieldType = (_a = fieldMap[fieldName]) === null || _a === void 0 ? void 0 : _a.type;
+        if (fieldType == null) {
+            switch (fieldName) {
+                case '__typename':
+                    fieldType = graphql_1.TypeNameMetaFieldDef.type;
+                    break;
+                case '__schema':
+                    fieldType = graphql_1.SchemaMetaFieldDef.type;
+                    break;
+            }
+        }
+        const newPathIndex = pathIndex + 1;
+        let fieldErrors;
+        if (errorMap) {
+            fieldErrors = errorMap[responseKey];
+            if (fieldErrors != null) {
+                delete errorMap[responseKey];
+            }
+            addPathSegmentInfo(type, fieldName, newPathIndex, fieldErrors, errorInfo);
+        }
+        const newValue = visitFieldValue(object[responseKey], fieldType, subFieldNodes, schema, fragments, variableValues, resultVisitorMap, newPathIndex, fieldErrors, errorInfo);
+        updateObject(newObject, responseKey, newValue, typeVisitorMap, fieldName);
+    }
+    const oldTypename = newObject.__typename;
+    if (oldTypename != null) {
+        updateObject(newObject, '__typename', oldTypename, typeVisitorMap, '__typename');
+    }
+    if (errorMap) {
+        for (const errorsKey in errorMap) {
+            const errors = errorMap[errorsKey];
+            for (const error of errors) {
+                errorInfo.unpathedErrors.add(error);
+            }
+        }
+    }
+    const leaveObject = typeVisitorMap === null || typeVisitorMap === void 0 ? void 0 : typeVisitorMap.__leave;
+    return leaveObject != null ? leaveObject(newObject) : newObject;
+}
+function updateObject(object, responseKey, newValue, typeVisitorMap, fieldName) {
+    if (typeVisitorMap == null) {
+        object[responseKey] = newValue;
+        return;
+    }
+    const fieldVisitor = typeVisitorMap[fieldName];
+    if (fieldVisitor == null) {
+        object[responseKey] = newValue;
+        return;
+    }
+    const visitedValue = fieldVisitor(newValue);
+    if (visitedValue === undefined) {
+        delete object[responseKey];
+        return;
+    }
+    object[responseKey] = visitedValue;
+}
+function visitListValue(list, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo) {
+    return list.map(listMember => visitFieldValue(listMember, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex + 1, errors, errorInfo));
+}
+function visitFieldValue(value, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors = [], errorInfo) {
+    if (value == null) {
+        return value;
+    }
+    const nullableType = (0, graphql_1.getNullableType)(returnType);
+    if ((0, graphql_1.isListType)(nullableType)) {
+        return visitListValue(value, nullableType.ofType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
+    }
+    else if ((0, graphql_1.isAbstractType)(nullableType)) {
+        const finalType = schema.getType(value.__typename);
+        const collectedFields = (0, collectFields_js_1.collectSubFields)(schema, fragments, variableValues, finalType, fieldNodes);
+        return visitObjectValue(value, finalType, collectedFields, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
+    }
+    else if ((0, graphql_1.isObjectType)(nullableType)) {
+        const collectedFields = (0, collectFields_js_1.collectSubFields)(schema, fragments, variableValues, nullableType, fieldNodes);
+        return visitObjectValue(value, nullableType, collectedFields, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
+    }
+    const typeVisitorMap = resultVisitorMap === null || resultVisitorMap === void 0 ? void 0 : resultVisitorMap[nullableType.name];
+    if (typeVisitorMap == null) {
+        return value;
+    }
+    const visitedValue = typeVisitorMap(value);
+    return visitedValue === undefined ? value : visitedValue;
+}
+function sortErrorsByPathSegment(errors, pathIndex) {
+    var _a;
+    const errorMap = Object.create(null);
+    const unpathedErrors = new Set();
+    for (const error of errors) {
+        const pathSegment = (_a = error.path) === null || _a === void 0 ? void 0 : _a[pathIndex];
+        if (pathSegment == null) {
+            unpathedErrors.add(error);
+            continue;
+        }
+        if (pathSegment in errorMap) {
+            errorMap[pathSegment].push(error);
+        }
+        else {
+            errorMap[pathSegment] = [error];
+        }
+    }
+    return {
+        errorMap,
+        unpathedErrors,
+    };
+}
+function addPathSegmentInfo(type, fieldName, pathIndex, errors = [], errorInfo) {
+    for (const error of errors) {
+        const segmentInfo = {
+            type,
+            fieldName,
+            pathIndex,
+        };
+        const pathSegmentsInfo = errorInfo.segmentInfoMap.get(error);
+        if (pathSegmentsInfo == null) {
+            errorInfo.segmentInfoMap.set(error, [segmentInfo]);
+        }
+        else {
+            pathSegmentsInfo.push(segmentInfo);
+        }
+    }
+}
+
+
+/***/ }),
 /* 1 */,
 /* 2 */,
 /* 3 */,
@@ -109,7 +344,45 @@ var _default = {
 exports.default = _default;
 
 /***/ }),
-/* 11 */,
+/* 11 */
+/***/ (function(module) {
+
+// Returns a wrapper function that returns a wrapped callback
+// The wrapper function should do some stuff, and return a
+// presumably different callback function.
+// This makes sure that own properties are retained, so that
+// decorations and such are not lost along the way.
+module.exports = wrappy
+function wrappy (fn, cb) {
+  if (fn && cb) return wrappy(fn)(cb)
+
+  if (typeof fn !== 'function')
+    throw new TypeError('need wrapper function')
+
+  Object.keys(fn).forEach(function (k) {
+    wrapper[k] = fn[k]
+  })
+
+  return wrapper
+
+  function wrapper() {
+    var args = new Array(arguments.length)
+    for (var i = 0; i < args.length; i++) {
+      args[i] = arguments[i]
+    }
+    var ret = fn.apply(this, args)
+    var cb = args[args.length-1]
+    if (typeof ret === 'function' && ret !== cb) {
+      Object.keys(cb).forEach(function (k) {
+        ret[k] = cb[k]
+      })
+    }
+    return ret
+  }
+}
+
+
+/***/ }),
 /* 12 */,
 /* 13 */,
 /* 14 */,
@@ -121,7 +394,51 @@ module.exports = require("tls");
 
 /***/ }),
 /* 17 */,
-/* 18 */,
+/* 18 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeInterface = void 0;
+const graphql_1 = __webpack_require__(232);
+const fields_js_1 = __webpack_require__(663);
+const directives_js_1 = __webpack_require__(154);
+const index_js_1 = __webpack_require__(948);
+function mergeInterface(node, existingNode, config) {
+    if (existingNode) {
+        try {
+            return {
+                name: node.name,
+                description: node['description'] || existingNode['description'],
+                kind: (config === null || config === void 0 ? void 0 : config.convertExtensions) ||
+                    node.kind === 'InterfaceTypeDefinition' ||
+                    existingNode.kind === 'InterfaceTypeDefinition'
+                    ? 'InterfaceTypeDefinition'
+                    : 'InterfaceTypeExtension',
+                loc: node.loc,
+                fields: (0, fields_js_1.mergeFields)(node, node.fields, existingNode.fields, config),
+                directives: (0, directives_js_1.mergeDirectives)(node.directives, existingNode.directives, config),
+                interfaces: node['interfaces']
+                    ? (0, index_js_1.mergeNamedTypeArray)(node['interfaces'], existingNode['interfaces'], config)
+                    : undefined,
+            };
+        }
+        catch (e) {
+            throw new Error(`Unable to merge GraphQL interface "${node.name.value}": ${e.message}`);
+        }
+    }
+    return (config === null || config === void 0 ? void 0 : config.convertExtensions)
+        ? {
+            ...node,
+            kind: graphql_1.Kind.INTERFACE_TYPE_DEFINITION,
+        }
+        : node;
+}
+exports.mergeInterface = mergeInterface;
+
+
+/***/ }),
 /* 19 */,
 /* 20 */,
 /* 21 */
@@ -143,7 +460,52 @@ exports.default = _default;
 
 /***/ }),
 /* 22 */,
-/* 23 */,
+/* 23 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeSchemaDefs = exports.DEFAULT_OPERATION_TYPE_NAME_MAP = void 0;
+const graphql_1 = __webpack_require__(232);
+const directives_js_1 = __webpack_require__(154);
+exports.DEFAULT_OPERATION_TYPE_NAME_MAP = {
+    query: 'Query',
+    mutation: 'Mutation',
+    subscription: 'Subscription',
+};
+function mergeOperationTypes(opNodeList = [], existingOpNodeList = []) {
+    const finalOpNodeList = [];
+    for (const opNodeType in exports.DEFAULT_OPERATION_TYPE_NAME_MAP) {
+        const opNode = opNodeList.find(n => n.operation === opNodeType) || existingOpNodeList.find(n => n.operation === opNodeType);
+        if (opNode) {
+            finalOpNodeList.push(opNode);
+        }
+    }
+    return finalOpNodeList;
+}
+function mergeSchemaDefs(node, existingNode, config) {
+    if (existingNode) {
+        return {
+            kind: node.kind === graphql_1.Kind.SCHEMA_DEFINITION || existingNode.kind === graphql_1.Kind.SCHEMA_DEFINITION
+                ? graphql_1.Kind.SCHEMA_DEFINITION
+                : graphql_1.Kind.SCHEMA_EXTENSION,
+            description: node['description'] || existingNode['description'],
+            directives: (0, directives_js_1.mergeDirectives)(node.directives, existingNode.directives, config),
+            operationTypes: mergeOperationTypes(node.operationTypes, existingNode.operationTypes),
+        };
+    }
+    return ((config === null || config === void 0 ? void 0 : config.convertExtensions)
+        ? {
+            ...node,
+            kind: graphql_1.Kind.SCHEMA_DEFINITION,
+        }
+        : node);
+}
+exports.mergeSchemaDefs = mergeSchemaDefs;
+
+
+/***/ }),
 /* 24 */
 /***/ (function(__unusedmodule, exports) {
 
@@ -1092,7 +1454,54 @@ function UniqueOperationTypesRule(context) {
 /***/ }),
 /* 47 */,
 /* 48 */,
-/* 49 */,
+/* 49 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+var wrappy = __webpack_require__(11)
+module.exports = wrappy(once)
+module.exports.strict = wrappy(onceStrict)
+
+once.proto = once(function () {
+  Object.defineProperty(Function.prototype, 'once', {
+    value: function () {
+      return once(this)
+    },
+    configurable: true
+  })
+
+  Object.defineProperty(Function.prototype, 'onceStrict', {
+    value: function () {
+      return onceStrict(this)
+    },
+    configurable: true
+  })
+})
+
+function once (fn) {
+  var f = function () {
+    if (f.called) return f.value
+    f.called = true
+    return f.value = fn.apply(this, arguments)
+  }
+  f.called = false
+  return f
+}
+
+function onceStrict (fn) {
+  var f = function () {
+    if (f.called)
+      throw new Error(f.onceError)
+    f.called = true
+    return f.value = fn.apply(this, arguments)
+  }
+  var name = fn.name || 'Function wrapped with `once`'
+  f.onceError = name + " shouldn't be called more than once"
+  f.called = false
+  return f
+}
+
+
+/***/ }),
 /* 50 */,
 /* 51 */,
 /* 52 */,
@@ -1345,7 +1754,128 @@ function isRequiredArgumentNode(arg) {
 /* 60 */,
 /* 61 */,
 /* 62 */,
-/* 63 */,
+/* 63 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.modifyObjectFields = exports.selectObjectFields = exports.removeObjectFields = exports.appendObjectFields = void 0;
+const graphql_1 = __webpack_require__(232);
+const Interfaces_js_1 = __webpack_require__(368);
+const mapSchema_js_1 = __webpack_require__(675);
+const addTypes_js_1 = __webpack_require__(884);
+function appendObjectFields(schema, typeName, additionalFields) {
+    if (schema.getType(typeName) == null) {
+        return (0, addTypes_js_1.addTypes)(schema, [
+            new graphql_1.GraphQLObjectType({
+                name: typeName,
+                fields: additionalFields,
+            }),
+        ]);
+    }
+    return (0, mapSchema_js_1.mapSchema)(schema, {
+        [Interfaces_js_1.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                const newFieldConfigMap = {};
+                for (const fieldName in originalFieldConfigMap) {
+                    newFieldConfigMap[fieldName] = originalFieldConfigMap[fieldName];
+                }
+                for (const fieldName in additionalFields) {
+                    newFieldConfigMap[fieldName] = additionalFields[fieldName];
+                }
+                return (0, mapSchema_js_1.correctASTNodes)(new graphql_1.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        },
+    });
+}
+exports.appendObjectFields = appendObjectFields;
+function removeObjectFields(schema, typeName, testFn) {
+    const removedFields = {};
+    const newSchema = (0, mapSchema_js_1.mapSchema)(schema, {
+        [Interfaces_js_1.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                const newFieldConfigMap = {};
+                for (const fieldName in originalFieldConfigMap) {
+                    const originalFieldConfig = originalFieldConfigMap[fieldName];
+                    if (testFn(fieldName, originalFieldConfig)) {
+                        removedFields[fieldName] = originalFieldConfig;
+                    }
+                    else {
+                        newFieldConfigMap[fieldName] = originalFieldConfig;
+                    }
+                }
+                return (0, mapSchema_js_1.correctASTNodes)(new graphql_1.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        },
+    });
+    return [newSchema, removedFields];
+}
+exports.removeObjectFields = removeObjectFields;
+function selectObjectFields(schema, typeName, testFn) {
+    const selectedFields = {};
+    (0, mapSchema_js_1.mapSchema)(schema, {
+        [Interfaces_js_1.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                for (const fieldName in originalFieldConfigMap) {
+                    const originalFieldConfig = originalFieldConfigMap[fieldName];
+                    if (testFn(fieldName, originalFieldConfig)) {
+                        selectedFields[fieldName] = originalFieldConfig;
+                    }
+                }
+            }
+            return undefined;
+        },
+    });
+    return selectedFields;
+}
+exports.selectObjectFields = selectObjectFields;
+function modifyObjectFields(schema, typeName, testFn, newFields) {
+    const removedFields = {};
+    const newSchema = (0, mapSchema_js_1.mapSchema)(schema, {
+        [Interfaces_js_1.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                const newFieldConfigMap = {};
+                for (const fieldName in originalFieldConfigMap) {
+                    const originalFieldConfig = originalFieldConfigMap[fieldName];
+                    if (testFn(fieldName, originalFieldConfig)) {
+                        removedFields[fieldName] = originalFieldConfig;
+                    }
+                    else {
+                        newFieldConfigMap[fieldName] = originalFieldConfig;
+                    }
+                }
+                for (const fieldName in newFields) {
+                    const fieldConfig = newFields[fieldName];
+                    newFieldConfigMap[fieldName] = fieldConfig;
+                }
+                return (0, mapSchema_js_1.correctASTNodes)(new graphql_1.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        },
+    });
+    return [newSchema, removedFields];
+}
+exports.modifyObjectFields = modifyObjectFields;
+
+
+/***/ }),
 /* 64 */,
 /* 65 */,
 /* 66 */,
@@ -3273,7 +3803,40 @@ module.exports = require("os");
 /* 91 */,
 /* 92 */,
 /* 93 */,
-/* 94 */,
+/* 94 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.DirectiveLocation = void 0;
+var DirectiveLocation;
+(function (DirectiveLocation) {
+    /** Request Definitions */
+    DirectiveLocation["QUERY"] = "QUERY";
+    DirectiveLocation["MUTATION"] = "MUTATION";
+    DirectiveLocation["SUBSCRIPTION"] = "SUBSCRIPTION";
+    DirectiveLocation["FIELD"] = "FIELD";
+    DirectiveLocation["FRAGMENT_DEFINITION"] = "FRAGMENT_DEFINITION";
+    DirectiveLocation["FRAGMENT_SPREAD"] = "FRAGMENT_SPREAD";
+    DirectiveLocation["INLINE_FRAGMENT"] = "INLINE_FRAGMENT";
+    DirectiveLocation["VARIABLE_DEFINITION"] = "VARIABLE_DEFINITION";
+    /** Type System Definitions */
+    DirectiveLocation["SCHEMA"] = "SCHEMA";
+    DirectiveLocation["SCALAR"] = "SCALAR";
+    DirectiveLocation["OBJECT"] = "OBJECT";
+    DirectiveLocation["FIELD_DEFINITION"] = "FIELD_DEFINITION";
+    DirectiveLocation["ARGUMENT_DEFINITION"] = "ARGUMENT_DEFINITION";
+    DirectiveLocation["INTERFACE"] = "INTERFACE";
+    DirectiveLocation["UNION"] = "UNION";
+    DirectiveLocation["ENUM"] = "ENUM";
+    DirectiveLocation["ENUM_VALUE"] = "ENUM_VALUE";
+    DirectiveLocation["INPUT_OBJECT"] = "INPUT_OBJECT";
+    DirectiveLocation["INPUT_FIELD_DEFINITION"] = "INPUT_FIELD_DEFINITION";
+})(DirectiveLocation = exports.DirectiveLocation || (exports.DirectiveLocation = {}));
+
+
+/***/ }),
 /* 95 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -4257,7 +4820,89 @@ function inheritsComments(child, parent) {
 /* 109 */,
 /* 110 */,
 /* 111 */,
-/* 112 */,
+/* 112 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getArgumentValues = void 0;
+const graphql_1 = __webpack_require__(232);
+const errors_js_1 = __webpack_require__(403);
+const inspect_js_1 = __webpack_require__(524);
+/**
+ * Prepares an object map of argument values given a list of argument
+ * definitions and list of argument AST nodes.
+ *
+ * Note: The returned value is a plain Object with a prototype, since it is
+ * exposed to user code. Care should be taken to not pull values from the
+ * Object prototype.
+ */
+function getArgumentValues(def, node, variableValues = {}) {
+    var _a;
+    const variableMap = Object.entries(variableValues).reduce((prev, [key, value]) => ({
+        ...prev,
+        [key]: value,
+    }), {});
+    const coercedValues = {};
+    const argumentNodes = (_a = node.arguments) !== null && _a !== void 0 ? _a : [];
+    const argNodeMap = argumentNodes.reduce((prev, arg) => ({
+        ...prev,
+        [arg.name.value]: arg,
+    }), {});
+    for (const { name, type: argType, defaultValue } of def.args) {
+        const argumentNode = argNodeMap[name];
+        if (!argumentNode) {
+            if (defaultValue !== undefined) {
+                coercedValues[name] = defaultValue;
+            }
+            else if ((0, graphql_1.isNonNullType)(argType)) {
+                throw (0, errors_js_1.createGraphQLError)(`Argument "${name}" of required type "${(0, inspect_js_1.inspect)(argType)}" ` + 'was not provided.', {
+                    nodes: [node],
+                });
+            }
+            continue;
+        }
+        const valueNode = argumentNode.value;
+        let isNull = valueNode.kind === graphql_1.Kind.NULL;
+        if (valueNode.kind === graphql_1.Kind.VARIABLE) {
+            const variableName = valueNode.name.value;
+            if (variableValues == null || variableMap[variableName] == null) {
+                if (defaultValue !== undefined) {
+                    coercedValues[name] = defaultValue;
+                }
+                else if ((0, graphql_1.isNonNullType)(argType)) {
+                    throw (0, errors_js_1.createGraphQLError)(`Argument "${name}" of required type "${(0, inspect_js_1.inspect)(argType)}" ` +
+                        `was provided the variable "$${variableName}" which was not provided a runtime value.`, {
+                        nodes: [valueNode],
+                    });
+                }
+                continue;
+            }
+            isNull = variableValues[variableName] == null;
+        }
+        if (isNull && (0, graphql_1.isNonNullType)(argType)) {
+            throw (0, errors_js_1.createGraphQLError)(`Argument "${name}" of non-null type "${(0, inspect_js_1.inspect)(argType)}" ` + 'must not be null.', {
+                nodes: [valueNode],
+            });
+        }
+        const coercedValue = (0, graphql_1.valueFromAST)(valueNode, argType, variableValues);
+        if (coercedValue === undefined) {
+            // Note: ValuesOfCorrectTypeRule validation should catch this before
+            // execution. This is a runtime check to ensure execution does not
+            // continue with an invalid argument value.
+            throw (0, errors_js_1.createGraphQLError)(`Argument "${name}" has invalid value ${(0, graphql_1.print)(valueNode)}.`, {
+                nodes: [valueNode],
+            });
+        }
+        coercedValues[name] = coercedValue;
+    }
+    return coercedValues;
+}
+exports.getArgumentValues = getArgumentValues;
+
+
+/***/ }),
 /* 113 */,
 /* 114 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -5544,7 +6189,802 @@ Scope.contextVariables = ["arguments", "undefined", "Infinity", "NaN"];
 
 /***/ }),
 /* 119 */,
-/* 120 */,
+/* 120 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+// Approach:
+//
+// 1. Get the minimatch set
+// 2. For each pattern in the set, PROCESS(pattern, false)
+// 3. Store matches per-set, then uniq them
+//
+// PROCESS(pattern, inGlobStar)
+// Get the first [n] items from pattern that are all strings
+// Join these together.  This is PREFIX.
+//   If there is no more remaining, then stat(PREFIX) and
+//   add to matches if it succeeds.  END.
+//
+// If inGlobStar and PREFIX is symlink and points to dir
+//   set ENTRIES = []
+// else readdir(PREFIX) as ENTRIES
+//   If fail, END
+//
+// with ENTRIES
+//   If pattern[n] is GLOBSTAR
+//     // handle the case where the globstar match is empty
+//     // by pruning it out, and testing the resulting pattern
+//     PROCESS(pattern[0..n] + pattern[n+1 .. $], false)
+//     // handle other cases.
+//     for ENTRY in ENTRIES (not dotfiles)
+//       // attach globstar + tail onto the entry
+//       // Mark that this entry is a globstar match
+//       PROCESS(pattern[0..n] + ENTRY + pattern[n .. $], true)
+//
+//   else // not globstar
+//     for ENTRY in ENTRIES (not dotfiles, unless pattern[n] is dot)
+//       Test ENTRY against pattern[n]
+//       If fails, continue
+//       If passes, PROCESS(pattern[0..n] + item + pattern[n+1 .. $])
+//
+// Caveat:
+//   Cache all stats and readdirs results to minimize syscall.  Since all
+//   we ever care about is existence and directory-ness, we can just keep
+//   `true` for files, and [children,...] for directories, or `false` for
+//   things that don't exist.
+
+module.exports = glob
+
+var rp = __webpack_require__(302)
+var minimatch = __webpack_require__(449)
+var Minimatch = minimatch.Minimatch
+var inherits = __webpack_require__(938)
+var EE = __webpack_require__(614).EventEmitter
+var path = __webpack_require__(622)
+var assert = __webpack_require__(357)
+var isAbsolute = __webpack_require__(622).isAbsolute
+var globSync = __webpack_require__(245)
+var common = __webpack_require__(856)
+var setopts = common.setopts
+var ownProp = common.ownProp
+var inflight = __webpack_require__(634)
+var util = __webpack_require__(669)
+var childrenIgnored = common.childrenIgnored
+var isIgnored = common.isIgnored
+
+var once = __webpack_require__(49)
+
+function glob (pattern, options, cb) {
+  if (typeof options === 'function') cb = options, options = {}
+  if (!options) options = {}
+
+  if (options.sync) {
+    if (cb)
+      throw new TypeError('callback provided to sync glob')
+    return globSync(pattern, options)
+  }
+
+  return new Glob(pattern, options, cb)
+}
+
+glob.sync = globSync
+var GlobSync = glob.GlobSync = globSync.GlobSync
+
+// old api surface
+glob.glob = glob
+
+function extend (origin, add) {
+  if (add === null || typeof add !== 'object') {
+    return origin
+  }
+
+  var keys = Object.keys(add)
+  var i = keys.length
+  while (i--) {
+    origin[keys[i]] = add[keys[i]]
+  }
+  return origin
+}
+
+glob.hasMagic = function (pattern, options_) {
+  var options = extend({}, options_)
+  options.noprocess = true
+
+  var g = new Glob(pattern, options)
+  var set = g.minimatch.set
+
+  if (!pattern)
+    return false
+
+  if (set.length > 1)
+    return true
+
+  for (var j = 0; j < set[0].length; j++) {
+    if (typeof set[0][j] !== 'string')
+      return true
+  }
+
+  return false
+}
+
+glob.Glob = Glob
+inherits(Glob, EE)
+function Glob (pattern, options, cb) {
+  if (typeof options === 'function') {
+    cb = options
+    options = null
+  }
+
+  if (options && options.sync) {
+    if (cb)
+      throw new TypeError('callback provided to sync glob')
+    return new GlobSync(pattern, options)
+  }
+
+  if (!(this instanceof Glob))
+    return new Glob(pattern, options, cb)
+
+  setopts(this, pattern, options)
+  this._didRealPath = false
+
+  // process each pattern in the minimatch set
+  var n = this.minimatch.set.length
+
+  // The matches are stored as {<filename>: true,...} so that
+  // duplicates are automagically pruned.
+  // Later, we do an Object.keys() on these.
+  // Keep them as a list so we can fill in when nonull is set.
+  this.matches = new Array(n)
+
+  if (typeof cb === 'function') {
+    cb = once(cb)
+    this.on('error', cb)
+    this.on('end', function (matches) {
+      cb(null, matches)
+    })
+  }
+
+  var self = this
+  this._processing = 0
+
+  this._emitQueue = []
+  this._processQueue = []
+  this.paused = false
+
+  if (this.noprocess)
+    return this
+
+  if (n === 0)
+    return done()
+
+  var sync = true
+  for (var i = 0; i < n; i ++) {
+    this._process(this.minimatch.set[i], i, false, done)
+  }
+  sync = false
+
+  function done () {
+    --self._processing
+    if (self._processing <= 0) {
+      if (sync) {
+        process.nextTick(function () {
+          self._finish()
+        })
+      } else {
+        self._finish()
+      }
+    }
+  }
+}
+
+Glob.prototype._finish = function () {
+  assert(this instanceof Glob)
+  if (this.aborted)
+    return
+
+  if (this.realpath && !this._didRealpath)
+    return this._realpath()
+
+  common.finish(this)
+  this.emit('end', this.found)
+}
+
+Glob.prototype._realpath = function () {
+  if (this._didRealpath)
+    return
+
+  this._didRealpath = true
+
+  var n = this.matches.length
+  if (n === 0)
+    return this._finish()
+
+  var self = this
+  for (var i = 0; i < this.matches.length; i++)
+    this._realpathSet(i, next)
+
+  function next () {
+    if (--n === 0)
+      self._finish()
+  }
+}
+
+Glob.prototype._realpathSet = function (index, cb) {
+  var matchset = this.matches[index]
+  if (!matchset)
+    return cb()
+
+  var found = Object.keys(matchset)
+  var self = this
+  var n = found.length
+
+  if (n === 0)
+    return cb()
+
+  var set = this.matches[index] = Object.create(null)
+  found.forEach(function (p, i) {
+    // If there's a problem with the stat, then it means that
+    // one or more of the links in the realpath couldn't be
+    // resolved.  just return the abs value in that case.
+    p = self._makeAbs(p)
+    rp.realpath(p, self.realpathCache, function (er, real) {
+      if (!er)
+        set[real] = true
+      else if (er.syscall === 'stat')
+        set[p] = true
+      else
+        self.emit('error', er) // srsly wtf right here
+
+      if (--n === 0) {
+        self.matches[index] = set
+        cb()
+      }
+    })
+  })
+}
+
+Glob.prototype._mark = function (p) {
+  return common.mark(this, p)
+}
+
+Glob.prototype._makeAbs = function (f) {
+  return common.makeAbs(this, f)
+}
+
+Glob.prototype.abort = function () {
+  this.aborted = true
+  this.emit('abort')
+}
+
+Glob.prototype.pause = function () {
+  if (!this.paused) {
+    this.paused = true
+    this.emit('pause')
+  }
+}
+
+Glob.prototype.resume = function () {
+  if (this.paused) {
+    this.emit('resume')
+    this.paused = false
+    if (this._emitQueue.length) {
+      var eq = this._emitQueue.slice(0)
+      this._emitQueue.length = 0
+      for (var i = 0; i < eq.length; i ++) {
+        var e = eq[i]
+        this._emitMatch(e[0], e[1])
+      }
+    }
+    if (this._processQueue.length) {
+      var pq = this._processQueue.slice(0)
+      this._processQueue.length = 0
+      for (var i = 0; i < pq.length; i ++) {
+        var p = pq[i]
+        this._processing--
+        this._process(p[0], p[1], p[2], p[3])
+      }
+    }
+  }
+}
+
+Glob.prototype._process = function (pattern, index, inGlobStar, cb) {
+  assert(this instanceof Glob)
+  assert(typeof cb === 'function')
+
+  if (this.aborted)
+    return
+
+  this._processing++
+  if (this.paused) {
+    this._processQueue.push([pattern, index, inGlobStar, cb])
+    return
+  }
+
+  //console.error('PROCESS %d', this._processing, pattern)
+
+  // Get the first [n] parts of pattern that are all strings.
+  var n = 0
+  while (typeof pattern[n] === 'string') {
+    n ++
+  }
+  // now n is the index of the first one that is *not* a string.
+
+  // see if there's anything else
+  var prefix
+  switch (n) {
+    // if not, then this is rather simple
+    case pattern.length:
+      this._processSimple(pattern.join('/'), index, cb)
+      return
+
+    case 0:
+      // pattern *starts* with some non-trivial item.
+      // going to readdir(cwd), but not include the prefix in matches.
+      prefix = null
+      break
+
+    default:
+      // pattern has some string bits in the front.
+      // whatever it starts with, whether that's 'absolute' like /foo/bar,
+      // or 'relative' like '../baz'
+      prefix = pattern.slice(0, n).join('/')
+      break
+  }
+
+  var remain = pattern.slice(n)
+
+  // get the list of entries.
+  var read
+  if (prefix === null)
+    read = '.'
+  else if (isAbsolute(prefix) ||
+      isAbsolute(pattern.map(function (p) {
+        return typeof p === 'string' ? p : '[*]'
+      }).join('/'))) {
+    if (!prefix || !isAbsolute(prefix))
+      prefix = '/' + prefix
+    read = prefix
+  } else
+    read = prefix
+
+  var abs = this._makeAbs(read)
+
+  //if ignored, skip _processing
+  if (childrenIgnored(this, read))
+    return cb()
+
+  var isGlobStar = remain[0] === minimatch.GLOBSTAR
+  if (isGlobStar)
+    this._processGlobStar(prefix, read, abs, remain, index, inGlobStar, cb)
+  else
+    this._processReaddir(prefix, read, abs, remain, index, inGlobStar, cb)
+}
+
+Glob.prototype._processReaddir = function (prefix, read, abs, remain, index, inGlobStar, cb) {
+  var self = this
+  this._readdir(abs, inGlobStar, function (er, entries) {
+    return self._processReaddir2(prefix, read, abs, remain, index, inGlobStar, entries, cb)
+  })
+}
+
+Glob.prototype._processReaddir2 = function (prefix, read, abs, remain, index, inGlobStar, entries, cb) {
+
+  // if the abs isn't a dir, then nothing can match!
+  if (!entries)
+    return cb()
+
+  // It will only match dot entries if it starts with a dot, or if
+  // dot is set.  Stuff like @(.foo|.bar) isn't allowed.
+  var pn = remain[0]
+  var negate = !!this.minimatch.negate
+  var rawGlob = pn._glob
+  var dotOk = this.dot || rawGlob.charAt(0) === '.'
+
+  var matchedEntries = []
+  for (var i = 0; i < entries.length; i++) {
+    var e = entries[i]
+    if (e.charAt(0) !== '.' || dotOk) {
+      var m
+      if (negate && !prefix) {
+        m = !e.match(pn)
+      } else {
+        m = e.match(pn)
+      }
+      if (m)
+        matchedEntries.push(e)
+    }
+  }
+
+  //console.error('prd2', prefix, entries, remain[0]._glob, matchedEntries)
+
+  var len = matchedEntries.length
+  // If there are no matched entries, then nothing matches.
+  if (len === 0)
+    return cb()
+
+  // if this is the last remaining pattern bit, then no need for
+  // an additional stat *unless* the user has specified mark or
+  // stat explicitly.  We know they exist, since readdir returned
+  // them.
+
+  if (remain.length === 1 && !this.mark && !this.stat) {
+    if (!this.matches[index])
+      this.matches[index] = Object.create(null)
+
+    for (var i = 0; i < len; i ++) {
+      var e = matchedEntries[i]
+      if (prefix) {
+        if (prefix !== '/')
+          e = prefix + '/' + e
+        else
+          e = prefix + e
+      }
+
+      if (e.charAt(0) === '/' && !this.nomount) {
+        e = path.join(this.root, e)
+      }
+      this._emitMatch(index, e)
+    }
+    // This was the last one, and no stats were needed
+    return cb()
+  }
+
+  // now test all matched entries as stand-ins for that part
+  // of the pattern.
+  remain.shift()
+  for (var i = 0; i < len; i ++) {
+    var e = matchedEntries[i]
+    var newPattern
+    if (prefix) {
+      if (prefix !== '/')
+        e = prefix + '/' + e
+      else
+        e = prefix + e
+    }
+    this._process([e].concat(remain), index, inGlobStar, cb)
+  }
+  cb()
+}
+
+Glob.prototype._emitMatch = function (index, e) {
+  if (this.aborted)
+    return
+
+  if (isIgnored(this, e))
+    return
+
+  if (this.paused) {
+    this._emitQueue.push([index, e])
+    return
+  }
+
+  var abs = isAbsolute(e) ? e : this._makeAbs(e)
+
+  if (this.mark)
+    e = this._mark(e)
+
+  if (this.absolute)
+    e = abs
+
+  if (this.matches[index][e])
+    return
+
+  if (this.nodir) {
+    var c = this.cache[abs]
+    if (c === 'DIR' || Array.isArray(c))
+      return
+  }
+
+  this.matches[index][e] = true
+
+  var st = this.statCache[abs]
+  if (st)
+    this.emit('stat', e, st)
+
+  this.emit('match', e)
+}
+
+Glob.prototype._readdirInGlobStar = function (abs, cb) {
+  if (this.aborted)
+    return
+
+  // follow all symlinked directories forever
+  // just proceed as if this is a non-globstar situation
+  if (this.follow)
+    return this._readdir(abs, false, cb)
+
+  var lstatkey = 'lstat\0' + abs
+  var self = this
+  var lstatcb = inflight(lstatkey, lstatcb_)
+
+  if (lstatcb)
+    self.fs.lstat(abs, lstatcb)
+
+  function lstatcb_ (er, lstat) {
+    if (er && er.code === 'ENOENT')
+      return cb()
+
+    var isSym = lstat && lstat.isSymbolicLink()
+    self.symlinks[abs] = isSym
+
+    // If it's not a symlink or a dir, then it's definitely a regular file.
+    // don't bother doing a readdir in that case.
+    if (!isSym && lstat && !lstat.isDirectory()) {
+      self.cache[abs] = 'FILE'
+      cb()
+    } else
+      self._readdir(abs, false, cb)
+  }
+}
+
+Glob.prototype._readdir = function (abs, inGlobStar, cb) {
+  if (this.aborted)
+    return
+
+  cb = inflight('readdir\0'+abs+'\0'+inGlobStar, cb)
+  if (!cb)
+    return
+
+  //console.error('RD %j %j', +inGlobStar, abs)
+  if (inGlobStar && !ownProp(this.symlinks, abs))
+    return this._readdirInGlobStar(abs, cb)
+
+  if (ownProp(this.cache, abs)) {
+    var c = this.cache[abs]
+    if (!c || c === 'FILE')
+      return cb()
+
+    if (Array.isArray(c))
+      return cb(null, c)
+  }
+
+  var self = this
+  self.fs.readdir(abs, readdirCb(this, abs, cb))
+}
+
+function readdirCb (self, abs, cb) {
+  return function (er, entries) {
+    if (er)
+      self._readdirError(abs, er, cb)
+    else
+      self._readdirEntries(abs, entries, cb)
+  }
+}
+
+Glob.prototype._readdirEntries = function (abs, entries, cb) {
+  if (this.aborted)
+    return
+
+  // if we haven't asked to stat everything, then just
+  // assume that everything in there exists, so we can avoid
+  // having to stat it a second time.
+  if (!this.mark && !this.stat) {
+    for (var i = 0; i < entries.length; i ++) {
+      var e = entries[i]
+      if (abs === '/')
+        e = abs + e
+      else
+        e = abs + '/' + e
+      this.cache[e] = true
+    }
+  }
+
+  this.cache[abs] = entries
+  return cb(null, entries)
+}
+
+Glob.prototype._readdirError = function (f, er, cb) {
+  if (this.aborted)
+    return
+
+  // handle errors, and cache the information
+  switch (er.code) {
+    case 'ENOTSUP': // https://github.com/isaacs/node-glob/issues/205
+    case 'ENOTDIR': // totally normal. means it *does* exist.
+      var abs = this._makeAbs(f)
+      this.cache[abs] = 'FILE'
+      if (abs === this.cwdAbs) {
+        var error = new Error(er.code + ' invalid cwd ' + this.cwd)
+        error.path = this.cwd
+        error.code = er.code
+        this.emit('error', error)
+        this.abort()
+      }
+      break
+
+    case 'ENOENT': // not terribly unusual
+    case 'ELOOP':
+    case 'ENAMETOOLONG':
+    case 'UNKNOWN':
+      this.cache[this._makeAbs(f)] = false
+      break
+
+    default: // some unusual error.  Treat as failure.
+      this.cache[this._makeAbs(f)] = false
+      if (this.strict) {
+        this.emit('error', er)
+        // If the error is handled, then we abort
+        // if not, we threw out of here
+        this.abort()
+      }
+      if (!this.silent)
+        console.error('glob error', er)
+      break
+  }
+
+  return cb()
+}
+
+Glob.prototype._processGlobStar = function (prefix, read, abs, remain, index, inGlobStar, cb) {
+  var self = this
+  this._readdir(abs, inGlobStar, function (er, entries) {
+    self._processGlobStar2(prefix, read, abs, remain, index, inGlobStar, entries, cb)
+  })
+}
+
+
+Glob.prototype._processGlobStar2 = function (prefix, read, abs, remain, index, inGlobStar, entries, cb) {
+  //console.error('pgs2', prefix, remain[0], entries)
+
+  // no entries means not a dir, so it can never have matches
+  // foo.txt/** doesn't match foo.txt
+  if (!entries)
+    return cb()
+
+  // test without the globstar, and with every child both below
+  // and replacing the globstar.
+  var remainWithoutGlobStar = remain.slice(1)
+  var gspref = prefix ? [ prefix ] : []
+  var noGlobStar = gspref.concat(remainWithoutGlobStar)
+
+  // the noGlobStar pattern exits the inGlobStar state
+  this._process(noGlobStar, index, false, cb)
+
+  var isSym = this.symlinks[abs]
+  var len = entries.length
+
+  // If it's a symlink, and we're in a globstar, then stop
+  if (isSym && inGlobStar)
+    return cb()
+
+  for (var i = 0; i < len; i++) {
+    var e = entries[i]
+    if (e.charAt(0) === '.' && !this.dot)
+      continue
+
+    // these two cases enter the inGlobStar state
+    var instead = gspref.concat(entries[i], remainWithoutGlobStar)
+    this._process(instead, index, true, cb)
+
+    var below = gspref.concat(entries[i], remain)
+    this._process(below, index, true, cb)
+  }
+
+  cb()
+}
+
+Glob.prototype._processSimple = function (prefix, index, cb) {
+  // XXX review this.  Shouldn't it be doing the mounting etc
+  // before doing stat?  kinda weird?
+  var self = this
+  this._stat(prefix, function (er, exists) {
+    self._processSimple2(prefix, index, er, exists, cb)
+  })
+}
+Glob.prototype._processSimple2 = function (prefix, index, er, exists, cb) {
+
+  //console.error('ps2', prefix, exists)
+
+  if (!this.matches[index])
+    this.matches[index] = Object.create(null)
+
+  // If it doesn't exist, then just mark the lack of results
+  if (!exists)
+    return cb()
+
+  if (prefix && isAbsolute(prefix) && !this.nomount) {
+    var trail = /[\/\\]$/.test(prefix)
+    if (prefix.charAt(0) === '/') {
+      prefix = path.join(this.root, prefix)
+    } else {
+      prefix = path.resolve(this.root, prefix)
+      if (trail)
+        prefix += '/'
+    }
+  }
+
+  if (process.platform === 'win32')
+    prefix = prefix.replace(/\\/g, '/')
+
+  // Mark this as a match
+  this._emitMatch(index, prefix)
+  cb()
+}
+
+// Returns either 'DIR', 'FILE', or false
+Glob.prototype._stat = function (f, cb) {
+  var abs = this._makeAbs(f)
+  var needDir = f.slice(-1) === '/'
+
+  if (f.length > this.maxLength)
+    return cb()
+
+  if (!this.stat && ownProp(this.cache, abs)) {
+    var c = this.cache[abs]
+
+    if (Array.isArray(c))
+      c = 'DIR'
+
+    // It exists, but maybe not how we need it
+    if (!needDir || c === 'DIR')
+      return cb(null, c)
+
+    if (needDir && c === 'FILE')
+      return cb()
+
+    // otherwise we have to stat, because maybe c=true
+    // if we know it exists, but not what it is.
+  }
+
+  var exists
+  var stat = this.statCache[abs]
+  if (stat !== undefined) {
+    if (stat === false)
+      return cb(null, stat)
+    else {
+      var type = stat.isDirectory() ? 'DIR' : 'FILE'
+      if (needDir && type === 'FILE')
+        return cb()
+      else
+        return cb(null, type, stat)
+    }
+  }
+
+  var self = this
+  var statcb = inflight('stat\0' + abs, lstatcb_)
+  if (statcb)
+    self.fs.lstat(abs, statcb)
+
+  function lstatcb_ (er, lstat) {
+    if (lstat && lstat.isSymbolicLink()) {
+      // If it's a symlink, then treat it as the target, unless
+      // the target does not exist, then treat it as a file.
+      return self.fs.stat(abs, function (er, stat) {
+        if (er)
+          self._stat2(f, abs, null, lstat, cb)
+        else
+          self._stat2(f, abs, er, stat, cb)
+      })
+    } else {
+      self._stat2(f, abs, er, lstat, cb)
+    }
+  }
+}
+
+Glob.prototype._stat2 = function (f, abs, er, stat, cb) {
+  if (er && (er.code === 'ENOENT' || er.code === 'ENOTDIR')) {
+    this.statCache[abs] = false
+    return cb()
+  }
+
+  var needDir = f.slice(-1) === '/'
+  this.statCache[abs] = stat
+
+  if (abs.slice(-1) === '/' && stat && !stat.isDirectory())
+    return cb(null, false, stat)
+
+  var c = true
+  if (stat)
+    c = stat.isDirectory() ? 'DIR' : 'FILE'
+  this.cache[abs] = this.cache[abs] || c
+
+  if (needDir && c === 'FILE')
+    return cb()
+
+  return cb(null, c, stat)
+}
+
+
+/***/ }),
 /* 121 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -5681,7 +7121,34 @@ function isTypeExtensionNode(node) {
 
 /***/ }),
 /* 124 */,
-/* 125 */,
+/* 125 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeArguments = void 0;
+const utils_1 = __webpack_require__(971);
+function mergeArguments(args1, args2, config) {
+    const result = deduplicateArguments([...args2, ...args1].filter(utils_1.isSome));
+    if (config && config.sort) {
+        result.sort(utils_1.compareNodes);
+    }
+    return result;
+}
+exports.mergeArguments = mergeArguments;
+function deduplicateArguments(args) {
+    return args.reduce((acc, current) => {
+        const dup = acc.find(arg => arg.name.value === current.name.value);
+        if (!dup) {
+            return acc.concat([current]);
+        }
+        return acc;
+    }, []);
+}
+
+
+/***/ }),
 /* 126 */,
 /* 127 */,
 /* 128 */,
@@ -6194,7 +7661,16 @@ async function executeSubscription(exeContext) {
 
 
 /***/ }),
-/* 137 */,
+/* 137 */
+/***/ (function(module) {
+
+const isWindows = typeof process === 'object' &&
+  process &&
+  process.platform === 'win32'
+module.exports = isWindows ? { sep: '\\' } : { sep: '/' }
+
+
+/***/ }),
 /* 138 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -6836,7 +8312,50 @@ exports.debug = debug; // for test
 
 
 /***/ }),
-/* 142 */,
+/* 142 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getRootTypeMap = exports.getRootTypes = exports.getRootTypeNames = exports.getDefinedRootType = void 0;
+const memoize_js_1 = __webpack_require__(389);
+function getDefinedRootType(schema, operation) {
+    const rootTypeMap = (0, exports.getRootTypeMap)(schema);
+    const rootType = rootTypeMap.get(operation);
+    if (rootType == null) {
+        throw new Error(`Root type for operation "${operation}" not defined by the given schema.`);
+    }
+    return rootType;
+}
+exports.getDefinedRootType = getDefinedRootType;
+exports.getRootTypeNames = (0, memoize_js_1.memoize1)(function getRootTypeNames(schema) {
+    const rootTypes = (0, exports.getRootTypes)(schema);
+    return new Set([...rootTypes].map(type => type.name));
+});
+exports.getRootTypes = (0, memoize_js_1.memoize1)(function getRootTypes(schema) {
+    const rootTypeMap = (0, exports.getRootTypeMap)(schema);
+    return new Set(rootTypeMap.values());
+});
+exports.getRootTypeMap = (0, memoize_js_1.memoize1)(function getRootTypeMap(schema) {
+    const rootTypeMap = new Map();
+    const queryType = schema.getQueryType();
+    if (queryType) {
+        rootTypeMap.set('query', queryType);
+    }
+    const mutationType = schema.getMutationType();
+    if (mutationType) {
+        rootTypeMap.set('mutation', mutationType);
+    }
+    const subscriptionType = schema.getSubscriptionType();
+    if (subscriptionType) {
+        rootTypeMap.set('subscription', subscriptionType);
+    }
+    return rootTypeMap;
+});
+
+
+/***/ }),
 /* 143 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -6855,7 +8374,68 @@ function cloneDeepWithoutLoc(node) {
 }
 
 /***/ }),
-/* 144 */,
+/* 144 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseInputValueLiteral = exports.parseInputValue = exports.serializeInputValue = exports.transformInputValue = void 0;
+const graphql_1 = __webpack_require__(232);
+function transformInputValue(type, value, inputLeafValueTransformer = null, inputObjectValueTransformer = null) {
+    if (value == null) {
+        return value;
+    }
+    const nullableType = (0, graphql_1.getNullableType)(type);
+    if ((0, graphql_1.isLeafType)(nullableType)) {
+        return inputLeafValueTransformer != null ? inputLeafValueTransformer(nullableType, value) : value;
+    }
+    else if ((0, graphql_1.isListType)(nullableType)) {
+        return value.map((listMember) => transformInputValue(nullableType.ofType, listMember, inputLeafValueTransformer, inputObjectValueTransformer));
+    }
+    else if ((0, graphql_1.isInputObjectType)(nullableType)) {
+        const fields = nullableType.getFields();
+        const newValue = {};
+        for (const key in value) {
+            const field = fields[key];
+            if (field != null) {
+                newValue[key] = transformInputValue(field.type, value[key], inputLeafValueTransformer, inputObjectValueTransformer);
+            }
+        }
+        return inputObjectValueTransformer != null ? inputObjectValueTransformer(nullableType, newValue) : newValue;
+    }
+    // unreachable, no other possible return value
+}
+exports.transformInputValue = transformInputValue;
+function serializeInputValue(type, value) {
+    return transformInputValue(type, value, (t, v) => {
+        try {
+            return t.serialize(v);
+        }
+        catch (_a) {
+            return v;
+        }
+    });
+}
+exports.serializeInputValue = serializeInputValue;
+function parseInputValue(type, value) {
+    return transformInputValue(type, value, (t, v) => {
+        try {
+            return t.parseValue(v);
+        }
+        catch (_a) {
+            return v;
+        }
+    });
+}
+exports.parseInputValue = parseInputValue;
+function parseInputValueLiteral(type, value) {
+    return transformInputValue(type, value, (t, v) => t.parseLiteral(v, {}));
+}
+exports.parseInputValueLiteral = parseInputValueLiteral;
+
+
+/***/ }),
 /* 145 */,
 /* 146 */,
 /* 147 */,
@@ -7041,7 +8621,113 @@ function promiseForObject(object) {
 
 
 /***/ }),
-/* 154 */,
+/* 154 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeDirective = exports.mergeDirectives = void 0;
+const graphql_1 = __webpack_require__(232);
+const utils_1 = __webpack_require__(971);
+function directiveAlreadyExists(directivesArr, otherDirective) {
+    return !!directivesArr.find(directive => directive.name.value === otherDirective.name.value);
+}
+function nameAlreadyExists(name, namesArr) {
+    return namesArr.some(({ value }) => value === name.value);
+}
+function mergeArguments(a1, a2) {
+    const result = [...a2];
+    for (const argument of a1) {
+        const existingIndex = result.findIndex(a => a.name.value === argument.name.value);
+        if (existingIndex > -1) {
+            const existingArg = result[existingIndex];
+            if (existingArg.value.kind === 'ListValue') {
+                const source = existingArg.value.values;
+                const target = argument.value.values;
+                // merge values of two lists
+                existingArg.value.values = deduplicateLists(source, target, (targetVal, source) => {
+                    const value = targetVal.value;
+                    return !value || !source.some((sourceVal) => sourceVal.value === value);
+                });
+            }
+            else {
+                existingArg.value = argument.value;
+            }
+        }
+        else {
+            result.push(argument);
+        }
+    }
+    return result;
+}
+function deduplicateDirectives(directives) {
+    return directives
+        .map((directive, i, all) => {
+        const firstAt = all.findIndex(d => d.name.value === directive.name.value);
+        if (firstAt !== i) {
+            const dup = all[firstAt];
+            directive.arguments = mergeArguments(directive.arguments, dup.arguments);
+            return null;
+        }
+        return directive;
+    })
+        .filter(utils_1.isSome);
+}
+function mergeDirectives(d1 = [], d2 = [], config) {
+    const reverseOrder = config && config.reverseDirectives;
+    const asNext = reverseOrder ? d1 : d2;
+    const asFirst = reverseOrder ? d2 : d1;
+    const result = deduplicateDirectives([...asNext]);
+    for (const directive of asFirst) {
+        if (directiveAlreadyExists(result, directive)) {
+            const existingDirectiveIndex = result.findIndex(d => d.name.value === directive.name.value);
+            const existingDirective = result[existingDirectiveIndex];
+            result[existingDirectiveIndex].arguments = mergeArguments(directive.arguments || [], existingDirective.arguments || []);
+        }
+        else {
+            result.push(directive);
+        }
+    }
+    return result;
+}
+exports.mergeDirectives = mergeDirectives;
+function validateInputs(node, existingNode) {
+    const printedNode = (0, graphql_1.print)({
+        ...node,
+        description: undefined,
+    });
+    const printedExistingNode = (0, graphql_1.print)({
+        ...existingNode,
+        description: undefined,
+    });
+    // eslint-disable-next-line
+    const leaveInputs = new RegExp('(directive @w*d*)|( on .*$)', 'g');
+    const sameArguments = printedNode.replace(leaveInputs, '') === printedExistingNode.replace(leaveInputs, '');
+    if (!sameArguments) {
+        throw new Error(`Unable to merge GraphQL directive "${node.name.value}". \nExisting directive:  \n\t${printedExistingNode} \nReceived directive: \n\t${printedNode}`);
+    }
+}
+function mergeDirective(node, existingNode) {
+    if (existingNode) {
+        validateInputs(node, existingNode);
+        return {
+            ...node,
+            locations: [
+                ...existingNode.locations,
+                ...node.locations.filter(name => !nameAlreadyExists(name, existingNode.locations)),
+            ],
+        };
+    }
+    return node;
+}
+exports.mergeDirective = mergeDirective;
+function deduplicateLists(source, target, filterFn) {
+    return source.concat(target.filter(val => filterFn(val, source)));
+}
+
+
+/***/ }),
 /* 155 */,
 /* 156 */,
 /* 157 */,
@@ -7236,7 +8922,329 @@ function sortFields(fields) {
 
 
 /***/ }),
-/* 164 */,
+/* 164 */
+/***/ (function(module) {
+
+/******************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global global, define, System, Reflect, Promise */
+var __extends;
+var __assign;
+var __rest;
+var __decorate;
+var __param;
+var __metadata;
+var __awaiter;
+var __generator;
+var __exportStar;
+var __values;
+var __read;
+var __spread;
+var __spreadArrays;
+var __spreadArray;
+var __await;
+var __asyncGenerator;
+var __asyncDelegator;
+var __asyncValues;
+var __makeTemplateObject;
+var __importStar;
+var __importDefault;
+var __classPrivateFieldGet;
+var __classPrivateFieldSet;
+var __classPrivateFieldIn;
+var __createBinding;
+(function (factory) {
+    var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
+    if (typeof define === "function" && define.amd) {
+        define("tslib", ["exports"], function (exports) { factory(createExporter(root, createExporter(exports))); });
+    }
+    else if ( true && typeof module.exports === "object") {
+        factory(createExporter(root, createExporter(module.exports)));
+    }
+    else {
+        factory(createExporter(root));
+    }
+    function createExporter(exports, previous) {
+        if (exports !== root) {
+            if (typeof Object.create === "function") {
+                Object.defineProperty(exports, "__esModule", { value: true });
+            }
+            else {
+                exports.__esModule = true;
+            }
+        }
+        return function (id, v) { return exports[id] = previous ? previous(id, v) : v; };
+    }
+})
+(function (exporter) {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+
+    __extends = function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+
+    __assign = Object.assign || function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+    };
+
+    __rest = function (s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+            t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+                if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                    t[p[i]] = s[p[i]];
+            }
+        return t;
+    };
+
+    __decorate = function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+
+    __param = function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+
+    __metadata = function (metadataKey, metadataValue) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(metadataKey, metadataValue);
+    };
+
+    __awaiter = function (thisArg, _arguments, P, generator) {
+        function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+
+    __generator = function (thisArg, body) {
+        var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+        return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+        function verb(n) { return function (v) { return step([n, v]); }; }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_) try {
+                if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+                if (y = 0, t) op = [op[0] & 2, t.value];
+                switch (op[0]) {
+                    case 0: case 1: t = op; break;
+                    case 4: _.label++; return { value: op[1], done: false };
+                    case 5: _.label++; y = op[1]; op = [0]; continue;
+                    case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                    default:
+                        if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                        if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                        if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                        if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                        if (t[2]) _.ops.pop();
+                        _.trys.pop(); continue;
+                }
+                op = body.call(thisArg, _);
+            } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+            if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+
+    __exportStar = function(m, o) {
+        for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(o, p)) __createBinding(o, m, p);
+    };
+
+    __createBinding = Object.create ? (function(o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+            desc = { enumerable: true, get: function() { return m[k]; } };
+        }
+        Object.defineProperty(o, k2, desc);
+    }) : (function(o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+    });
+
+    __values = function (o) {
+        var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
+        if (m) return m.call(o);
+        if (o && typeof o.length === "number") return {
+            next: function () {
+                if (o && i >= o.length) o = void 0;
+                return { value: o && o[i++], done: !o };
+            }
+        };
+        throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
+    };
+
+    __read = function (o, n) {
+        var m = typeof Symbol === "function" && o[Symbol.iterator];
+        if (!m) return o;
+        var i = m.call(o), r, ar = [], e;
+        try {
+            while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+        }
+        catch (error) { e = { error: error }; }
+        finally {
+            try {
+                if (r && !r.done && (m = i["return"])) m.call(i);
+            }
+            finally { if (e) throw e.error; }
+        }
+        return ar;
+    };
+
+    /** @deprecated */
+    __spread = function () {
+        for (var ar = [], i = 0; i < arguments.length; i++)
+            ar = ar.concat(__read(arguments[i]));
+        return ar;
+    };
+
+    /** @deprecated */
+    __spreadArrays = function () {
+        for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+        for (var r = Array(s), k = 0, i = 0; i < il; i++)
+            for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+                r[k] = a[j];
+        return r;
+    };
+
+    __spreadArray = function (to, from, pack) {
+        if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+            if (ar || !(i in from)) {
+                if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+                ar[i] = from[i];
+            }
+        }
+        return to.concat(ar || Array.prototype.slice.call(from));
+    };
+
+    __await = function (v) {
+        return this instanceof __await ? (this.v = v, this) : new __await(v);
+    };
+
+    __asyncGenerator = function (thisArg, _arguments, generator) {
+        if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+        var g = generator.apply(thisArg, _arguments || []), i, q = [];
+        return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+        function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+        function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+        function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r);  }
+        function fulfill(value) { resume("next", value); }
+        function reject(value) { resume("throw", value); }
+        function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+    };
+
+    __asyncDelegator = function (o) {
+        var i, p;
+        return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
+        function verb(n, f) { i[n] = o[n] ? function (v) { return (p = !p) ? { value: __await(o[n](v)), done: n === "return" } : f ? f(v) : v; } : f; }
+    };
+
+    __asyncValues = function (o) {
+        if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+        var m = o[Symbol.asyncIterator], i;
+        return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+        function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+        function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+    };
+
+    __makeTemplateObject = function (cooked, raw) {
+        if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+        return cooked;
+    };
+
+    var __setModuleDefault = Object.create ? (function(o, v) {
+        Object.defineProperty(o, "default", { enumerable: true, value: v });
+    }) : function(o, v) {
+        o["default"] = v;
+    };
+
+    __importStar = function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+
+    __importDefault = function (mod) {
+        return (mod && mod.__esModule) ? mod : { "default": mod };
+    };
+
+    __classPrivateFieldGet = function (receiver, state, kind, f) {
+        if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+        if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+        return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+
+    __classPrivateFieldSet = function (receiver, state, value, kind, f) {
+        if (kind === "m") throw new TypeError("Private method is not writable");
+        if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+        if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+        return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+    };
+
+    __classPrivateFieldIn = function (state, receiver) {
+        if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+        return typeof state === "function" ? receiver === state : state.has(receiver);
+    };
+
+    exporter("__extends", __extends);
+    exporter("__assign", __assign);
+    exporter("__rest", __rest);
+    exporter("__decorate", __decorate);
+    exporter("__param", __param);
+    exporter("__metadata", __metadata);
+    exporter("__awaiter", __awaiter);
+    exporter("__generator", __generator);
+    exporter("__exportStar", __exportStar);
+    exporter("__createBinding", __createBinding);
+    exporter("__values", __values);
+    exporter("__read", __read);
+    exporter("__spread", __spread);
+    exporter("__spreadArrays", __spreadArrays);
+    exporter("__spreadArray", __spreadArray);
+    exporter("__await", __await);
+    exporter("__asyncGenerator", __asyncGenerator);
+    exporter("__asyncDelegator", __asyncDelegator);
+    exporter("__asyncValues", __asyncValues);
+    exporter("__makeTemplateObject", __makeTemplateObject);
+    exporter("__importStar", __importStar);
+    exporter("__importDefault", __importDefault);
+    exporter("__classPrivateFieldGet", __classPrivateFieldGet);
+    exporter("__classPrivateFieldSet", __classPrivateFieldSet);
+    exporter("__classPrivateFieldIn", __classPrivateFieldIn);
+});
+
+
+/***/ }),
 /* 165 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -9557,7 +11565,79 @@ function _getQueueContexts() {
 /***/ }),
 /* 176 */,
 /* 177 */,
-/* 178 */,
+/* 178 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.filterSchema = void 0;
+const graphql_1 = __webpack_require__(232);
+const Interfaces_js_1 = __webpack_require__(368);
+const mapSchema_js_1 = __webpack_require__(675);
+function filterSchema({ schema, typeFilter = () => true, fieldFilter = undefined, rootFieldFilter = undefined, objectFieldFilter = undefined, interfaceFieldFilter = undefined, inputObjectFieldFilter = undefined, argumentFilter = undefined, }) {
+    const filteredSchema = (0, mapSchema_js_1.mapSchema)(schema, {
+        [Interfaces_js_1.MapperKind.QUERY]: (type) => filterRootFields(type, 'Query', rootFieldFilter, argumentFilter),
+        [Interfaces_js_1.MapperKind.MUTATION]: (type) => filterRootFields(type, 'Mutation', rootFieldFilter, argumentFilter),
+        [Interfaces_js_1.MapperKind.SUBSCRIPTION]: (type) => filterRootFields(type, 'Subscription', rootFieldFilter, argumentFilter),
+        [Interfaces_js_1.MapperKind.OBJECT_TYPE]: (type) => typeFilter(type.name, type)
+            ? filterElementFields(graphql_1.GraphQLObjectType, type, objectFieldFilter || fieldFilter, argumentFilter)
+            : null,
+        [Interfaces_js_1.MapperKind.INTERFACE_TYPE]: (type) => typeFilter(type.name, type)
+            ? filterElementFields(graphql_1.GraphQLInterfaceType, type, interfaceFieldFilter || fieldFilter, argumentFilter)
+            : null,
+        [Interfaces_js_1.MapperKind.INPUT_OBJECT_TYPE]: (type) => typeFilter(type.name, type)
+            ? filterElementFields(graphql_1.GraphQLInputObjectType, type, inputObjectFieldFilter || fieldFilter)
+            : null,
+        [Interfaces_js_1.MapperKind.UNION_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
+        [Interfaces_js_1.MapperKind.ENUM_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
+        [Interfaces_js_1.MapperKind.SCALAR_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
+    });
+    return filteredSchema;
+}
+exports.filterSchema = filterSchema;
+function filterRootFields(type, operation, rootFieldFilter, argumentFilter) {
+    if (rootFieldFilter || argumentFilter) {
+        const config = type.toConfig();
+        for (const fieldName in config.fields) {
+            const field = config.fields[fieldName];
+            if (rootFieldFilter && !rootFieldFilter(operation, fieldName, config.fields[fieldName])) {
+                delete config.fields[fieldName];
+            }
+            else if (argumentFilter && field.args) {
+                for (const argName in field.args) {
+                    if (!argumentFilter(operation, fieldName, argName, field.args[argName])) {
+                        delete field.args[argName];
+                    }
+                }
+            }
+        }
+        return new graphql_1.GraphQLObjectType(config);
+    }
+    return type;
+}
+function filterElementFields(ElementConstructor, type, fieldFilter, argumentFilter) {
+    if (fieldFilter || argumentFilter) {
+        const config = type.toConfig();
+        for (const fieldName in config.fields) {
+            const field = config.fields[fieldName];
+            if (fieldFilter && !fieldFilter(type.name, fieldName, config.fields[fieldName])) {
+                delete config.fields[fieldName];
+            }
+            else if (argumentFilter && 'args' in field) {
+                for (const argName in field.args) {
+                    if (!argumentFilter(type.name, fieldName, argName, field.args[argName])) {
+                        delete field.args[argName];
+                    }
+                }
+            }
+        }
+        return new ElementConstructor(config);
+    }
+}
+
+
+/***/ }),
 /* 179 */,
 /* 180 */,
 /* 181 */,
@@ -10364,7 +12444,58 @@ module.exports = require("https");
 /* 213 */,
 /* 214 */,
 /* 215 */,
-/* 216 */,
+/* 216 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeDeep = void 0;
+const helpers_js_1 = __webpack_require__(602);
+function mergeDeep(sources, respectPrototype = false) {
+    const target = sources[0] || {};
+    const output = {};
+    if (respectPrototype) {
+        Object.setPrototypeOf(output, Object.create(Object.getPrototypeOf(target)));
+    }
+    for (const source of sources) {
+        if (isObject(target) && isObject(source)) {
+            if (respectPrototype) {
+                const outputPrototype = Object.getPrototypeOf(output);
+                const sourcePrototype = Object.getPrototypeOf(source);
+                if (sourcePrototype) {
+                    for (const key of Object.getOwnPropertyNames(sourcePrototype)) {
+                        const descriptor = Object.getOwnPropertyDescriptor(sourcePrototype, key);
+                        if ((0, helpers_js_1.isSome)(descriptor)) {
+                            Object.defineProperty(outputPrototype, key, descriptor);
+                        }
+                    }
+                }
+            }
+            for (const key in source) {
+                if (isObject(source[key])) {
+                    if (!(key in output)) {
+                        Object.assign(output, { [key]: source[key] });
+                    }
+                    else {
+                        output[key] = mergeDeep([output[key], source[key]], respectPrototype);
+                    }
+                }
+                else {
+                    Object.assign(output, { [key]: source[key] });
+                }
+            }
+        }
+    }
+    return output;
+}
+exports.mergeDeep = mergeDeep;
+function isObject(item) {
+    return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+
+/***/ }),
 /* 217 */,
 /* 218 */,
 /* 219 */,
@@ -11930,7 +14061,393 @@ var _index6 = __webpack_require__(169);
 
 
 /***/ }),
-/* 233 */,
+/* 233 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getBlockStringIndentation = exports.dedentBlockStringValue = exports.getLeadingCommentBlock = exports.getComment = exports.getDescription = exports.printWithComments = exports.printComment = exports.pushComment = exports.collectComment = exports.resetComments = void 0;
+const graphql_1 = __webpack_require__(232);
+const MAX_LINE_LENGTH = 80;
+let commentsRegistry = {};
+function resetComments() {
+    commentsRegistry = {};
+}
+exports.resetComments = resetComments;
+function collectComment(node) {
+    var _a;
+    const entityName = (_a = node.name) === null || _a === void 0 ? void 0 : _a.value;
+    if (entityName == null) {
+        return;
+    }
+    pushComment(node, entityName);
+    switch (node.kind) {
+        case 'EnumTypeDefinition':
+            if (node.values) {
+                for (const value of node.values) {
+                    pushComment(value, entityName, value.name.value);
+                }
+            }
+            break;
+        case 'ObjectTypeDefinition':
+        case 'InputObjectTypeDefinition':
+        case 'InterfaceTypeDefinition':
+            if (node.fields) {
+                for (const field of node.fields) {
+                    pushComment(field, entityName, field.name.value);
+                    if (isFieldDefinitionNode(field) && field.arguments) {
+                        for (const arg of field.arguments) {
+                            pushComment(arg, entityName, field.name.value, arg.name.value);
+                        }
+                    }
+                }
+            }
+            break;
+    }
+}
+exports.collectComment = collectComment;
+function pushComment(node, entity, field, argument) {
+    const comment = getComment(node);
+    if (typeof comment !== 'string' || comment.length === 0) {
+        return;
+    }
+    const keys = [entity];
+    if (field) {
+        keys.push(field);
+        if (argument) {
+            keys.push(argument);
+        }
+    }
+    const path = keys.join('.');
+    if (!commentsRegistry[path]) {
+        commentsRegistry[path] = [];
+    }
+    commentsRegistry[path].push(comment);
+}
+exports.pushComment = pushComment;
+function printComment(comment) {
+    return '\n# ' + comment.replace(/\n/g, '\n# ');
+}
+exports.printComment = printComment;
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/**
+ * NOTE: ==> This file has been modified just to add comments to the printed AST
+ * This is a temp measure, we will move to using the original non modified printer.js ASAP.
+ */
+/**
+ * Given maybeArray, print an empty string if it is null or empty, otherwise
+ * print all items together separated by separator if provided
+ */
+function join(maybeArray, separator) {
+    return maybeArray ? maybeArray.filter(x => x).join(separator || '') : '';
+}
+function hasMultilineItems(maybeArray) {
+    var _a;
+    return (_a = maybeArray === null || maybeArray === void 0 ? void 0 : maybeArray.some(str => str.includes('\n'))) !== null && _a !== void 0 ? _a : false;
+}
+function addDescription(cb) {
+    return (node, _key, _parent, path, ancestors) => {
+        var _a;
+        const keys = [];
+        const parent = path.reduce((prev, key) => {
+            if (['fields', 'arguments', 'values'].includes(key) && prev.name) {
+                keys.push(prev.name.value);
+            }
+            return prev[key];
+        }, ancestors[0]);
+        const key = [...keys, (_a = parent === null || parent === void 0 ? void 0 : parent.name) === null || _a === void 0 ? void 0 : _a.value].filter(Boolean).join('.');
+        const items = [];
+        if (node.kind.includes('Definition') && commentsRegistry[key]) {
+            items.push(...commentsRegistry[key]);
+        }
+        return join([...items.map(printComment), node.description, cb(node, _key, _parent, path, ancestors)], '\n');
+    };
+}
+function indent(maybeString) {
+    return maybeString && `  ${maybeString.replace(/\n/g, '\n  ')}`;
+}
+/**
+ * Given array, print each item on its own line, wrapped in an
+ * indented "{ }" block.
+ */
+function block(array) {
+    return array && array.length !== 0 ? `{\n${indent(join(array, '\n'))}\n}` : '';
+}
+/**
+ * If maybeString is not null or empty, then wrap with start and end, otherwise
+ * print an empty string.
+ */
+function wrap(start, maybeString, end) {
+    return maybeString ? start + maybeString + (end || '') : '';
+}
+/**
+ * Print a block string in the indented block form by adding a leading and
+ * trailing blank line. However, if a block string starts with whitespace and is
+ * a single-line, adding a leading blank line would strip that whitespace.
+ */
+function printBlockString(value, isDescription = false) {
+    const escaped = value.replace(/"""/g, '\\"""');
+    return (value[0] === ' ' || value[0] === '\t') && value.indexOf('\n') === -1
+        ? `"""${escaped.replace(/"$/, '"\n')}"""`
+        : `"""\n${isDescription ? escaped : indent(escaped)}\n"""`;
+}
+const printDocASTReducer = {
+    Name: { leave: node => node.value },
+    Variable: { leave: node => '$' + node.name },
+    // Document
+    Document: {
+        leave: node => join(node.definitions, '\n\n'),
+    },
+    OperationDefinition: {
+        leave: node => {
+            const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
+            const prefix = join([node.operation, join([node.name, varDefs]), join(node.directives, ' ')], ' ');
+            // the query short form.
+            return prefix + ' ' + node.selectionSet;
+        },
+    },
+    VariableDefinition: {
+        leave: ({ variable, type, defaultValue, directives }) => variable + ': ' + type + wrap(' = ', defaultValue) + wrap(' ', join(directives, ' ')),
+    },
+    SelectionSet: { leave: ({ selections }) => block(selections) },
+    Field: {
+        leave({ alias, name, arguments: args, directives, selectionSet }) {
+            const prefix = wrap('', alias, ': ') + name;
+            let argsLine = prefix + wrap('(', join(args, ', '), ')');
+            if (argsLine.length > MAX_LINE_LENGTH) {
+                argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)');
+            }
+            return join([argsLine, join(directives, ' '), selectionSet], ' ');
+        },
+    },
+    Argument: { leave: ({ name, value }) => name + ': ' + value },
+    // Fragments
+    FragmentSpread: {
+        leave: ({ name, directives }) => '...' + name + wrap(' ', join(directives, ' ')),
+    },
+    InlineFragment: {
+        leave: ({ typeCondition, directives, selectionSet }) => join(['...', wrap('on ', typeCondition), join(directives, ' '), selectionSet], ' '),
+    },
+    FragmentDefinition: {
+        leave: ({ name, typeCondition, variableDefinitions, directives, selectionSet }) => 
+        // Note: fragment variable definitions are experimental and may be changed
+        // or removed in the future.
+        `fragment ${name}${wrap('(', join(variableDefinitions, ', '), ')')} ` +
+            `on ${typeCondition} ${wrap('', join(directives, ' '), ' ')}` +
+            selectionSet,
+    },
+    // Value
+    IntValue: { leave: ({ value }) => value },
+    FloatValue: { leave: ({ value }) => value },
+    StringValue: {
+        leave: ({ value, block: isBlockString }) => {
+            if (isBlockString) {
+                return printBlockString(value);
+            }
+            return JSON.stringify(value);
+        },
+    },
+    BooleanValue: { leave: ({ value }) => (value ? 'true' : 'false') },
+    NullValue: { leave: () => 'null' },
+    EnumValue: { leave: ({ value }) => value },
+    ListValue: { leave: ({ values }) => '[' + join(values, ', ') + ']' },
+    ObjectValue: { leave: ({ fields }) => '{' + join(fields, ', ') + '}' },
+    ObjectField: { leave: ({ name, value }) => name + ': ' + value },
+    // Directive
+    Directive: {
+        leave: ({ name, arguments: args }) => '@' + name + wrap('(', join(args, ', '), ')'),
+    },
+    // Type
+    NamedType: { leave: ({ name }) => name },
+    ListType: { leave: ({ type }) => '[' + type + ']' },
+    NonNullType: { leave: ({ type }) => type + '!' },
+    // Type System Definitions
+    SchemaDefinition: {
+        leave: ({ directives, operationTypes }) => join(['schema', join(directives, ' '), block(operationTypes)], ' '),
+    },
+    OperationTypeDefinition: {
+        leave: ({ operation, type }) => operation + ': ' + type,
+    },
+    ScalarTypeDefinition: {
+        leave: ({ name, directives }) => join(['scalar', name, join(directives, ' ')], ' '),
+    },
+    ObjectTypeDefinition: {
+        leave: ({ name, interfaces, directives, fields }) => join(['type', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    FieldDefinition: {
+        leave: ({ name, arguments: args, type, directives }) => name +
+            (hasMultilineItems(args)
+                ? wrap('(\n', indent(join(args, '\n')), '\n)')
+                : wrap('(', join(args, ', '), ')')) +
+            ': ' +
+            type +
+            wrap(' ', join(directives, ' ')),
+    },
+    InputValueDefinition: {
+        leave: ({ name, type, defaultValue, directives }) => join([name + ': ' + type, wrap('= ', defaultValue), join(directives, ' ')], ' '),
+    },
+    InterfaceTypeDefinition: {
+        leave: ({ name, interfaces, directives, fields }) => join(['interface', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    UnionTypeDefinition: {
+        leave: ({ name, directives, types }) => join(['union', name, join(directives, ' '), wrap('= ', join(types, ' | '))], ' '),
+    },
+    EnumTypeDefinition: {
+        leave: ({ name, directives, values }) => join(['enum', name, join(directives, ' '), block(values)], ' '),
+    },
+    EnumValueDefinition: {
+        leave: ({ name, directives }) => join([name, join(directives, ' ')], ' '),
+    },
+    InputObjectTypeDefinition: {
+        leave: ({ name, directives, fields }) => join(['input', name, join(directives, ' '), block(fields)], ' '),
+    },
+    DirectiveDefinition: {
+        leave: ({ name, arguments: args, repeatable, locations }) => 'directive @' +
+            name +
+            (hasMultilineItems(args)
+                ? wrap('(\n', indent(join(args, '\n')), '\n)')
+                : wrap('(', join(args, ', '), ')')) +
+            (repeatable ? ' repeatable' : '') +
+            ' on ' +
+            join(locations, ' | '),
+    },
+    SchemaExtension: {
+        leave: ({ directives, operationTypes }) => join(['extend schema', join(directives, ' '), block(operationTypes)], ' '),
+    },
+    ScalarTypeExtension: {
+        leave: ({ name, directives }) => join(['extend scalar', name, join(directives, ' ')], ' '),
+    },
+    ObjectTypeExtension: {
+        leave: ({ name, interfaces, directives, fields }) => join(['extend type', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    InterfaceTypeExtension: {
+        leave: ({ name, interfaces, directives, fields }) => join(['extend interface', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    UnionTypeExtension: {
+        leave: ({ name, directives, types }) => join(['extend union', name, join(directives, ' '), wrap('= ', join(types, ' | '))], ' '),
+    },
+    EnumTypeExtension: {
+        leave: ({ name, directives, values }) => join(['extend enum', name, join(directives, ' '), block(values)], ' '),
+    },
+    InputObjectTypeExtension: {
+        leave: ({ name, directives, fields }) => join(['extend input', name, join(directives, ' '), block(fields)], ' '),
+    },
+};
+const printDocASTReducerWithComments = Object.keys(printDocASTReducer).reduce((prev, key) => ({
+    ...prev,
+    [key]: {
+        leave: addDescription(printDocASTReducer[key].leave),
+    },
+}), {});
+/**
+ * Converts an AST into a string, using one set of reasonable
+ * formatting rules.
+ */
+function printWithComments(ast) {
+    return (0, graphql_1.visit)(ast, printDocASTReducerWithComments);
+}
+exports.printWithComments = printWithComments;
+function isFieldDefinitionNode(node) {
+    return node.kind === 'FieldDefinition';
+}
+// graphql < v13 and > v15 does not export getDescription
+function getDescription(node, options) {
+    if (node.description != null) {
+        return node.description.value;
+    }
+    if (options === null || options === void 0 ? void 0 : options.commentDescriptions) {
+        return getComment(node);
+    }
+}
+exports.getDescription = getDescription;
+function getComment(node) {
+    const rawValue = getLeadingCommentBlock(node);
+    if (rawValue !== undefined) {
+        return dedentBlockStringValue(`\n${rawValue}`);
+    }
+}
+exports.getComment = getComment;
+function getLeadingCommentBlock(node) {
+    const loc = node.loc;
+    if (!loc) {
+        return;
+    }
+    const comments = [];
+    let token = loc.startToken.prev;
+    while (token != null &&
+        token.kind === graphql_1.TokenKind.COMMENT &&
+        token.next != null &&
+        token.prev != null &&
+        token.line + 1 === token.next.line &&
+        token.line !== token.prev.line) {
+        const value = String(token.value);
+        comments.push(value);
+        token = token.prev;
+    }
+    return comments.length > 0 ? comments.reverse().join('\n') : undefined;
+}
+exports.getLeadingCommentBlock = getLeadingCommentBlock;
+function dedentBlockStringValue(rawString) {
+    // Expand a block string's raw value into independent lines.
+    const lines = rawString.split(/\r\n|[\n\r]/g);
+    // Remove common indentation from all lines but first.
+    const commonIndent = getBlockStringIndentation(lines);
+    if (commonIndent !== 0) {
+        for (let i = 1; i < lines.length; i++) {
+            lines[i] = lines[i].slice(commonIndent);
+        }
+    }
+    // Remove leading and trailing blank lines.
+    while (lines.length > 0 && isBlank(lines[0])) {
+        lines.shift();
+    }
+    while (lines.length > 0 && isBlank(lines[lines.length - 1])) {
+        lines.pop();
+    }
+    // Return a string of the lines joined with U+000A.
+    return lines.join('\n');
+}
+exports.dedentBlockStringValue = dedentBlockStringValue;
+/**
+ * @internal
+ */
+function getBlockStringIndentation(lines) {
+    let commonIndent = null;
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        const indent = leadingWhitespace(line);
+        if (indent === line.length) {
+            continue; // skip empty lines
+        }
+        if (commonIndent === null || indent < commonIndent) {
+            commonIndent = indent;
+            if (commonIndent === 0) {
+                break;
+            }
+        }
+    }
+    return commonIndent === null ? 0 : commonIndent;
+}
+exports.getBlockStringIndentation = getBlockStringIndentation;
+function leadingWhitespace(str) {
+    let i = 0;
+    while (i < str.length && (str[i] === ' ' || str[i] === '\t')) {
+        i++;
+    }
+    return i;
+}
+function isBlank(str) {
+    return leadingWhitespace(str) === str.length;
+}
+
+
+/***/ }),
 /* 234 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -12307,7 +14824,28 @@ function UniqueDirectivesPerLocationRule(context) {
 /* 239 */,
 /* 240 */,
 /* 241 */,
-/* 242 */,
+/* 242 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeNamedTypeArray = void 0;
+const utils_1 = __webpack_require__(971);
+function alreadyExists(arr, other) {
+    return !!arr.find(i => i.name.value === other.name.value);
+}
+function mergeNamedTypeArray(first = [], second = [], config = {}) {
+    const result = [...second, ...first.filter(d => !alreadyExists(second, d))];
+    if (config && config.sort) {
+        result.sort(utils_1.compareNodes);
+    }
+    return result;
+}
+exports.mergeNamedTypeArray = mergeNamedTypeArray;
+
+
+/***/ }),
 /* 243 */
 /***/ (function(__unusedmodule, exports) {
 
@@ -12337,8 +14875,513 @@ function addComments(node, type, comments) {
 }
 
 /***/ }),
-/* 244 */,
-/* 245 */,
+/* 244 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isDocumentNode = void 0;
+const graphql_1 = __webpack_require__(232);
+function isDocumentNode(object) {
+    return object && typeof object === 'object' && 'kind' in object && object.kind === graphql_1.Kind.DOCUMENT;
+}
+exports.isDocumentNode = isDocumentNode;
+
+
+/***/ }),
+/* 245 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+module.exports = globSync
+globSync.GlobSync = GlobSync
+
+var rp = __webpack_require__(302)
+var minimatch = __webpack_require__(449)
+var Minimatch = minimatch.Minimatch
+var Glob = __webpack_require__(120).Glob
+var util = __webpack_require__(669)
+var path = __webpack_require__(622)
+var assert = __webpack_require__(357)
+var isAbsolute = __webpack_require__(622).isAbsolute
+var common = __webpack_require__(856)
+var setopts = common.setopts
+var ownProp = common.ownProp
+var childrenIgnored = common.childrenIgnored
+var isIgnored = common.isIgnored
+
+function globSync (pattern, options) {
+  if (typeof options === 'function' || arguments.length === 3)
+    throw new TypeError('callback provided to sync glob\n'+
+                        'See: https://github.com/isaacs/node-glob/issues/167')
+
+  return new GlobSync(pattern, options).found
+}
+
+function GlobSync (pattern, options) {
+  if (!pattern)
+    throw new Error('must provide pattern')
+
+  if (typeof options === 'function' || arguments.length === 3)
+    throw new TypeError('callback provided to sync glob\n'+
+                        'See: https://github.com/isaacs/node-glob/issues/167')
+
+  if (!(this instanceof GlobSync))
+    return new GlobSync(pattern, options)
+
+  setopts(this, pattern, options)
+
+  if (this.noprocess)
+    return this
+
+  var n = this.minimatch.set.length
+  this.matches = new Array(n)
+  for (var i = 0; i < n; i ++) {
+    this._process(this.minimatch.set[i], i, false)
+  }
+  this._finish()
+}
+
+GlobSync.prototype._finish = function () {
+  assert.ok(this instanceof GlobSync)
+  if (this.realpath) {
+    var self = this
+    this.matches.forEach(function (matchset, index) {
+      var set = self.matches[index] = Object.create(null)
+      for (var p in matchset) {
+        try {
+          p = self._makeAbs(p)
+          var real = rp.realpathSync(p, self.realpathCache)
+          set[real] = true
+        } catch (er) {
+          if (er.syscall === 'stat')
+            set[self._makeAbs(p)] = true
+          else
+            throw er
+        }
+      }
+    })
+  }
+  common.finish(this)
+}
+
+
+GlobSync.prototype._process = function (pattern, index, inGlobStar) {
+  assert.ok(this instanceof GlobSync)
+
+  // Get the first [n] parts of pattern that are all strings.
+  var n = 0
+  while (typeof pattern[n] === 'string') {
+    n ++
+  }
+  // now n is the index of the first one that is *not* a string.
+
+  // See if there's anything else
+  var prefix
+  switch (n) {
+    // if not, then this is rather simple
+    case pattern.length:
+      this._processSimple(pattern.join('/'), index)
+      return
+
+    case 0:
+      // pattern *starts* with some non-trivial item.
+      // going to readdir(cwd), but not include the prefix in matches.
+      prefix = null
+      break
+
+    default:
+      // pattern has some string bits in the front.
+      // whatever it starts with, whether that's 'absolute' like /foo/bar,
+      // or 'relative' like '../baz'
+      prefix = pattern.slice(0, n).join('/')
+      break
+  }
+
+  var remain = pattern.slice(n)
+
+  // get the list of entries.
+  var read
+  if (prefix === null)
+    read = '.'
+  else if (isAbsolute(prefix) ||
+      isAbsolute(pattern.map(function (p) {
+        return typeof p === 'string' ? p : '[*]'
+      }).join('/'))) {
+    if (!prefix || !isAbsolute(prefix))
+      prefix = '/' + prefix
+    read = prefix
+  } else
+    read = prefix
+
+  var abs = this._makeAbs(read)
+
+  //if ignored, skip processing
+  if (childrenIgnored(this, read))
+    return
+
+  var isGlobStar = remain[0] === minimatch.GLOBSTAR
+  if (isGlobStar)
+    this._processGlobStar(prefix, read, abs, remain, index, inGlobStar)
+  else
+    this._processReaddir(prefix, read, abs, remain, index, inGlobStar)
+}
+
+
+GlobSync.prototype._processReaddir = function (prefix, read, abs, remain, index, inGlobStar) {
+  var entries = this._readdir(abs, inGlobStar)
+
+  // if the abs isn't a dir, then nothing can match!
+  if (!entries)
+    return
+
+  // It will only match dot entries if it starts with a dot, or if
+  // dot is set.  Stuff like @(.foo|.bar) isn't allowed.
+  var pn = remain[0]
+  var negate = !!this.minimatch.negate
+  var rawGlob = pn._glob
+  var dotOk = this.dot || rawGlob.charAt(0) === '.'
+
+  var matchedEntries = []
+  for (var i = 0; i < entries.length; i++) {
+    var e = entries[i]
+    if (e.charAt(0) !== '.' || dotOk) {
+      var m
+      if (negate && !prefix) {
+        m = !e.match(pn)
+      } else {
+        m = e.match(pn)
+      }
+      if (m)
+        matchedEntries.push(e)
+    }
+  }
+
+  var len = matchedEntries.length
+  // If there are no matched entries, then nothing matches.
+  if (len === 0)
+    return
+
+  // if this is the last remaining pattern bit, then no need for
+  // an additional stat *unless* the user has specified mark or
+  // stat explicitly.  We know they exist, since readdir returned
+  // them.
+
+  if (remain.length === 1 && !this.mark && !this.stat) {
+    if (!this.matches[index])
+      this.matches[index] = Object.create(null)
+
+    for (var i = 0; i < len; i ++) {
+      var e = matchedEntries[i]
+      if (prefix) {
+        if (prefix.slice(-1) !== '/')
+          e = prefix + '/' + e
+        else
+          e = prefix + e
+      }
+
+      if (e.charAt(0) === '/' && !this.nomount) {
+        e = path.join(this.root, e)
+      }
+      this._emitMatch(index, e)
+    }
+    // This was the last one, and no stats were needed
+    return
+  }
+
+  // now test all matched entries as stand-ins for that part
+  // of the pattern.
+  remain.shift()
+  for (var i = 0; i < len; i ++) {
+    var e = matchedEntries[i]
+    var newPattern
+    if (prefix)
+      newPattern = [prefix, e]
+    else
+      newPattern = [e]
+    this._process(newPattern.concat(remain), index, inGlobStar)
+  }
+}
+
+
+GlobSync.prototype._emitMatch = function (index, e) {
+  if (isIgnored(this, e))
+    return
+
+  var abs = this._makeAbs(e)
+
+  if (this.mark)
+    e = this._mark(e)
+
+  if (this.absolute) {
+    e = abs
+  }
+
+  if (this.matches[index][e])
+    return
+
+  if (this.nodir) {
+    var c = this.cache[abs]
+    if (c === 'DIR' || Array.isArray(c))
+      return
+  }
+
+  this.matches[index][e] = true
+
+  if (this.stat)
+    this._stat(e)
+}
+
+
+GlobSync.prototype._readdirInGlobStar = function (abs) {
+  // follow all symlinked directories forever
+  // just proceed as if this is a non-globstar situation
+  if (this.follow)
+    return this._readdir(abs, false)
+
+  var entries
+  var lstat
+  var stat
+  try {
+    lstat = this.fs.lstatSync(abs)
+  } catch (er) {
+    if (er.code === 'ENOENT') {
+      // lstat failed, doesn't exist
+      return null
+    }
+  }
+
+  var isSym = lstat && lstat.isSymbolicLink()
+  this.symlinks[abs] = isSym
+
+  // If it's not a symlink or a dir, then it's definitely a regular file.
+  // don't bother doing a readdir in that case.
+  if (!isSym && lstat && !lstat.isDirectory())
+    this.cache[abs] = 'FILE'
+  else
+    entries = this._readdir(abs, false)
+
+  return entries
+}
+
+GlobSync.prototype._readdir = function (abs, inGlobStar) {
+  var entries
+
+  if (inGlobStar && !ownProp(this.symlinks, abs))
+    return this._readdirInGlobStar(abs)
+
+  if (ownProp(this.cache, abs)) {
+    var c = this.cache[abs]
+    if (!c || c === 'FILE')
+      return null
+
+    if (Array.isArray(c))
+      return c
+  }
+
+  try {
+    return this._readdirEntries(abs, this.fs.readdirSync(abs))
+  } catch (er) {
+    this._readdirError(abs, er)
+    return null
+  }
+}
+
+GlobSync.prototype._readdirEntries = function (abs, entries) {
+  // if we haven't asked to stat everything, then just
+  // assume that everything in there exists, so we can avoid
+  // having to stat it a second time.
+  if (!this.mark && !this.stat) {
+    for (var i = 0; i < entries.length; i ++) {
+      var e = entries[i]
+      if (abs === '/')
+        e = abs + e
+      else
+        e = abs + '/' + e
+      this.cache[e] = true
+    }
+  }
+
+  this.cache[abs] = entries
+
+  // mark and cache dir-ness
+  return entries
+}
+
+GlobSync.prototype._readdirError = function (f, er) {
+  // handle errors, and cache the information
+  switch (er.code) {
+    case 'ENOTSUP': // https://github.com/isaacs/node-glob/issues/205
+    case 'ENOTDIR': // totally normal. means it *does* exist.
+      var abs = this._makeAbs(f)
+      this.cache[abs] = 'FILE'
+      if (abs === this.cwdAbs) {
+        var error = new Error(er.code + ' invalid cwd ' + this.cwd)
+        error.path = this.cwd
+        error.code = er.code
+        throw error
+      }
+      break
+
+    case 'ENOENT': // not terribly unusual
+    case 'ELOOP':
+    case 'ENAMETOOLONG':
+    case 'UNKNOWN':
+      this.cache[this._makeAbs(f)] = false
+      break
+
+    default: // some unusual error.  Treat as failure.
+      this.cache[this._makeAbs(f)] = false
+      if (this.strict)
+        throw er
+      if (!this.silent)
+        console.error('glob error', er)
+      break
+  }
+}
+
+GlobSync.prototype._processGlobStar = function (prefix, read, abs, remain, index, inGlobStar) {
+
+  var entries = this._readdir(abs, inGlobStar)
+
+  // no entries means not a dir, so it can never have matches
+  // foo.txt/** doesn't match foo.txt
+  if (!entries)
+    return
+
+  // test without the globstar, and with every child both below
+  // and replacing the globstar.
+  var remainWithoutGlobStar = remain.slice(1)
+  var gspref = prefix ? [ prefix ] : []
+  var noGlobStar = gspref.concat(remainWithoutGlobStar)
+
+  // the noGlobStar pattern exits the inGlobStar state
+  this._process(noGlobStar, index, false)
+
+  var len = entries.length
+  var isSym = this.symlinks[abs]
+
+  // If it's a symlink, and we're in a globstar, then stop
+  if (isSym && inGlobStar)
+    return
+
+  for (var i = 0; i < len; i++) {
+    var e = entries[i]
+    if (e.charAt(0) === '.' && !this.dot)
+      continue
+
+    // these two cases enter the inGlobStar state
+    var instead = gspref.concat(entries[i], remainWithoutGlobStar)
+    this._process(instead, index, true)
+
+    var below = gspref.concat(entries[i], remain)
+    this._process(below, index, true)
+  }
+}
+
+GlobSync.prototype._processSimple = function (prefix, index) {
+  // XXX review this.  Shouldn't it be doing the mounting etc
+  // before doing stat?  kinda weird?
+  var exists = this._stat(prefix)
+
+  if (!this.matches[index])
+    this.matches[index] = Object.create(null)
+
+  // If it doesn't exist, then just mark the lack of results
+  if (!exists)
+    return
+
+  if (prefix && isAbsolute(prefix) && !this.nomount) {
+    var trail = /[\/\\]$/.test(prefix)
+    if (prefix.charAt(0) === '/') {
+      prefix = path.join(this.root, prefix)
+    } else {
+      prefix = path.resolve(this.root, prefix)
+      if (trail)
+        prefix += '/'
+    }
+  }
+
+  if (process.platform === 'win32')
+    prefix = prefix.replace(/\\/g, '/')
+
+  // Mark this as a match
+  this._emitMatch(index, prefix)
+}
+
+// Returns either 'DIR', 'FILE', or false
+GlobSync.prototype._stat = function (f) {
+  var abs = this._makeAbs(f)
+  var needDir = f.slice(-1) === '/'
+
+  if (f.length > this.maxLength)
+    return false
+
+  if (!this.stat && ownProp(this.cache, abs)) {
+    var c = this.cache[abs]
+
+    if (Array.isArray(c))
+      c = 'DIR'
+
+    // It exists, but maybe not how we need it
+    if (!needDir || c === 'DIR')
+      return c
+
+    if (needDir && c === 'FILE')
+      return false
+
+    // otherwise we have to stat, because maybe c=true
+    // if we know it exists, but not what it is.
+  }
+
+  var exists
+  var stat = this.statCache[abs]
+  if (!stat) {
+    var lstat
+    try {
+      lstat = this.fs.lstatSync(abs)
+    } catch (er) {
+      if (er && (er.code === 'ENOENT' || er.code === 'ENOTDIR')) {
+        this.statCache[abs] = false
+        return false
+      }
+    }
+
+    if (lstat && lstat.isSymbolicLink()) {
+      try {
+        stat = this.fs.statSync(abs)
+      } catch (er) {
+        stat = lstat
+      }
+    } else {
+      stat = lstat
+    }
+  }
+
+  this.statCache[abs] = stat
+
+  var c = true
+  if (stat)
+    c = stat.isDirectory() ? 'DIR' : 'FILE'
+
+  this.cache[abs] = this.cache[abs] || c
+
+  if (needDir && c === 'FILE')
+    return false
+
+  return c
+}
+
+GlobSync.prototype._mark = function (p) {
+  return common.mark(this, p)
+}
+
+GlobSync.prototype._makeAbs = function (f) {
+  return common.makeAbs(this, f)
+}
+
+
+/***/ }),
 /* 246 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -13074,7 +16117,38 @@ module.exports = (chalk, tmp) => {
 
 
 /***/ }),
-/* 265 */,
+/* 265 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isAggregateError = exports.AggregateError = void 0;
+let AggregateErrorImpl;
+exports.AggregateError = AggregateErrorImpl;
+if (typeof AggregateError === 'undefined') {
+    class AggregateErrorClass extends Error {
+        constructor(errors, message = '') {
+            super(message);
+            this.errors = errors;
+            this.name = 'AggregateError';
+            Error.captureStackTrace(this, AggregateErrorClass);
+        }
+    }
+    exports.AggregateError = AggregateErrorImpl = function (errors, message) {
+        return new AggregateErrorClass(errors, message);
+    };
+}
+else {
+    exports.AggregateError = AggregateErrorImpl = AggregateError;
+}
+function isAggregateError(error) {
+    return 'errors' in error && Array.isArray(error['errors']);
+}
+exports.isAggregateError = isAggregateError;
+
+
+/***/ }),
 /* 266 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -13451,7 +16525,57 @@ function getSuggestedFieldNames(type, fieldName) {
 
 
 /***/ }),
-/* 270 */,
+/* 270 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseGraphQLJSON = void 0;
+const graphql_1 = __webpack_require__(232);
+function stripBOM(content) {
+    content = content.toString();
+    // Remove byte order marker. This catches EF BB BF (the UTF-8 BOM)
+    // because the buffer-to-string conversion in `fs.readFileSync()`
+    // translates it to FEFF, the UTF-16 BOM.
+    if (content.charCodeAt(0) === 0xfeff) {
+        content = content.slice(1);
+    }
+    return content;
+}
+function parseBOM(content) {
+    return JSON.parse(stripBOM(content));
+}
+function parseGraphQLJSON(location, jsonContent, options) {
+    let parsedJson = parseBOM(jsonContent);
+    if (parsedJson.data) {
+        parsedJson = parsedJson.data;
+    }
+    if (parsedJson.kind === 'Document') {
+        return {
+            location,
+            document: parsedJson,
+        };
+    }
+    else if (parsedJson.__schema) {
+        const schema = (0, graphql_1.buildClientSchema)(parsedJson, options);
+        return {
+            location,
+            schema,
+        };
+    }
+    else if (typeof parsedJson === 'string') {
+        return {
+            location,
+            rawSDL: parsedJson,
+        };
+    }
+    throw new Error(`Not valid JSON content`);
+}
+exports.parseGraphQLJSON = parseGraphQLJSON;
+
+
+/***/ }),
 /* 271 */,
 /* 272 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -13510,7 +16634,81 @@ function cleanJSXElementLiteralChild(child, args) {
 /* 274 */,
 /* 275 */,
 /* 276 */,
-/* 277 */,
+/* 277 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getBuiltInForStub = exports.isNamedStub = exports.createStub = exports.createNamedStub = void 0;
+const graphql_1 = __webpack_require__(232);
+function createNamedStub(name, type) {
+    let constructor;
+    if (type === 'object') {
+        constructor = graphql_1.GraphQLObjectType;
+    }
+    else if (type === 'interface') {
+        constructor = graphql_1.GraphQLInterfaceType;
+    }
+    else {
+        constructor = graphql_1.GraphQLInputObjectType;
+    }
+    return new constructor({
+        name,
+        fields: {
+            _fake: {
+                type: graphql_1.GraphQLString,
+            },
+        },
+    });
+}
+exports.createNamedStub = createNamedStub;
+function createStub(node, type) {
+    switch (node.kind) {
+        case graphql_1.Kind.LIST_TYPE:
+            return new graphql_1.GraphQLList(createStub(node.type, type));
+        case graphql_1.Kind.NON_NULL_TYPE:
+            return new graphql_1.GraphQLNonNull(createStub(node.type, type));
+        default:
+            if (type === 'output') {
+                return createNamedStub(node.name.value, 'object');
+            }
+            return createNamedStub(node.name.value, 'input');
+    }
+}
+exports.createStub = createStub;
+function isNamedStub(type) {
+    if ('getFields' in type) {
+        const fields = type.getFields();
+        // eslint-disable-next-line no-unreachable-loop
+        for (const fieldName in fields) {
+            const field = fields[fieldName];
+            return field.name === '_fake';
+        }
+    }
+    return false;
+}
+exports.isNamedStub = isNamedStub;
+function getBuiltInForStub(type) {
+    switch (type.name) {
+        case graphql_1.GraphQLInt.name:
+            return graphql_1.GraphQLInt;
+        case graphql_1.GraphQLFloat.name:
+            return graphql_1.GraphQLFloat;
+        case graphql_1.GraphQLString.name:
+            return graphql_1.GraphQLString;
+        case graphql_1.GraphQLBoolean.name:
+            return graphql_1.GraphQLBoolean;
+        case graphql_1.GraphQLID.name:
+            return graphql_1.GraphQLID;
+        default:
+            return type;
+    }
+}
+exports.getBuiltInForStub = getBuiltInForStub;
+
+
+/***/ }),
 /* 278 */,
 /* 279 */,
 /* 280 */,
@@ -13518,7 +16716,32 @@ function cleanJSXElementLiteralChild(child, args) {
 /* 282 */,
 /* 283 */,
 /* 284 */,
-/* 285 */,
+/* 285 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getImplementingTypes = void 0;
+const graphql_1 = __webpack_require__(232);
+function getImplementingTypes(interfaceName, schema) {
+    const allTypesMap = schema.getTypeMap();
+    const result = [];
+    for (const graphqlTypeName in allTypesMap) {
+        const graphqlType = allTypesMap[graphqlTypeName];
+        if ((0, graphql_1.isObjectType)(graphqlType)) {
+            const allInterfaces = graphqlType.getInterfaces();
+            if (allInterfaces.find(int => int.name === interfaceName)) {
+                result.push(graphqlType.name);
+            }
+        }
+    }
+    return result;
+}
+exports.getImplementingTypes = getImplementingTypes;
+
+
+/***/ }),
 /* 286 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -13838,7 +17061,40 @@ function isBlockScoped(node) {
 
 /***/ }),
 /* 293 */,
-/* 294 */,
+/* 294 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeScalar = void 0;
+const graphql_1 = __webpack_require__(232);
+const directives_js_1 = __webpack_require__(154);
+function mergeScalar(node, existingNode, config) {
+    if (existingNode) {
+        return {
+            name: node.name,
+            description: node['description'] || existingNode['description'],
+            kind: (config === null || config === void 0 ? void 0 : config.convertExtensions) ||
+                node.kind === 'ScalarTypeDefinition' ||
+                existingNode.kind === 'ScalarTypeDefinition'
+                ? 'ScalarTypeDefinition'
+                : 'ScalarTypeExtension',
+            loc: node.loc,
+            directives: (0, directives_js_1.mergeDirectives)(node.directives, existingNode.directives, config),
+        };
+    }
+    return (config === null || config === void 0 ? void 0 : config.convertExtensions)
+        ? {
+            ...node,
+            kind: graphql_1.Kind.SCALAR_TYPE_DEFINITION,
+        }
+        : node;
+}
+exports.mergeScalar = mergeScalar;
+
+
+/***/ }),
 /* 295 */,
 /* 296 */,
 /* 297 */
@@ -14265,7 +17521,78 @@ function mapAsyncIterator(iterable, callback) {
 
 /***/ }),
 /* 301 */,
-/* 302 */,
+/* 302 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+module.exports = realpath
+realpath.realpath = realpath
+realpath.sync = realpathSync
+realpath.realpathSync = realpathSync
+realpath.monkeypatch = monkeypatch
+realpath.unmonkeypatch = unmonkeypatch
+
+var fs = __webpack_require__(747)
+var origRealpath = fs.realpath
+var origRealpathSync = fs.realpathSync
+
+var version = process.version
+var ok = /^v[0-5]\./.test(version)
+var old = __webpack_require__(981)
+
+function newError (er) {
+  return er && er.syscall === 'realpath' && (
+    er.code === 'ELOOP' ||
+    er.code === 'ENOMEM' ||
+    er.code === 'ENAMETOOLONG'
+  )
+}
+
+function realpath (p, cache, cb) {
+  if (ok) {
+    return origRealpath(p, cache, cb)
+  }
+
+  if (typeof cache === 'function') {
+    cb = cache
+    cache = null
+  }
+  origRealpath(p, cache, function (er, result) {
+    if (newError(er)) {
+      old.realpath(p, cache, cb)
+    } else {
+      cb(er, result)
+    }
+  })
+}
+
+function realpathSync (p, cache) {
+  if (ok) {
+    return origRealpathSync(p, cache)
+  }
+
+  try {
+    return origRealpathSync(p, cache)
+  } catch (er) {
+    if (newError(er)) {
+      return old.realpathSync(p, cache)
+    } else {
+      throw er
+    }
+  }
+}
+
+function monkeypatch () {
+  fs.realpath = realpath
+  fs.realpathSync = realpathSync
+}
+
+function unmonkeypatch () {
+  fs.realpath = origRealpath
+  fs.realpathSync = origRealpathSync
+}
+
+
+/***/ }),
 /* 303 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -14566,7 +17893,86 @@ function ImportNamespaceSpecifier(node) {
 
 /***/ }),
 /* 305 */,
-/* 306 */,
+/* 306 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getResolversFromSchema = void 0;
+const graphql_1 = __webpack_require__(232);
+function getResolversFromSchema(schema, 
+// Include default merged resolvers
+includeDefaultMergedResolver) {
+    var _a, _b;
+    const resolvers = Object.create(null);
+    const typeMap = schema.getTypeMap();
+    for (const typeName in typeMap) {
+        if (!typeName.startsWith('__')) {
+            const type = typeMap[typeName];
+            if ((0, graphql_1.isScalarType)(type)) {
+                if (!(0, graphql_1.isSpecifiedScalarType)(type)) {
+                    const config = type.toConfig();
+                    delete config.astNode; // avoid AST duplication elsewhere
+                    resolvers[typeName] = new graphql_1.GraphQLScalarType(config);
+                }
+            }
+            else if ((0, graphql_1.isEnumType)(type)) {
+                resolvers[typeName] = {};
+                const values = type.getValues();
+                for (const value of values) {
+                    resolvers[typeName][value.name] = value.value;
+                }
+            }
+            else if ((0, graphql_1.isInterfaceType)(type)) {
+                if (type.resolveType != null) {
+                    resolvers[typeName] = {
+                        __resolveType: type.resolveType,
+                    };
+                }
+            }
+            else if ((0, graphql_1.isUnionType)(type)) {
+                if (type.resolveType != null) {
+                    resolvers[typeName] = {
+                        __resolveType: type.resolveType,
+                    };
+                }
+            }
+            else if ((0, graphql_1.isObjectType)(type)) {
+                resolvers[typeName] = {};
+                if (type.isTypeOf != null) {
+                    resolvers[typeName].__isTypeOf = type.isTypeOf;
+                }
+                const fields = type.getFields();
+                for (const fieldName in fields) {
+                    const field = fields[fieldName];
+                    if (field.subscribe != null) {
+                        resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
+                        resolvers[typeName][fieldName].subscribe = field.subscribe;
+                    }
+                    if (field.resolve != null && ((_a = field.resolve) === null || _a === void 0 ? void 0 : _a.name) !== 'defaultFieldResolver') {
+                        switch ((_b = field.resolve) === null || _b === void 0 ? void 0 : _b.name) {
+                            case 'defaultMergedResolver':
+                                if (!includeDefaultMergedResolver) {
+                                    continue;
+                                }
+                                break;
+                            case 'defaultFieldResolver':
+                                continue;
+                        }
+                        resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
+                        resolvers[typeName][fieldName].resolve = field.resolve;
+                    }
+                }
+            }
+        }
+    }
+    return resolvers;
+}
+exports.getResolversFromSchema = getResolversFromSchema;
+
+
+/***/ }),
 /* 307 */,
 /* 308 */,
 /* 309 */,
@@ -15134,7 +18540,44 @@ module.exports = function toFastproperties(o) {
 
 /***/ }),
 /* 354 */,
-/* 355 */,
+/* 355 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.astFromType = void 0;
+const graphql_1 = __webpack_require__(232);
+const inspect_js_1 = __webpack_require__(524);
+function astFromType(type) {
+    if ((0, graphql_1.isNonNullType)(type)) {
+        const innerType = astFromType(type.ofType);
+        if (innerType.kind === graphql_1.Kind.NON_NULL_TYPE) {
+            throw new Error(`Invalid type node ${(0, inspect_js_1.inspect)(type)}. Inner type of non-null type cannot be a non-null type.`);
+        }
+        return {
+            kind: graphql_1.Kind.NON_NULL_TYPE,
+            type: innerType,
+        };
+    }
+    else if ((0, graphql_1.isListType)(type)) {
+        return {
+            kind: graphql_1.Kind.LIST_TYPE,
+            type: astFromType(type.ofType),
+        };
+    }
+    return {
+        kind: graphql_1.Kind.NAMED_TYPE,
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: type.name,
+        },
+    };
+}
+exports.astFromType = astFromType;
+
+
+/***/ }),
 /* 356 */,
 /* 357 */
 /***/ (function(module) {
@@ -15192,7 +18635,364 @@ function matchesPattern(member, match, allowPartial) {
 
 /***/ }),
 /* 360 */,
-/* 361 */,
+/* 361 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.buildOperationNodeForField = void 0;
+const graphql_1 = __webpack_require__(232);
+const rootTypes_js_1 = __webpack_require__(142);
+let operationVariables = [];
+let fieldTypeMap = new Map();
+function addOperationVariable(variable) {
+    operationVariables.push(variable);
+}
+function resetOperationVariables() {
+    operationVariables = [];
+}
+function resetFieldMap() {
+    fieldTypeMap = new Map();
+}
+function buildOperationNodeForField({ schema, kind, field, models, ignore = [], depthLimit, circularReferenceDepth, argNames, selectedFields = true, }) {
+    resetOperationVariables();
+    resetFieldMap();
+    const rootTypeNames = (0, rootTypes_js_1.getRootTypeNames)(schema);
+    const operationNode = buildOperationAndCollectVariables({
+        schema,
+        fieldName: field,
+        kind,
+        models: models || [],
+        ignore,
+        depthLimit: depthLimit || Infinity,
+        circularReferenceDepth: circularReferenceDepth || 1,
+        argNames,
+        selectedFields,
+        rootTypeNames,
+    });
+    // attach variables
+    operationNode.variableDefinitions = [...operationVariables];
+    resetOperationVariables();
+    resetFieldMap();
+    return operationNode;
+}
+exports.buildOperationNodeForField = buildOperationNodeForField;
+function buildOperationAndCollectVariables({ schema, fieldName, kind, models, ignore, depthLimit, circularReferenceDepth, argNames, selectedFields, rootTypeNames, }) {
+    const type = (0, rootTypes_js_1.getDefinedRootType)(schema, kind);
+    const field = type.getFields()[fieldName];
+    const operationName = `${fieldName}_${kind}`;
+    if (field.args) {
+        for (const arg of field.args) {
+            const argName = arg.name;
+            if (!argNames || argNames.includes(argName)) {
+                addOperationVariable(resolveVariable(arg, argName));
+            }
+        }
+    }
+    return {
+        kind: graphql_1.Kind.OPERATION_DEFINITION,
+        operation: kind,
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: operationName,
+        },
+        variableDefinitions: [],
+        selectionSet: {
+            kind: graphql_1.Kind.SELECTION_SET,
+            selections: [
+                resolveField({
+                    type,
+                    field,
+                    models,
+                    firstCall: true,
+                    path: [],
+                    ancestors: [],
+                    ignore,
+                    depthLimit,
+                    circularReferenceDepth,
+                    schema,
+                    depth: 0,
+                    argNames,
+                    selectedFields,
+                    rootTypeNames,
+                }),
+            ],
+        },
+    };
+}
+function resolveSelectionSet({ parent, type, models, firstCall, path, ancestors, ignore, depthLimit, circularReferenceDepth, schema, depth, argNames, selectedFields, rootTypeNames, }) {
+    if (typeof selectedFields === 'boolean' && depth > depthLimit) {
+        return;
+    }
+    if ((0, graphql_1.isUnionType)(type)) {
+        const types = type.getTypes();
+        return {
+            kind: graphql_1.Kind.SELECTION_SET,
+            selections: types
+                .filter(t => !hasCircularRef([...ancestors, t], {
+                depth: circularReferenceDepth,
+            }))
+                .map(t => {
+                return {
+                    kind: graphql_1.Kind.INLINE_FRAGMENT,
+                    typeCondition: {
+                        kind: graphql_1.Kind.NAMED_TYPE,
+                        name: {
+                            kind: graphql_1.Kind.NAME,
+                            value: t.name,
+                        },
+                    },
+                    selectionSet: resolveSelectionSet({
+                        parent: type,
+                        type: t,
+                        models,
+                        path,
+                        ancestors,
+                        ignore,
+                        depthLimit,
+                        circularReferenceDepth,
+                        schema,
+                        depth,
+                        argNames,
+                        selectedFields,
+                        rootTypeNames,
+                    }),
+                };
+            })
+                .filter(fragmentNode => { var _a, _b; return ((_b = (_a = fragmentNode === null || fragmentNode === void 0 ? void 0 : fragmentNode.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length) > 0; }),
+        };
+    }
+    if ((0, graphql_1.isInterfaceType)(type)) {
+        const types = Object.values(schema.getTypeMap()).filter((t) => (0, graphql_1.isObjectType)(t) && t.getInterfaces().includes(type));
+        return {
+            kind: graphql_1.Kind.SELECTION_SET,
+            selections: types
+                .filter(t => !hasCircularRef([...ancestors, t], {
+                depth: circularReferenceDepth,
+            }))
+                .map(t => {
+                return {
+                    kind: graphql_1.Kind.INLINE_FRAGMENT,
+                    typeCondition: {
+                        kind: graphql_1.Kind.NAMED_TYPE,
+                        name: {
+                            kind: graphql_1.Kind.NAME,
+                            value: t.name,
+                        },
+                    },
+                    selectionSet: resolveSelectionSet({
+                        parent: type,
+                        type: t,
+                        models,
+                        path,
+                        ancestors,
+                        ignore,
+                        depthLimit,
+                        circularReferenceDepth,
+                        schema,
+                        depth,
+                        argNames,
+                        selectedFields,
+                        rootTypeNames,
+                    }),
+                };
+            })
+                .filter(fragmentNode => { var _a, _b; return ((_b = (_a = fragmentNode === null || fragmentNode === void 0 ? void 0 : fragmentNode.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length) > 0; }),
+        };
+    }
+    if ((0, graphql_1.isObjectType)(type) && !rootTypeNames.has(type.name)) {
+        const isIgnored = ignore.includes(type.name) || ignore.includes(`${parent.name}.${path[path.length - 1]}`);
+        const isModel = models.includes(type.name);
+        if (!firstCall && isModel && !isIgnored) {
+            return {
+                kind: graphql_1.Kind.SELECTION_SET,
+                selections: [
+                    {
+                        kind: graphql_1.Kind.FIELD,
+                        name: {
+                            kind: graphql_1.Kind.NAME,
+                            value: 'id',
+                        },
+                    },
+                ],
+            };
+        }
+        const fields = type.getFields();
+        return {
+            kind: graphql_1.Kind.SELECTION_SET,
+            selections: Object.keys(fields)
+                .filter(fieldName => {
+                return !hasCircularRef([...ancestors, (0, graphql_1.getNamedType)(fields[fieldName].type)], {
+                    depth: circularReferenceDepth,
+                });
+            })
+                .map(fieldName => {
+                const selectedSubFields = typeof selectedFields === 'object' ? selectedFields[fieldName] : true;
+                if (selectedSubFields) {
+                    return resolveField({
+                        type,
+                        field: fields[fieldName],
+                        models,
+                        path: [...path, fieldName],
+                        ancestors,
+                        ignore,
+                        depthLimit,
+                        circularReferenceDepth,
+                        schema,
+                        depth,
+                        argNames,
+                        selectedFields: selectedSubFields,
+                        rootTypeNames,
+                    });
+                }
+                return null;
+            })
+                .filter((f) => {
+                var _a, _b;
+                if (f == null) {
+                    return false;
+                }
+                else if ('selectionSet' in f) {
+                    return !!((_b = (_a = f.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length);
+                }
+                return true;
+            }),
+        };
+    }
+}
+function resolveVariable(arg, name) {
+    function resolveVariableType(type) {
+        if ((0, graphql_1.isListType)(type)) {
+            return {
+                kind: graphql_1.Kind.LIST_TYPE,
+                type: resolveVariableType(type.ofType),
+            };
+        }
+        if ((0, graphql_1.isNonNullType)(type)) {
+            return {
+                kind: graphql_1.Kind.NON_NULL_TYPE,
+                // for v16 compatibility
+                type: resolveVariableType(type.ofType),
+            };
+        }
+        return {
+            kind: graphql_1.Kind.NAMED_TYPE,
+            name: {
+                kind: graphql_1.Kind.NAME,
+                value: type.name,
+            },
+        };
+    }
+    return {
+        kind: graphql_1.Kind.VARIABLE_DEFINITION,
+        variable: {
+            kind: graphql_1.Kind.VARIABLE,
+            name: {
+                kind: graphql_1.Kind.NAME,
+                value: name || arg.name,
+            },
+        },
+        type: resolveVariableType(arg.type),
+    };
+}
+function getArgumentName(name, path) {
+    return [...path, name].join('_');
+}
+function resolveField({ type, field, models, firstCall, path, ancestors, ignore, depthLimit, circularReferenceDepth, schema, depth, argNames, selectedFields, rootTypeNames, }) {
+    const namedType = (0, graphql_1.getNamedType)(field.type);
+    let args = [];
+    let removeField = false;
+    if (field.args && field.args.length) {
+        args = field.args
+            .map(arg => {
+            const argumentName = getArgumentName(arg.name, path);
+            if (argNames && !argNames.includes(argumentName)) {
+                if ((0, graphql_1.isNonNullType)(arg.type)) {
+                    removeField = true;
+                }
+                return null;
+            }
+            if (!firstCall) {
+                addOperationVariable(resolveVariable(arg, argumentName));
+            }
+            return {
+                kind: graphql_1.Kind.ARGUMENT,
+                name: {
+                    kind: graphql_1.Kind.NAME,
+                    value: arg.name,
+                },
+                value: {
+                    kind: graphql_1.Kind.VARIABLE,
+                    name: {
+                        kind: graphql_1.Kind.NAME,
+                        value: getArgumentName(arg.name, path),
+                    },
+                },
+            };
+        })
+            .filter(Boolean);
+    }
+    if (removeField) {
+        return null;
+    }
+    const fieldPath = [...path, field.name];
+    const fieldPathStr = fieldPath.join('.');
+    let fieldName = field.name;
+    if (fieldTypeMap.has(fieldPathStr) && fieldTypeMap.get(fieldPathStr) !== field.type.toString()) {
+        fieldName += field.type.toString().replace('!', 'NonNull');
+    }
+    fieldTypeMap.set(fieldPathStr, field.type.toString());
+    if (!(0, graphql_1.isScalarType)(namedType) && !(0, graphql_1.isEnumType)(namedType)) {
+        return {
+            kind: graphql_1.Kind.FIELD,
+            name: {
+                kind: graphql_1.Kind.NAME,
+                value: field.name,
+            },
+            ...(fieldName !== field.name && { alias: { kind: graphql_1.Kind.NAME, value: fieldName } }),
+            selectionSet: resolveSelectionSet({
+                parent: type,
+                type: namedType,
+                models,
+                firstCall,
+                path: fieldPath,
+                ancestors: [...ancestors, type],
+                ignore,
+                depthLimit,
+                circularReferenceDepth,
+                schema,
+                depth: depth + 1,
+                argNames,
+                selectedFields,
+                rootTypeNames,
+            }) || undefined,
+            arguments: args,
+        };
+    }
+    return {
+        kind: graphql_1.Kind.FIELD,
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: field.name,
+        },
+        ...(fieldName !== field.name && { alias: { kind: graphql_1.Kind.NAME, value: fieldName } }),
+        arguments: args,
+    };
+}
+function hasCircularRef(types, config = {
+    depth: 1,
+}) {
+    const type = types[types.length - 1];
+    if ((0, graphql_1.isScalarType)(type)) {
+        return false;
+    }
+    const size = types.filter(t => t.name === type.name).length;
+    return size > config.depth;
+}
+
+
+/***/ }),
 /* 362 */,
 /* 363 */,
 /* 364 */
@@ -15386,7 +19186,44 @@ function isSDLNode(value) {
 
 
 /***/ }),
-/* 368 */,
+/* 368 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MapperKind = void 0;
+var MapperKind;
+(function (MapperKind) {
+    MapperKind["TYPE"] = "MapperKind.TYPE";
+    MapperKind["SCALAR_TYPE"] = "MapperKind.SCALAR_TYPE";
+    MapperKind["ENUM_TYPE"] = "MapperKind.ENUM_TYPE";
+    MapperKind["COMPOSITE_TYPE"] = "MapperKind.COMPOSITE_TYPE";
+    MapperKind["OBJECT_TYPE"] = "MapperKind.OBJECT_TYPE";
+    MapperKind["INPUT_OBJECT_TYPE"] = "MapperKind.INPUT_OBJECT_TYPE";
+    MapperKind["ABSTRACT_TYPE"] = "MapperKind.ABSTRACT_TYPE";
+    MapperKind["UNION_TYPE"] = "MapperKind.UNION_TYPE";
+    MapperKind["INTERFACE_TYPE"] = "MapperKind.INTERFACE_TYPE";
+    MapperKind["ROOT_OBJECT"] = "MapperKind.ROOT_OBJECT";
+    MapperKind["QUERY"] = "MapperKind.QUERY";
+    MapperKind["MUTATION"] = "MapperKind.MUTATION";
+    MapperKind["SUBSCRIPTION"] = "MapperKind.SUBSCRIPTION";
+    MapperKind["DIRECTIVE"] = "MapperKind.DIRECTIVE";
+    MapperKind["FIELD"] = "MapperKind.FIELD";
+    MapperKind["COMPOSITE_FIELD"] = "MapperKind.COMPOSITE_FIELD";
+    MapperKind["OBJECT_FIELD"] = "MapperKind.OBJECT_FIELD";
+    MapperKind["ROOT_FIELD"] = "MapperKind.ROOT_FIELD";
+    MapperKind["QUERY_ROOT_FIELD"] = "MapperKind.QUERY_ROOT_FIELD";
+    MapperKind["MUTATION_ROOT_FIELD"] = "MapperKind.MUTATION_ROOT_FIELD";
+    MapperKind["SUBSCRIPTION_ROOT_FIELD"] = "MapperKind.SUBSCRIPTION_ROOT_FIELD";
+    MapperKind["INTERFACE_FIELD"] = "MapperKind.INTERFACE_FIELD";
+    MapperKind["INPUT_OBJECT_FIELD"] = "MapperKind.INPUT_OBJECT_FIELD";
+    MapperKind["ARGUMENT"] = "MapperKind.ARGUMENT";
+    MapperKind["ENUM_VALUE"] = "MapperKind.ENUM_VALUE";
+})(MapperKind = exports.MapperKind || (exports.MapperKind = {}));
+
+
+/***/ }),
 /* 369 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -15878,8 +19715,35 @@ function mapValue(map, fn) {
 
 
 /***/ }),
-/* 373 */,
-/* 374 */,
+/* 373 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+/***/ }),
+/* 374 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getObjectTypeFromTypeMap = void 0;
+const graphql_1 = __webpack_require__(232);
+function getObjectTypeFromTypeMap(typeMap, type) {
+    if (type) {
+        const maybeObjectType = typeMap[type.name];
+        if ((0, graphql_1.isObjectType)(maybeObjectType)) {
+            return maybeObjectType;
+        }
+    }
+}
+exports.getObjectTypeFromTypeMap = getObjectTypeFromTypeMap;
+
+
+/***/ }),
 /* 375 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -17642,8 +21506,215 @@ function readName(lexer, start) {
 
 
 /***/ }),
-/* 389 */,
-/* 390 */,
+/* 389 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.memoize2of4 = exports.memoize5 = exports.memoize4 = exports.memoize3 = exports.memoize2 = exports.memoize1 = void 0;
+function memoize1(fn) {
+    const memoize1cache = new WeakMap();
+    return function memoized(a1) {
+        const cachedValue = memoize1cache.get(a1);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1);
+            memoize1cache.set(a1, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+exports.memoize1 = memoize1;
+function memoize2(fn) {
+    const memoize2cache = new WeakMap();
+    return function memoized(a1, a2) {
+        let cache2 = memoize2cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize2cache.set(a1, cache2);
+            const newValue = fn(a1, a2);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        const cachedValue = cache2.get(a2);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+exports.memoize2 = memoize2;
+function memoize3(fn) {
+    const memoize3Cache = new WeakMap();
+    return function memoized(a1, a2, a3) {
+        let cache2 = memoize3Cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize3Cache.set(a1, cache2);
+            const cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const newValue = fn(a1, a2, a3);
+            cache3.set(a3, newValue);
+            return newValue;
+        }
+        let cache3 = cache2.get(a2);
+        if (!cache3) {
+            cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const newValue = fn(a1, a2, a3);
+            cache3.set(a3, newValue);
+            return newValue;
+        }
+        const cachedValue = cache3.get(a3);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3);
+            cache3.set(a3, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+exports.memoize3 = memoize3;
+function memoize4(fn) {
+    const memoize4Cache = new WeakMap();
+    return function memoized(a1, a2, a3, a4) {
+        let cache2 = memoize4Cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize4Cache.set(a1, cache2);
+            const cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        let cache3 = cache2.get(a2);
+        if (!cache3) {
+            cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        const cache4 = cache3.get(a3);
+        if (!cache4) {
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        const cachedValue = cache4.get(a4);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+exports.memoize4 = memoize4;
+function memoize5(fn) {
+    const memoize5Cache = new WeakMap();
+    return function memoized(a1, a2, a3, a4, a5) {
+        let cache2 = memoize5Cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize5Cache.set(a1, cache2);
+            const cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        let cache3 = cache2.get(a2);
+        if (!cache3) {
+            cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        let cache4 = cache3.get(a3);
+        if (!cache4) {
+            cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        let cache5 = cache4.get(a4);
+        if (!cache5) {
+            cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        const cachedValue = cache5.get(a5);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+exports.memoize5 = memoize5;
+const memoize2of4cache = new WeakMap();
+function memoize2of4(fn) {
+    return function memoized(a1, a2, a3, a4) {
+        let cache2 = memoize2of4cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize2of4cache.set(a1, cache2);
+            const newValue = fn(a1, a2, a3, a4);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        const cachedValue = cache2.get(a2);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3, a4);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+exports.memoize2of4 = memoize2of4;
+
+
+/***/ }),
+/* 390 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = __webpack_require__(811);
+tslib_1.__exportStar(__webpack_require__(542), exports);
+tslib_1.__exportStar(__webpack_require__(948), exports);
+tslib_1.__exportStar(__webpack_require__(627), exports);
+
+
+/***/ }),
 /* 391 */,
 /* 392 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -17914,7 +21985,98 @@ function getObjectTag(object) {
 
 
 /***/ }),
-/* 394 */,
+/* 394 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.observableToAsyncIterable = void 0;
+function observableToAsyncIterable(observable) {
+    const pullQueue = [];
+    const pushQueue = [];
+    let listening = true;
+    const pushValue = (value) => {
+        if (pullQueue.length !== 0) {
+            // It is safe to use the ! operator here as we check the length.
+            pullQueue.shift()({ value, done: false });
+        }
+        else {
+            pushQueue.push({ value, done: false });
+        }
+    };
+    const pushError = (error) => {
+        if (pullQueue.length !== 0) {
+            // It is safe to use the ! operator here as we check the length.
+            pullQueue.shift()({ value: { errors: [error] }, done: false });
+        }
+        else {
+            pushQueue.push({ value: { errors: [error] }, done: false });
+        }
+    };
+    const pushDone = () => {
+        if (pullQueue.length !== 0) {
+            // It is safe to use the ! operator here as we check the length.
+            pullQueue.shift()({ done: true });
+        }
+        else {
+            pushQueue.push({ done: true });
+        }
+    };
+    const pullValue = () => new Promise(resolve => {
+        if (pushQueue.length !== 0) {
+            const element = pushQueue.shift();
+            // either {value: {errors: [...]}} or {value: ...}
+            resolve(element);
+        }
+        else {
+            pullQueue.push(resolve);
+        }
+    });
+    const subscription = observable.subscribe({
+        next(value) {
+            pushValue(value);
+        },
+        error(err) {
+            pushError(err);
+        },
+        complete() {
+            pushDone();
+        },
+    });
+    const emptyQueue = () => {
+        if (listening) {
+            listening = false;
+            subscription.unsubscribe();
+            for (const resolve of pullQueue) {
+                resolve({ value: undefined, done: true });
+            }
+            pullQueue.length = 0;
+            pushQueue.length = 0;
+        }
+    };
+    return {
+        next() {
+            // return is a defined method, so it is safe to call it.
+            return listening ? pullValue() : this.return();
+        },
+        return() {
+            emptyQueue();
+            return Promise.resolve({ value: undefined, done: true });
+        },
+        throw(error) {
+            emptyQueue();
+            return Promise.reject(error);
+        },
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+    };
+}
+exports.observableToAsyncIterable = observableToAsyncIterable;
+
+
+/***/ }),
 /* 395 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -18105,7 +22267,35 @@ function isBinding(node, parent, grandparent) {
 }
 
 /***/ }),
-/* 403 */,
+/* 403 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.relocatedError = exports.createGraphQLError = void 0;
+const graphql_1 = __webpack_require__(232);
+function createGraphQLError(message, options) {
+    if (graphql_1.versionInfo.major >= 17) {
+        return new graphql_1.GraphQLError(message, options);
+    }
+    return new graphql_1.GraphQLError(message, options === null || options === void 0 ? void 0 : options.nodes, options === null || options === void 0 ? void 0 : options.source, options === null || options === void 0 ? void 0 : options.positions, options === null || options === void 0 ? void 0 : options.path, options === null || options === void 0 ? void 0 : options.originalError, options === null || options === void 0 ? void 0 : options.extensions);
+}
+exports.createGraphQLError = createGraphQLError;
+function relocatedError(originalError, path) {
+    return createGraphQLError(originalError.message, {
+        nodes: originalError.nodes,
+        source: originalError.source,
+        positions: originalError.positions,
+        path: path == null ? originalError.path : path,
+        originalError,
+        extensions: originalError.extensions,
+    });
+}
+exports.relocatedError = relocatedError;
+
+
+/***/ }),
 /* 404 */,
 /* 405 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -19614,7 +23804,66 @@ module.exports.default = module.exports; // For TypeScript
 
 
 /***/ }),
-/* 407 */,
+/* 407 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mapAsyncIterator = void 0;
+/**
+ * Given an AsyncIterable and a callback function, return an AsyncIterator
+ * which produces values mapped via calling the callback function.
+ */
+function mapAsyncIterator(iterator, callback, rejectCallback) {
+    let $return;
+    let abruptClose;
+    if (typeof iterator.return === 'function') {
+        $return = iterator.return;
+        abruptClose = (error) => {
+            const rethrow = () => Promise.reject(error);
+            return $return.call(iterator).then(rethrow, rethrow);
+        };
+    }
+    function mapResult(result) {
+        return result.done ? result : asyncMapValue(result.value, callback).then(iteratorResult, abruptClose);
+    }
+    let mapReject;
+    if (rejectCallback) {
+        // Capture rejectCallback to ensure it cannot be null.
+        const reject = rejectCallback;
+        mapReject = (error) => asyncMapValue(error, reject).then(iteratorResult, abruptClose);
+    }
+    return {
+        next() {
+            return iterator.next().then(mapResult, mapReject);
+        },
+        return() {
+            return $return
+                ? $return.call(iterator).then(mapResult, mapReject)
+                : Promise.resolve({ value: undefined, done: true });
+        },
+        throw(error) {
+            if (typeof iterator.throw === 'function') {
+                return iterator.throw(error).then(mapResult, mapReject);
+            }
+            return Promise.reject(error).catch(abruptClose);
+        },
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+    };
+}
+exports.mapAsyncIterator = mapAsyncIterator;
+function asyncMapValue(value, callback) {
+    return new Promise(resolve => resolve(callback(value)));
+}
+function iteratorResult(value) {
+    return { value, done: false };
+}
+
+
+/***/ }),
 /* 408 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -20192,3501 +24441,19 @@ function collectReferencedTypes(type, typeSet) {
 
 /***/ }),
 /* 415 */,
-/* 416 */
+/* 416 */,
+/* 417 */,
+/* 418 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
 "use strict";
 
-
-Object.defineProperty(exports, '__esModule', { value: true });
-
-const graphql = __webpack_require__(232);
-
-const asArray = (fns) => (Array.isArray(fns) ? fns : fns ? [fns] : []);
-const invalidDocRegex = /\.[a-z0-9]+$/i;
-function isDocumentString(str) {
-    if (typeof str !== 'string') {
-        return false;
-    }
-    // XXX: is-valid-path or is-glob treat SDL as a valid path
-    // (`scalar Date` for example)
-    // this why checking the extension is fast enough
-    // and prevent from parsing the string in order to find out
-    // if the string is a SDL
-    if (invalidDocRegex.test(str)) {
-        return false;
-    }
-    try {
-        graphql.parse(str);
-        return true;
-    }
-    catch (e) { }
-    return false;
-}
-const invalidPathRegex = /[‘“!%&^<=>`]/;
-function isValidPath(str) {
-    return typeof str === 'string' && !invalidPathRegex.test(str);
-}
-function compareStrings(a, b) {
-    if (String(a) < String(b)) {
-        return -1;
-    }
-    if (String(a) > String(b)) {
-        return 1;
-    }
-    return 0;
-}
-function nodeToString(a) {
-    var _a, _b;
-    let name;
-    if ('alias' in a) {
-        name = (_a = a.alias) === null || _a === void 0 ? void 0 : _a.value;
-    }
-    if (name == null && 'name' in a) {
-        name = (_b = a.name) === null || _b === void 0 ? void 0 : _b.value;
-    }
-    if (name == null) {
-        name = a.kind;
-    }
-    return name;
-}
-function compareNodes(a, b, customFn) {
-    const aStr = nodeToString(a);
-    const bStr = nodeToString(b);
-    if (typeof customFn === 'function') {
-        return customFn(aStr, bStr);
-    }
-    return compareStrings(aStr, bStr);
-}
-function isSome(input) {
-    return input != null;
-}
-function assertSome(input, message = 'Value should be something') {
-    if (input == null) {
-        throw new Error(message);
-    }
-}
-
-if (typeof AggregateError === 'undefined') {
-    class AggregateErrorClass extends Error {
-        constructor(errors, message = '') {
-            super(message);
-            this.errors = errors;
-            this.name = 'AggregateError';
-            Error.captureStackTrace(this, AggregateErrorClass);
-        }
-    }
-    exports.AggregateError = function (errors, message) {
-        return new AggregateErrorClass(errors, message);
-    };
-}
-else {
-    exports.AggregateError = AggregateError;
-}
-function isAggregateError(error) {
-    return 'errors' in error && Array.isArray(error['errors']);
-}
-
-// Taken from graphql-js
-const MAX_RECURSIVE_DEPTH = 3;
-/**
- * Used to print values in error messages.
- */
-function inspect(value) {
-    return formatValue(value, []);
-}
-function formatValue(value, seenValues) {
-    switch (typeof value) {
-        case 'string':
-            return JSON.stringify(value);
-        case 'function':
-            return value.name ? `[function ${value.name}]` : '[function]';
-        case 'object':
-            return formatObjectValue(value, seenValues);
-        default:
-            return String(value);
-    }
-}
-function formatError(value) {
-    if (value instanceof graphql.GraphQLError) {
-        return value.toString();
-    }
-    return `${value.name}: ${value.message};\n ${value.stack}`;
-}
-function formatObjectValue(value, previouslySeenValues) {
-    if (value === null) {
-        return 'null';
-    }
-    if (value instanceof Error) {
-        if (isAggregateError(value)) {
-            return formatError(value) + '\n' + formatArray(value.errors, previouslySeenValues);
-        }
-        return formatError(value);
-    }
-    if (previouslySeenValues.includes(value)) {
-        return '[Circular]';
-    }
-    const seenValues = [...previouslySeenValues, value];
-    if (isJSONable(value)) {
-        const jsonValue = value.toJSON();
-        // check for infinite recursion
-        if (jsonValue !== value) {
-            return typeof jsonValue === 'string' ? jsonValue : formatValue(jsonValue, seenValues);
-        }
-    }
-    else if (Array.isArray(value)) {
-        return formatArray(value, seenValues);
-    }
-    return formatObject(value, seenValues);
-}
-function isJSONable(value) {
-    return typeof value.toJSON === 'function';
-}
-function formatObject(object, seenValues) {
-    const entries = Object.entries(object);
-    if (entries.length === 0) {
-        return '{}';
-    }
-    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
-        return '[' + getObjectTag(object) + ']';
-    }
-    const properties = entries.map(([key, value]) => key + ': ' + formatValue(value, seenValues));
-    return '{ ' + properties.join(', ') + ' }';
-}
-function formatArray(array, seenValues) {
-    if (array.length === 0) {
-        return '[]';
-    }
-    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
-        return '[Array]';
-    }
-    const len = array.length;
-    const remaining = array.length;
-    const items = [];
-    for (let i = 0; i < len; ++i) {
-        items.push(formatValue(array[i], seenValues));
-    }
-    if (remaining === 1) {
-        items.push('... 1 more item');
-    }
-    else if (remaining > 1) {
-        items.push(`... ${remaining} more items`);
-    }
-    return '[' + items.join(', ') + ']';
-}
-function getObjectTag(object) {
-    const tag = Object.prototype.toString
-        .call(object)
-        .replace(/^\[object /, '')
-        .replace(/]$/, '');
-    if (tag === 'Object' && typeof object.constructor === 'function') {
-        const name = object.constructor.name;
-        if (typeof name === 'string' && name !== '') {
-            return name;
-        }
-    }
-    return tag;
-}
-
-/**
- * Prepares an object map of argument values given a list of argument
- * definitions and list of argument AST nodes.
- *
- * Note: The returned value is a plain Object with a prototype, since it is
- * exposed to user code. Care should be taken to not pull values from the
- * Object prototype.
- */
-function getArgumentValues(def, node, variableValues = {}) {
-    var _a;
-    const variableMap = Object.entries(variableValues).reduce((prev, [key, value]) => ({
-        ...prev,
-        [key]: value,
-    }), {});
-    const coercedValues = {};
-    const argumentNodes = (_a = node.arguments) !== null && _a !== void 0 ? _a : [];
-    const argNodeMap = argumentNodes.reduce((prev, arg) => ({
-        ...prev,
-        [arg.name.value]: arg,
-    }), {});
-    for (const { name, type: argType, defaultValue } of def.args) {
-        const argumentNode = argNodeMap[name];
-        if (!argumentNode) {
-            if (defaultValue !== undefined) {
-                coercedValues[name] = defaultValue;
-            }
-            else if (graphql.isNonNullType(argType)) {
-                throw new graphql.GraphQLError(`Argument "${name}" of required type "${inspect(argType)}" ` + 'was not provided.', node);
-            }
-            continue;
-        }
-        const valueNode = argumentNode.value;
-        let isNull = valueNode.kind === graphql.Kind.NULL;
-        if (valueNode.kind === graphql.Kind.VARIABLE) {
-            const variableName = valueNode.name.value;
-            if (variableValues == null || variableMap[variableName] == null) {
-                if (defaultValue !== undefined) {
-                    coercedValues[name] = defaultValue;
-                }
-                else if (graphql.isNonNullType(argType)) {
-                    throw new graphql.GraphQLError(`Argument "${name}" of required type "${inspect(argType)}" ` +
-                        `was provided the variable "$${variableName}" which was not provided a runtime value.`, valueNode);
-                }
-                continue;
-            }
-            isNull = variableValues[variableName] == null;
-        }
-        if (isNull && graphql.isNonNullType(argType)) {
-            throw new graphql.GraphQLError(`Argument "${name}" of non-null type "${inspect(argType)}" ` + 'must not be null.', valueNode);
-        }
-        const coercedValue = graphql.valueFromAST(valueNode, argType, variableValues);
-        if (coercedValue === undefined) {
-            // Note: ValuesOfCorrectTypeRule validation should catch this before
-            // execution. This is a runtime check to ensure execution does not
-            // continue with an invalid argument value.
-            throw new graphql.GraphQLError(`Argument "${name}" has invalid value ${graphql.print(valueNode)}.`, valueNode);
-        }
-        coercedValues[name] = coercedValue;
-    }
-    return coercedValues;
-}
-
-function getDirectivesInExtensions(node, pathToDirectivesInExtensions = ['directives']) {
-    return pathToDirectivesInExtensions.reduce((acc, pathSegment) => (acc == null ? acc : acc[pathSegment]), node === null || node === void 0 ? void 0 : node.extensions);
-}
-function _getDirectiveInExtensions(directivesInExtensions, directiveName) {
-    const directiveInExtensions = directivesInExtensions.filter(directiveAnnotation => directiveAnnotation.name === directiveName);
-    if (!directiveInExtensions.length) {
-        return undefined;
-    }
-    return directiveInExtensions.map(directive => { var _a; return (_a = directive.args) !== null && _a !== void 0 ? _a : {}; });
-}
-function getDirectiveInExtensions(node, directiveName, pathToDirectivesInExtensions = ['directives']) {
-    const directivesInExtensions = pathToDirectivesInExtensions.reduce((acc, pathSegment) => (acc == null ? acc : acc[pathSegment]), node === null || node === void 0 ? void 0 : node.extensions);
-    if (directivesInExtensions === undefined) {
-        return undefined;
-    }
-    if (Array.isArray(directivesInExtensions)) {
-        return _getDirectiveInExtensions(directivesInExtensions, directiveName);
-    }
-    // Support condensed format by converting to longer format
-    // The condensed format does not preserve ordering of directives when  repeatable directives are used.
-    // See https://github.com/ardatan/graphql-tools/issues/2534
-    const reformattedDirectivesInExtensions = [];
-    for (const [name, argsOrArrayOfArgs] of Object.entries(directivesInExtensions)) {
-        if (Array.isArray(argsOrArrayOfArgs)) {
-            for (const args of argsOrArrayOfArgs) {
-                reformattedDirectivesInExtensions.push({ name, args });
-            }
-        }
-        else {
-            reformattedDirectivesInExtensions.push({ name, args: argsOrArrayOfArgs });
-        }
-    }
-    return _getDirectiveInExtensions(reformattedDirectivesInExtensions, directiveName);
-}
-function getDirectives(schema, node, pathToDirectivesInExtensions = ['directives']) {
-    const directivesInExtensions = getDirectivesInExtensions(node, pathToDirectivesInExtensions);
-    if (directivesInExtensions != null && directivesInExtensions.length > 0) {
-        return directivesInExtensions;
-    }
-    const schemaDirectives = schema && schema.getDirectives ? schema.getDirectives() : [];
-    const schemaDirectiveMap = schemaDirectives.reduce((schemaDirectiveMap, schemaDirective) => {
-        schemaDirectiveMap[schemaDirective.name] = schemaDirective;
-        return schemaDirectiveMap;
-    }, {});
-    let astNodes = [];
-    if (node.astNode) {
-        astNodes.push(node.astNode);
-    }
-    if ('extensionASTNodes' in node && node.extensionASTNodes) {
-        astNodes = [...astNodes, ...node.extensionASTNodes];
-    }
-    const result = [];
-    for (const astNode of astNodes) {
-        if (astNode.directives) {
-            for (const directiveNode of astNode.directives) {
-                const schemaDirective = schemaDirectiveMap[directiveNode.name.value];
-                if (schemaDirective) {
-                    result.push({ name: directiveNode.name.value, args: getArgumentValues(schemaDirective, directiveNode) });
-                }
-            }
-        }
-    }
-    return result;
-}
-function getDirective(schema, node, directiveName, pathToDirectivesInExtensions = ['directives']) {
-    const directiveInExtensions = getDirectiveInExtensions(node, directiveName, pathToDirectivesInExtensions);
-    if (directiveInExtensions != null) {
-        return directiveInExtensions;
-    }
-    const schemaDirective = schema && schema.getDirective ? schema.getDirective(directiveName) : undefined;
-    if (schemaDirective == null) {
-        return undefined;
-    }
-    let astNodes = [];
-    if (node.astNode) {
-        astNodes.push(node.astNode);
-    }
-    if ('extensionASTNodes' in node && node.extensionASTNodes) {
-        astNodes = [...astNodes, ...node.extensionASTNodes];
-    }
-    const result = [];
-    for (const astNode of astNodes) {
-        if (astNode.directives) {
-            for (const directiveNode of astNode.directives) {
-                if (directiveNode.name.value === directiveName) {
-                    result.push(getArgumentValues(schemaDirective, directiveNode));
-                }
-            }
-        }
-    }
-    if (!result.length) {
-        return undefined;
-    }
-    return result;
-}
-
-function parseDirectiveValue(value) {
-    switch (value.kind) {
-        case graphql.Kind.INT:
-            return parseInt(value.value);
-        case graphql.Kind.FLOAT:
-            return parseFloat(value.value);
-        case graphql.Kind.BOOLEAN:
-            return Boolean(value.value);
-        case graphql.Kind.STRING:
-        case graphql.Kind.ENUM:
-            return value.value;
-        case graphql.Kind.LIST:
-            return value.values.map(v => parseDirectiveValue(v));
-        case graphql.Kind.OBJECT:
-            return value.fields.reduce((prev, v) => ({ ...prev, [v.name.value]: parseDirectiveValue(v.value) }), {});
-        case graphql.Kind.NULL:
-            return null;
-        default:
-            return null;
-    }
-}
-function getFieldsWithDirectives(documentNode, options = {}) {
-    const result = {};
-    let selected = ['ObjectTypeDefinition', 'ObjectTypeExtension'];
-    if (options.includeInputTypes) {
-        selected = [...selected, 'InputObjectTypeDefinition', 'InputObjectTypeExtension'];
-    }
-    const allTypes = documentNode.definitions.filter(obj => selected.includes(obj.kind));
-    for (const type of allTypes) {
-        const typeName = type.name.value;
-        if (type.fields == null) {
-            continue;
-        }
-        for (const field of type.fields) {
-            if (field.directives && field.directives.length > 0) {
-                const fieldName = field.name.value;
-                const key = `${typeName}.${fieldName}`;
-                const directives = field.directives.map(d => ({
-                    name: d.name.value,
-                    args: (d.arguments || []).reduce((prev, arg) => ({ ...prev, [arg.name.value]: parseDirectiveValue(arg.value) }), {}),
-                }));
-                result[key] = directives;
-            }
-        }
-    }
-    return result;
-}
-
-function getImplementingTypes(interfaceName, schema) {
-    const allTypesMap = schema.getTypeMap();
-    const result = [];
-    for (const graphqlTypeName in allTypesMap) {
-        const graphqlType = allTypesMap[graphqlTypeName];
-        if (graphql.isObjectType(graphqlType)) {
-            const allInterfaces = graphqlType.getInterfaces();
-            if (allInterfaces.find(int => int.name === interfaceName)) {
-                result.push(graphqlType.name);
-            }
-        }
-    }
-    return result;
-}
-
-function astFromType(type) {
-    if (graphql.isNonNullType(type)) {
-        const innerType = astFromType(type.ofType);
-        if (innerType.kind === graphql.Kind.NON_NULL_TYPE) {
-            throw new Error(`Invalid type node ${inspect(type)}. Inner type of non-null type cannot be a non-null type.`);
-        }
-        return {
-            kind: graphql.Kind.NON_NULL_TYPE,
-            type: innerType,
-        };
-    }
-    else if (graphql.isListType(type)) {
-        return {
-            kind: graphql.Kind.LIST_TYPE,
-            type: astFromType(type.ofType),
-        };
-    }
-    return {
-        kind: graphql.Kind.NAMED_TYPE,
-        name: {
-            kind: graphql.Kind.NAME,
-            value: type.name,
-        },
-    };
-}
-
-/**
- * Produces a GraphQL Value AST given a JavaScript object.
- * Function will match JavaScript/JSON values to GraphQL AST schema format
- * by using the following mapping.
- *
- * | JSON Value    | GraphQL Value        |
- * | ------------- | -------------------- |
- * | Object        | Input Object         |
- * | Array         | List                 |
- * | Boolean       | Boolean              |
- * | String        | String               |
- * | Number        | Int / Float          |
- * | null          | NullValue            |
- *
- */
-function astFromValueUntyped(value) {
-    // only explicit null, not undefined, NaN
-    if (value === null) {
-        return { kind: graphql.Kind.NULL };
-    }
-    // undefined
-    if (value === undefined) {
-        return null;
-    }
-    // Convert JavaScript array to GraphQL list. If the GraphQLType is a list, but
-    // the value is not an array, convert the value using the list's item type.
-    if (Array.isArray(value)) {
-        const valuesNodes = [];
-        for (const item of value) {
-            const itemNode = astFromValueUntyped(item);
-            if (itemNode != null) {
-                valuesNodes.push(itemNode);
-            }
-        }
-        return { kind: graphql.Kind.LIST, values: valuesNodes };
-    }
-    if (typeof value === 'object') {
-        const fieldNodes = [];
-        for (const fieldName in value) {
-            const fieldValue = value[fieldName];
-            const ast = astFromValueUntyped(fieldValue);
-            if (ast) {
-                fieldNodes.push({
-                    kind: graphql.Kind.OBJECT_FIELD,
-                    name: { kind: graphql.Kind.NAME, value: fieldName },
-                    value: ast,
-                });
-            }
-        }
-        return { kind: graphql.Kind.OBJECT, fields: fieldNodes };
-    }
-    // Others serialize based on their corresponding JavaScript scalar types.
-    if (typeof value === 'boolean') {
-        return { kind: graphql.Kind.BOOLEAN, value };
-    }
-    // JavaScript numbers can be Int or Float values.
-    if (typeof value === 'number' && isFinite(value)) {
-        const stringNum = String(value);
-        return integerStringRegExp.test(stringNum)
-            ? { kind: graphql.Kind.INT, value: stringNum }
-            : { kind: graphql.Kind.FLOAT, value: stringNum };
-    }
-    if (typeof value === 'string') {
-        return { kind: graphql.Kind.STRING, value };
-    }
-    throw new TypeError(`Cannot convert value to AST: ${value}.`);
-}
-/**
- * IntValue:
- *   - NegativeSign? 0
- *   - NegativeSign? NonZeroDigit ( Digit+ )?
- */
-const integerStringRegExp = /^-?(?:0|[1-9][0-9]*)$/;
-
-function memoize1(fn) {
-    const memoize1cache = new WeakMap();
-    return function memoized(a1) {
-        const cachedValue = memoize1cache.get(a1);
-        if (cachedValue === undefined) {
-            const newValue = fn(a1);
-            memoize1cache.set(a1, newValue);
-            return newValue;
-        }
-        return cachedValue;
-    };
-}
-function memoize2(fn) {
-    const memoize2cache = new WeakMap();
-    return function memoized(a1, a2) {
-        let cache2 = memoize2cache.get(a1);
-        if (!cache2) {
-            cache2 = new WeakMap();
-            memoize2cache.set(a1, cache2);
-            const newValue = fn(a1, a2);
-            cache2.set(a2, newValue);
-            return newValue;
-        }
-        const cachedValue = cache2.get(a2);
-        if (cachedValue === undefined) {
-            const newValue = fn(a1, a2);
-            cache2.set(a2, newValue);
-            return newValue;
-        }
-        return cachedValue;
-    };
-}
-function memoize3(fn) {
-    const memoize3Cache = new WeakMap();
-    return function memoized(a1, a2, a3) {
-        let cache2 = memoize3Cache.get(a1);
-        if (!cache2) {
-            cache2 = new WeakMap();
-            memoize3Cache.set(a1, cache2);
-            const cache3 = new WeakMap();
-            cache2.set(a2, cache3);
-            const newValue = fn(a1, a2, a3);
-            cache3.set(a3, newValue);
-            return newValue;
-        }
-        let cache3 = cache2.get(a2);
-        if (!cache3) {
-            cache3 = new WeakMap();
-            cache2.set(a2, cache3);
-            const newValue = fn(a1, a2, a3);
-            cache3.set(a3, newValue);
-            return newValue;
-        }
-        const cachedValue = cache3.get(a3);
-        if (cachedValue === undefined) {
-            const newValue = fn(a1, a2, a3);
-            cache3.set(a3, newValue);
-            return newValue;
-        }
-        return cachedValue;
-    };
-}
-function memoize4(fn) {
-    const memoize4Cache = new WeakMap();
-    return function memoized(a1, a2, a3, a4) {
-        let cache2 = memoize4Cache.get(a1);
-        if (!cache2) {
-            cache2 = new WeakMap();
-            memoize4Cache.set(a1, cache2);
-            const cache3 = new WeakMap();
-            cache2.set(a2, cache3);
-            const cache4 = new WeakMap();
-            cache3.set(a3, cache4);
-            const newValue = fn(a1, a2, a3, a4);
-            cache4.set(a4, newValue);
-            return newValue;
-        }
-        let cache3 = cache2.get(a2);
-        if (!cache3) {
-            cache3 = new WeakMap();
-            cache2.set(a2, cache3);
-            const cache4 = new WeakMap();
-            cache3.set(a3, cache4);
-            const newValue = fn(a1, a2, a3, a4);
-            cache4.set(a4, newValue);
-            return newValue;
-        }
-        const cache4 = cache3.get(a3);
-        if (!cache4) {
-            const cache4 = new WeakMap();
-            cache3.set(a3, cache4);
-            const newValue = fn(a1, a2, a3, a4);
-            cache4.set(a4, newValue);
-            return newValue;
-        }
-        const cachedValue = cache4.get(a4);
-        if (cachedValue === undefined) {
-            const newValue = fn(a1, a2, a3, a4);
-            cache4.set(a4, newValue);
-            return newValue;
-        }
-        return cachedValue;
-    };
-}
-function memoize5(fn) {
-    const memoize5Cache = new WeakMap();
-    return function memoized(a1, a2, a3, a4, a5) {
-        let cache2 = memoize5Cache.get(a1);
-        if (!cache2) {
-            cache2 = new WeakMap();
-            memoize5Cache.set(a1, cache2);
-            const cache3 = new WeakMap();
-            cache2.set(a2, cache3);
-            const cache4 = new WeakMap();
-            cache3.set(a3, cache4);
-            const cache5 = new WeakMap();
-            cache4.set(a4, cache5);
-            const newValue = fn(a1, a2, a3, a4, a5);
-            cache5.set(a5, newValue);
-            return newValue;
-        }
-        let cache3 = cache2.get(a2);
-        if (!cache3) {
-            cache3 = new WeakMap();
-            cache2.set(a2, cache3);
-            const cache4 = new WeakMap();
-            cache3.set(a3, cache4);
-            const cache5 = new WeakMap();
-            cache4.set(a4, cache5);
-            const newValue = fn(a1, a2, a3, a4, a5);
-            cache5.set(a5, newValue);
-            return newValue;
-        }
-        let cache4 = cache3.get(a3);
-        if (!cache4) {
-            cache4 = new WeakMap();
-            cache3.set(a3, cache4);
-            const cache5 = new WeakMap();
-            cache4.set(a4, cache5);
-            const newValue = fn(a1, a2, a3, a4, a5);
-            cache5.set(a5, newValue);
-            return newValue;
-        }
-        let cache5 = cache4.get(a4);
-        if (!cache5) {
-            cache5 = new WeakMap();
-            cache4.set(a4, cache5);
-            const newValue = fn(a1, a2, a3, a4, a5);
-            cache5.set(a5, newValue);
-            return newValue;
-        }
-        const cachedValue = cache5.get(a5);
-        if (cachedValue === undefined) {
-            const newValue = fn(a1, a2, a3, a4, a5);
-            cache5.set(a5, newValue);
-            return newValue;
-        }
-        return cachedValue;
-    };
-}
-const memoize2of4cache = new WeakMap();
-function memoize2of4(fn) {
-    return function memoized(a1, a2, a3, a4) {
-        let cache2 = memoize2of4cache.get(a1);
-        if (!cache2) {
-            cache2 = new WeakMap();
-            memoize2of4cache.set(a1, cache2);
-            const newValue = fn(a1, a2, a3, a4);
-            cache2.set(a2, newValue);
-            return newValue;
-        }
-        const cachedValue = cache2.get(a2);
-        if (cachedValue === undefined) {
-            const newValue = fn(a1, a2, a3, a4);
-            cache2.set(a2, newValue);
-            return newValue;
-        }
-        return cachedValue;
-    };
-}
-
-function getDefinedRootType(schema, operation) {
-    const rootTypeMap = getRootTypeMap(schema);
-    const rootType = rootTypeMap.get(operation);
-    if (rootType == null) {
-        throw new Error(`Root type for operation "${operation}" not defined by the given schema.`);
-    }
-    return rootType;
-}
-const getRootTypeNames = memoize1(function getRootTypeNames(schema) {
-    const rootTypes = getRootTypes(schema);
-    return new Set([...rootTypes].map(type => type.name));
-});
-const getRootTypes = memoize1(function getRootTypes(schema) {
-    const rootTypeMap = getRootTypeMap(schema);
-    return new Set(rootTypeMap.values());
-});
-const getRootTypeMap = memoize1(function getRootTypeMap(schema) {
-    const rootTypeMap = new Map();
-    const queryType = schema.getQueryType();
-    if (queryType) {
-        rootTypeMap.set('query', queryType);
-    }
-    const mutationType = schema.getMutationType();
-    if (mutationType) {
-        rootTypeMap.set('mutation', mutationType);
-    }
-    const subscriptionType = schema.getSubscriptionType();
-    if (subscriptionType) {
-        rootTypeMap.set('subscription', subscriptionType);
-    }
-    return rootTypeMap;
-});
-
-function getDocumentNodeFromSchema(schema, options = {}) {
-    const pathToDirectivesInExtensions = options.pathToDirectivesInExtensions;
-    const typesMap = schema.getTypeMap();
-    const schemaNode = astFromSchema(schema, pathToDirectivesInExtensions);
-    const definitions = schemaNode != null ? [schemaNode] : [];
-    const directives = schema.getDirectives();
-    for (const directive of directives) {
-        if (graphql.isSpecifiedDirective(directive)) {
-            continue;
-        }
-        definitions.push(astFromDirective(directive, schema, pathToDirectivesInExtensions));
-    }
-    for (const typeName in typesMap) {
-        const type = typesMap[typeName];
-        const isPredefinedScalar = graphql.isSpecifiedScalarType(type);
-        const isIntrospection = graphql.isIntrospectionType(type);
-        if (isPredefinedScalar || isIntrospection) {
-            continue;
-        }
-        if (graphql.isObjectType(type)) {
-            definitions.push(astFromObjectType(type, schema, pathToDirectivesInExtensions));
-        }
-        else if (graphql.isInterfaceType(type)) {
-            definitions.push(astFromInterfaceType(type, schema, pathToDirectivesInExtensions));
-        }
-        else if (graphql.isUnionType(type)) {
-            definitions.push(astFromUnionType(type, schema, pathToDirectivesInExtensions));
-        }
-        else if (graphql.isInputObjectType(type)) {
-            definitions.push(astFromInputObjectType(type, schema, pathToDirectivesInExtensions));
-        }
-        else if (graphql.isEnumType(type)) {
-            definitions.push(astFromEnumType(type, schema, pathToDirectivesInExtensions));
-        }
-        else if (graphql.isScalarType(type)) {
-            definitions.push(astFromScalarType(type, schema, pathToDirectivesInExtensions));
-        }
-        else {
-            throw new Error(`Unknown type ${type}.`);
-        }
-    }
-    return {
-        kind: graphql.Kind.DOCUMENT,
-        definitions,
-    };
-}
-// this approach uses the default schema printer rather than a custom solution, so may be more backwards compatible
-// currently does not allow customization of printSchema options having to do with comments.
-function printSchemaWithDirectives(schema, options = {}) {
-    const documentNode = getDocumentNodeFromSchema(schema, options);
-    return graphql.print(documentNode);
-}
-function astFromSchema(schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    const operationTypeMap = new Map([
-        ['query', undefined],
-        ['mutation', undefined],
-        ['subscription', undefined],
-    ]);
-    const nodes = [];
-    if (schema.astNode != null) {
-        nodes.push(schema.astNode);
-    }
-    if (schema.extensionASTNodes != null) {
-        for (const extensionASTNode of schema.extensionASTNodes) {
-            nodes.push(extensionASTNode);
-        }
-    }
-    for (const node of nodes) {
-        if (node.operationTypes) {
-            for (const operationTypeDefinitionNode of node.operationTypes) {
-                operationTypeMap.set(operationTypeDefinitionNode.operation, operationTypeDefinitionNode);
-            }
-        }
-    }
-    const rootTypeMap = getRootTypeMap(schema);
-    for (const [operationTypeNode, operationTypeDefinitionNode] of operationTypeMap) {
-        const rootType = rootTypeMap.get(operationTypeNode);
-        if (rootType != null) {
-            const rootTypeAST = astFromType(rootType);
-            if (operationTypeDefinitionNode != null) {
-                operationTypeDefinitionNode.type = rootTypeAST;
-            }
-            else {
-                operationTypeMap.set(operationTypeNode, {
-                    kind: graphql.Kind.OPERATION_TYPE_DEFINITION,
-                    operation: operationTypeNode,
-                    type: rootTypeAST,
-                });
-            }
-        }
-    }
-    const operationTypes = [...operationTypeMap.values()].filter(isSome);
-    const directives = getDirectiveNodes(schema, schema, pathToDirectivesInExtensions);
-    if (!operationTypes.length && !directives.length) {
-        return null;
-    }
-    const schemaNode = {
-        kind: operationTypes != null ? graphql.Kind.SCHEMA_DEFINITION : graphql.Kind.SCHEMA_EXTENSION,
-        operationTypes,
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: directives,
-    };
-    // This code is so weird because it needs to support GraphQL.js 14
-    // In GraphQL.js 14 there is no `description` value on schemaNode
-    schemaNode.description =
-        ((_b = (_a = schema.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : schema.description != null)
-            ? {
-                kind: graphql.Kind.STRING,
-                value: schema.description,
-                block: true,
-            }
-            : undefined;
-    return schemaNode;
-}
-function astFromDirective(directive, schema, pathToDirectivesInExtensions) {
-    var _a, _b, _c, _d;
-    return {
-        kind: graphql.Kind.DIRECTIVE_DEFINITION,
-        description: (_b = (_a = directive.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (directive.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: directive.description,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: directive.name,
-        },
-        arguments: (_c = directive.args) === null || _c === void 0 ? void 0 : _c.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions)),
-        repeatable: directive.isRepeatable,
-        locations: ((_d = directive.locations) === null || _d === void 0 ? void 0 : _d.map(location => ({
-            kind: graphql.Kind.NAME,
-            value: location,
-        }))) || [],
-    };
-}
-function getDirectiveNodes(entity, schema, pathToDirectivesInExtensions) {
-    const directivesInExtensions = getDirectivesInExtensions(entity, pathToDirectivesInExtensions);
-    let nodes = [];
-    if (entity.astNode != null) {
-        nodes.push(entity.astNode);
-    }
-    if ('extensionASTNodes' in entity && entity.extensionASTNodes != null) {
-        nodes = nodes.concat(entity.extensionASTNodes);
-    }
-    let directives;
-    if (directivesInExtensions != null) {
-        directives = makeDirectiveNodes(schema, directivesInExtensions);
-    }
-    else {
-        directives = [];
-        for (const node of nodes) {
-            if (node.directives) {
-                directives.push(...node.directives);
-            }
-        }
-    }
-    return directives;
-}
-function getDeprecatableDirectiveNodes(entity, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    let directiveNodesBesidesDeprecated = [];
-    let deprecatedDirectiveNode = null;
-    const directivesInExtensions = getDirectivesInExtensions(entity, pathToDirectivesInExtensions);
-    let directives;
-    if (directivesInExtensions != null) {
-        directives = makeDirectiveNodes(schema, directivesInExtensions);
-    }
-    else {
-        directives = (_a = entity.astNode) === null || _a === void 0 ? void 0 : _a.directives;
-    }
-    if (directives != null) {
-        directiveNodesBesidesDeprecated = directives.filter(directive => directive.name.value !== 'deprecated');
-        if (entity.deprecationReason != null) {
-            deprecatedDirectiveNode = (_b = directives.filter(directive => directive.name.value === 'deprecated')) === null || _b === void 0 ? void 0 : _b[0];
-        }
-    }
-    if (entity.deprecationReason != null &&
-        deprecatedDirectiveNode == null) {
-        deprecatedDirectiveNode = makeDeprecatedDirective(entity.deprecationReason);
-    }
-    return deprecatedDirectiveNode == null
-        ? directiveNodesBesidesDeprecated
-        : [deprecatedDirectiveNode].concat(directiveNodesBesidesDeprecated);
-}
-function astFromArg(arg, schema, pathToDirectivesInExtensions) {
-    var _a, _b, _c;
-    return {
-        kind: graphql.Kind.INPUT_VALUE_DEFINITION,
-        description: (_b = (_a = arg.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (arg.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: arg.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: arg.name,
-        },
-        type: astFromType(arg.type),
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        defaultValue: arg.defaultValue !== undefined ? (_c = graphql.astFromValue(arg.defaultValue, arg.type)) !== null && _c !== void 0 ? _c : undefined : undefined,
-        directives: getDeprecatableDirectiveNodes(arg, schema, pathToDirectivesInExtensions),
-    };
-}
-function astFromObjectType(type, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    return {
-        kind: graphql.Kind.OBJECT_TYPE_DEFINITION,
-        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: type.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: type.name,
-        },
-        fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
-        interfaces: Object.values(type.getInterfaces()).map(iFace => astFromType(iFace)),
-        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
-    };
-}
-function astFromInterfaceType(type, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    const node = {
-        kind: graphql.Kind.INTERFACE_TYPE_DEFINITION,
-        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: type.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: type.name,
-        },
-        fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
-        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
-    };
-    if ('getInterfaces' in type) {
-        node.interfaces = Object.values(type.getInterfaces()).map(iFace => astFromType(iFace));
-    }
-    return node;
-}
-function astFromUnionType(type, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    return {
-        kind: graphql.Kind.UNION_TYPE_DEFINITION,
-        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: type.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: type.name,
-        },
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
-        types: type.getTypes().map(type => astFromType(type)),
-    };
-}
-function astFromInputObjectType(type, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    return {
-        kind: graphql.Kind.INPUT_OBJECT_TYPE_DEFINITION,
-        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: type.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: type.name,
-        },
-        fields: Object.values(type.getFields()).map(field => astFromInputField(field, schema, pathToDirectivesInExtensions)),
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
-    };
-}
-function astFromEnumType(type, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    return {
-        kind: graphql.Kind.ENUM_TYPE_DEFINITION,
-        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: type.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: type.name,
-        },
-        values: Object.values(type.getValues()).map(value => astFromEnumValue(value, schema, pathToDirectivesInExtensions)),
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
-    };
-}
-function astFromScalarType(type, schema, pathToDirectivesInExtensions) {
-    var _a, _b, _c;
-    const directivesInExtensions = getDirectivesInExtensions(type, pathToDirectivesInExtensions);
-    const directives = directivesInExtensions
-        ? makeDirectiveNodes(schema, directivesInExtensions)
-        : ((_a = type.astNode) === null || _a === void 0 ? void 0 : _a.directives) || [];
-    const specifiedByValue = (type['specifiedByUrl'] || type['specifiedByURL']);
-    if (specifiedByValue && !directives.some(directiveNode => directiveNode.name.value === 'specifiedBy')) {
-        const specifiedByArgs = {
-            url: specifiedByValue,
-        };
-        directives.push(makeDirectiveNode('specifiedBy', specifiedByArgs));
-    }
-    return {
-        kind: graphql.Kind.SCALAR_TYPE_DEFINITION,
-        description: (_c = (_b = type.astNode) === null || _b === void 0 ? void 0 : _b.description) !== null && _c !== void 0 ? _c : (type.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: type.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: type.name,
-        },
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: directives,
-    };
-}
-function astFromField(field, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    return {
-        kind: graphql.Kind.FIELD_DEFINITION,
-        description: (_b = (_a = field.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (field.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: field.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: field.name,
-        },
-        arguments: field.args.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions)),
-        type: astFromType(field.type),
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
-    };
-}
-function astFromInputField(field, schema, pathToDirectivesInExtensions) {
-    var _a, _b, _c;
-    return {
-        kind: graphql.Kind.INPUT_VALUE_DEFINITION,
-        description: (_b = (_a = field.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (field.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: field.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: field.name,
-        },
-        type: astFromType(field.type),
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
-        defaultValue: (_c = graphql.astFromValue(field.defaultValue, field.type)) !== null && _c !== void 0 ? _c : undefined,
-    };
-}
-function astFromEnumValue(value, schema, pathToDirectivesInExtensions) {
-    var _a, _b;
-    return {
-        kind: graphql.Kind.ENUM_VALUE_DEFINITION,
-        description: (_b = (_a = value.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (value.description
-            ? {
-                kind: graphql.Kind.STRING,
-                value: value.description,
-                block: true,
-            }
-            : undefined),
-        name: {
-            kind: graphql.Kind.NAME,
-            value: value.name,
-        },
-        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-        directives: getDeprecatableDirectiveNodes(value, schema, pathToDirectivesInExtensions),
-    };
-}
-function makeDeprecatedDirective(deprecationReason) {
-    return makeDirectiveNode('deprecated', { reason: deprecationReason }, graphql.GraphQLDeprecatedDirective);
-}
-function makeDirectiveNode(name, args, directive) {
-    const directiveArguments = [];
-    if (directive != null) {
-        for (const arg of directive.args) {
-            const argName = arg.name;
-            const argValue = args[argName];
-            if (argValue !== undefined) {
-                const value = graphql.astFromValue(argValue, arg.type);
-                if (value) {
-                    directiveArguments.push({
-                        kind: graphql.Kind.ARGUMENT,
-                        name: {
-                            kind: graphql.Kind.NAME,
-                            value: argName,
-                        },
-                        value,
-                    });
-                }
-            }
-        }
-    }
-    else {
-        for (const argName in args) {
-            const argValue = args[argName];
-            const value = astFromValueUntyped(argValue);
-            if (value) {
-                directiveArguments.push({
-                    kind: graphql.Kind.ARGUMENT,
-                    name: {
-                        kind: graphql.Kind.NAME,
-                        value: argName,
-                    },
-                    value,
-                });
-            }
-        }
-    }
-    return {
-        kind: graphql.Kind.DIRECTIVE,
-        name: {
-            kind: graphql.Kind.NAME,
-            value: name,
-        },
-        arguments: directiveArguments,
-    };
-}
-function makeDirectiveNodes(schema, directiveValues) {
-    const directiveNodes = [];
-    for (const directiveName in directiveValues) {
-        const arrayOrSingleValue = directiveValues[directiveName];
-        const directive = schema === null || schema === void 0 ? void 0 : schema.getDirective(directiveName);
-        if (Array.isArray(arrayOrSingleValue)) {
-            for (const value of arrayOrSingleValue) {
-                directiveNodes.push(makeDirectiveNode(directiveName, value, directive));
-            }
-        }
-        else {
-            directiveNodes.push(makeDirectiveNode(directiveName, arrayOrSingleValue, directive));
-        }
-    }
-    return directiveNodes;
-}
-
-async function validateGraphQlDocuments(schema, documentFiles, effectiveRules = createDefaultRules()) {
-    const allFragmentMap = new Map();
-    const documentFileObjectsToValidate = [];
-    for (const documentFile of documentFiles) {
-        if (documentFile.document) {
-            const definitionsToValidate = [];
-            for (const definitionNode of documentFile.document.definitions) {
-                if (definitionNode.kind === graphql.Kind.FRAGMENT_DEFINITION) {
-                    allFragmentMap.set(definitionNode.name.value, definitionNode);
-                }
-                else {
-                    definitionsToValidate.push(definitionNode);
-                }
-            }
-            documentFileObjectsToValidate.push({
-                location: documentFile.location,
-                document: {
-                    kind: graphql.Kind.DOCUMENT,
-                    definitions: definitionsToValidate,
-                },
-            });
-        }
-    }
-    const allErrors = [];
-    const allFragmentsDocument = {
-        kind: graphql.Kind.DOCUMENT,
-        definitions: [...allFragmentMap.values()],
-    };
-    await Promise.all(documentFileObjectsToValidate.map(async (documentFile) => {
-        const documentToValidate = graphql.concatAST([allFragmentsDocument, documentFile.document]);
-        const errors = graphql.validate(schema, documentToValidate, effectiveRules);
-        if (errors.length > 0) {
-            allErrors.push({
-                filePath: documentFile.location,
-                errors,
-            });
-        }
-    }));
-    return allErrors;
-}
-function checkValidationErrors(loadDocumentErrors) {
-    if (loadDocumentErrors.length > 0) {
-        const errors = [];
-        for (const loadDocumentError of loadDocumentErrors) {
-            for (const graphQLError of loadDocumentError.errors) {
-                const error = new Error();
-                error.name = 'GraphQLDocumentError';
-                error.message = `${error.name}: ${graphQLError.message}`;
-                error.stack = error.message;
-                if (graphQLError.locations) {
-                    for (const location of graphQLError.locations) {
-                        error.stack += `\n    at ${loadDocumentError.filePath}:${location.line}:${location.column}`;
-                    }
-                }
-                errors.push(error);
-            }
-        }
-        throw new exports.AggregateError(errors, `GraphQL Document Validation failed with ${errors.length} errors;
-  ${errors.map((error, index) => `Error ${index}: ${error.stack}`).join('\n\n')}`);
-    }
-}
-function createDefaultRules() {
-    let ignored = ['NoUnusedFragmentsRule', 'NoUnusedVariablesRule', 'KnownDirectivesRule'];
-    if (graphql.versionInfo.major < 15) {
-        ignored = ignored.map(rule => rule.replace(/Rule$/, ''));
-    }
-    return graphql.specifiedRules.filter((f) => !ignored.includes(f.name));
-}
-
-function stripBOM(content) {
-    content = content.toString();
-    // Remove byte order marker. This catches EF BB BF (the UTF-8 BOM)
-    // because the buffer-to-string conversion in `fs.readFileSync()`
-    // translates it to FEFF, the UTF-16 BOM.
-    if (content.charCodeAt(0) === 0xfeff) {
-        content = content.slice(1);
-    }
-    return content;
-}
-function parseBOM(content) {
-    return JSON.parse(stripBOM(content));
-}
-function parseGraphQLJSON(location, jsonContent, options) {
-    let parsedJson = parseBOM(jsonContent);
-    if (parsedJson.data) {
-        parsedJson = parsedJson.data;
-    }
-    if (parsedJson.kind === 'Document') {
-        return {
-            location,
-            document: parsedJson,
-        };
-    }
-    else if (parsedJson.__schema) {
-        const schema = graphql.buildClientSchema(parsedJson, options);
-        return {
-            location,
-            schema,
-        };
-    }
-    else if (typeof parsedJson === 'string') {
-        return {
-            location,
-            rawSDL: parsedJson,
-        };
-    }
-    throw new Error(`Not valid JSON content`);
-}
-
-const MAX_LINE_LENGTH = 80;
-let commentsRegistry = {};
-function resetComments() {
-    commentsRegistry = {};
-}
-function collectComment(node) {
-    var _a;
-    const entityName = (_a = node.name) === null || _a === void 0 ? void 0 : _a.value;
-    if (entityName == null) {
-        return;
-    }
-    pushComment(node, entityName);
-    switch (node.kind) {
-        case 'EnumTypeDefinition':
-            if (node.values) {
-                for (const value of node.values) {
-                    pushComment(value, entityName, value.name.value);
-                }
-            }
-            break;
-        case 'ObjectTypeDefinition':
-        case 'InputObjectTypeDefinition':
-        case 'InterfaceTypeDefinition':
-            if (node.fields) {
-                for (const field of node.fields) {
-                    pushComment(field, entityName, field.name.value);
-                    if (isFieldDefinitionNode(field) && field.arguments) {
-                        for (const arg of field.arguments) {
-                            pushComment(arg, entityName, field.name.value, arg.name.value);
-                        }
-                    }
-                }
-            }
-            break;
-    }
-}
-function pushComment(node, entity, field, argument) {
-    const comment = getComment(node);
-    if (typeof comment !== 'string' || comment.length === 0) {
-        return;
-    }
-    const keys = [entity];
-    if (field) {
-        keys.push(field);
-        if (argument) {
-            keys.push(argument);
-        }
-    }
-    const path = keys.join('.');
-    if (!commentsRegistry[path]) {
-        commentsRegistry[path] = [];
-    }
-    commentsRegistry[path].push(comment);
-}
-function printComment(comment) {
-    return '\n# ' + comment.replace(/\n/g, '\n# ');
-}
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-/**
- * NOTE: ==> This file has been modified just to add comments to the printed AST
- * This is a temp measure, we will move to using the original non modified printer.js ASAP.
- */
-/**
- * Given maybeArray, print an empty string if it is null or empty, otherwise
- * print all items together separated by separator if provided
- */
-function join(maybeArray, separator) {
-    return maybeArray ? maybeArray.filter(x => x).join(separator || '') : '';
-}
-function hasMultilineItems(maybeArray) {
-    var _a;
-    return (_a = maybeArray === null || maybeArray === void 0 ? void 0 : maybeArray.some(str => str.includes('\n'))) !== null && _a !== void 0 ? _a : false;
-}
-function addDescription(cb) {
-    return (node, _key, _parent, path, ancestors) => {
-        var _a;
-        const keys = [];
-        const parent = path.reduce((prev, key) => {
-            if (['fields', 'arguments', 'values'].includes(key) && prev.name) {
-                keys.push(prev.name.value);
-            }
-            return prev[key];
-        }, ancestors[0]);
-        const key = [...keys, (_a = parent === null || parent === void 0 ? void 0 : parent.name) === null || _a === void 0 ? void 0 : _a.value].filter(Boolean).join('.');
-        const items = [];
-        if (node.kind.includes('Definition') && commentsRegistry[key]) {
-            items.push(...commentsRegistry[key]);
-        }
-        return join([...items.map(printComment), node.description, cb(node, _key, _parent, path, ancestors)], '\n');
-    };
-}
-function indent(maybeString) {
-    return maybeString && `  ${maybeString.replace(/\n/g, '\n  ')}`;
-}
-/**
- * Given array, print each item on its own line, wrapped in an
- * indented "{ }" block.
- */
-function block(array) {
-    return array && array.length !== 0 ? `{\n${indent(join(array, '\n'))}\n}` : '';
-}
-/**
- * If maybeString is not null or empty, then wrap with start and end, otherwise
- * print an empty string.
- */
-function wrap(start, maybeString, end) {
-    return maybeString ? start + maybeString + (end || '') : '';
-}
-/**
- * Print a block string in the indented block form by adding a leading and
- * trailing blank line. However, if a block string starts with whitespace and is
- * a single-line, adding a leading blank line would strip that whitespace.
- */
-function printBlockString(value, isDescription = false) {
-    const escaped = value.replace(/"""/g, '\\"""');
-    return (value[0] === ' ' || value[0] === '\t') && value.indexOf('\n') === -1
-        ? `"""${escaped.replace(/"$/, '"\n')}"""`
-        : `"""\n${isDescription ? escaped : indent(escaped)}\n"""`;
-}
-const printDocASTReducer = {
-    Name: { leave: node => node.value },
-    Variable: { leave: node => '$' + node.name },
-    // Document
-    Document: {
-        leave: node => join(node.definitions, '\n\n'),
-    },
-    OperationDefinition: {
-        leave: node => {
-            const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
-            const prefix = join([node.operation, join([node.name, varDefs]), join(node.directives, ' ')], ' ');
-            // the query short form.
-            return prefix + ' ' + node.selectionSet;
-        },
-    },
-    VariableDefinition: {
-        leave: ({ variable, type, defaultValue, directives }) => variable + ': ' + type + wrap(' = ', defaultValue) + wrap(' ', join(directives, ' ')),
-    },
-    SelectionSet: { leave: ({ selections }) => block(selections) },
-    Field: {
-        leave({ alias, name, arguments: args, directives, selectionSet }) {
-            const prefix = wrap('', alias, ': ') + name;
-            let argsLine = prefix + wrap('(', join(args, ', '), ')');
-            if (argsLine.length > MAX_LINE_LENGTH) {
-                argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)');
-            }
-            return join([argsLine, join(directives, ' '), selectionSet], ' ');
-        },
-    },
-    Argument: { leave: ({ name, value }) => name + ': ' + value },
-    // Fragments
-    FragmentSpread: {
-        leave: ({ name, directives }) => '...' + name + wrap(' ', join(directives, ' ')),
-    },
-    InlineFragment: {
-        leave: ({ typeCondition, directives, selectionSet }) => join(['...', wrap('on ', typeCondition), join(directives, ' '), selectionSet], ' '),
-    },
-    FragmentDefinition: {
-        leave: ({ name, typeCondition, variableDefinitions, directives, selectionSet }) => 
-        // Note: fragment variable definitions are experimental and may be changed
-        // or removed in the future.
-        `fragment ${name}${wrap('(', join(variableDefinitions, ', '), ')')} ` +
-            `on ${typeCondition} ${wrap('', join(directives, ' '), ' ')}` +
-            selectionSet,
-    },
-    // Value
-    IntValue: { leave: ({ value }) => value },
-    FloatValue: { leave: ({ value }) => value },
-    StringValue: {
-        leave: ({ value, block: isBlockString }) => {
-            if (isBlockString) {
-                return printBlockString(value);
-            }
-            return JSON.stringify(value);
-        },
-    },
-    BooleanValue: { leave: ({ value }) => (value ? 'true' : 'false') },
-    NullValue: { leave: () => 'null' },
-    EnumValue: { leave: ({ value }) => value },
-    ListValue: { leave: ({ values }) => '[' + join(values, ', ') + ']' },
-    ObjectValue: { leave: ({ fields }) => '{' + join(fields, ', ') + '}' },
-    ObjectField: { leave: ({ name, value }) => name + ': ' + value },
-    // Directive
-    Directive: {
-        leave: ({ name, arguments: args }) => '@' + name + wrap('(', join(args, ', '), ')'),
-    },
-    // Type
-    NamedType: { leave: ({ name }) => name },
-    ListType: { leave: ({ type }) => '[' + type + ']' },
-    NonNullType: { leave: ({ type }) => type + '!' },
-    // Type System Definitions
-    SchemaDefinition: {
-        leave: ({ directives, operationTypes }) => join(['schema', join(directives, ' '), block(operationTypes)], ' '),
-    },
-    OperationTypeDefinition: {
-        leave: ({ operation, type }) => operation + ': ' + type,
-    },
-    ScalarTypeDefinition: {
-        leave: ({ name, directives }) => join(['scalar', name, join(directives, ' ')], ' '),
-    },
-    ObjectTypeDefinition: {
-        leave: ({ name, interfaces, directives, fields }) => join(['type', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
-    },
-    FieldDefinition: {
-        leave: ({ name, arguments: args, type, directives }) => name +
-            (hasMultilineItems(args)
-                ? wrap('(\n', indent(join(args, '\n')), '\n)')
-                : wrap('(', join(args, ', '), ')')) +
-            ': ' +
-            type +
-            wrap(' ', join(directives, ' ')),
-    },
-    InputValueDefinition: {
-        leave: ({ name, type, defaultValue, directives }) => join([name + ': ' + type, wrap('= ', defaultValue), join(directives, ' ')], ' '),
-    },
-    InterfaceTypeDefinition: {
-        leave: ({ name, interfaces, directives, fields }) => join(['interface', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
-    },
-    UnionTypeDefinition: {
-        leave: ({ name, directives, types }) => join(['union', name, join(directives, ' '), wrap('= ', join(types, ' | '))], ' '),
-    },
-    EnumTypeDefinition: {
-        leave: ({ name, directives, values }) => join(['enum', name, join(directives, ' '), block(values)], ' '),
-    },
-    EnumValueDefinition: {
-        leave: ({ name, directives }) => join([name, join(directives, ' ')], ' '),
-    },
-    InputObjectTypeDefinition: {
-        leave: ({ name, directives, fields }) => join(['input', name, join(directives, ' '), block(fields)], ' '),
-    },
-    DirectiveDefinition: {
-        leave: ({ name, arguments: args, repeatable, locations }) => 'directive @' +
-            name +
-            (hasMultilineItems(args)
-                ? wrap('(\n', indent(join(args, '\n')), '\n)')
-                : wrap('(', join(args, ', '), ')')) +
-            (repeatable ? ' repeatable' : '') +
-            ' on ' +
-            join(locations, ' | '),
-    },
-    SchemaExtension: {
-        leave: ({ directives, operationTypes }) => join(['extend schema', join(directives, ' '), block(operationTypes)], ' '),
-    },
-    ScalarTypeExtension: {
-        leave: ({ name, directives }) => join(['extend scalar', name, join(directives, ' ')], ' '),
-    },
-    ObjectTypeExtension: {
-        leave: ({ name, interfaces, directives, fields }) => join(['extend type', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
-    },
-    InterfaceTypeExtension: {
-        leave: ({ name, interfaces, directives, fields }) => join(['extend interface', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
-    },
-    UnionTypeExtension: {
-        leave: ({ name, directives, types }) => join(['extend union', name, join(directives, ' '), wrap('= ', join(types, ' | '))], ' '),
-    },
-    EnumTypeExtension: {
-        leave: ({ name, directives, values }) => join(['extend enum', name, join(directives, ' '), block(values)], ' '),
-    },
-    InputObjectTypeExtension: {
-        leave: ({ name, directives, fields }) => join(['extend input', name, join(directives, ' '), block(fields)], ' '),
-    },
-};
-const printDocASTReducerWithComments = Object.keys(printDocASTReducer).reduce((prev, key) => ({
-    ...prev,
-    [key]: {
-        leave: addDescription(printDocASTReducer[key].leave),
-    },
-}), {});
-/**
- * Converts an AST into a string, using one set of reasonable
- * formatting rules.
- */
-function printWithComments(ast) {
-    return graphql.visit(ast, printDocASTReducerWithComments);
-}
-function isFieldDefinitionNode(node) {
-    return node.kind === 'FieldDefinition';
-}
-// graphql < v13 and > v15 does not export getDescription
-function getDescription(node, options) {
-    if (node.description != null) {
-        return node.description.value;
-    }
-    if (options === null || options === void 0 ? void 0 : options.commentDescriptions) {
-        return getComment(node);
-    }
-}
-function getComment(node) {
-    const rawValue = getLeadingCommentBlock(node);
-    if (rawValue !== undefined) {
-        return dedentBlockStringValue(`\n${rawValue}`);
-    }
-}
-function getLeadingCommentBlock(node) {
-    const loc = node.loc;
-    if (!loc) {
-        return;
-    }
-    const comments = [];
-    let token = loc.startToken.prev;
-    while (token != null &&
-        token.kind === graphql.TokenKind.COMMENT &&
-        token.next != null &&
-        token.prev != null &&
-        token.line + 1 === token.next.line &&
-        token.line !== token.prev.line) {
-        const value = String(token.value);
-        comments.push(value);
-        token = token.prev;
-    }
-    return comments.length > 0 ? comments.reverse().join('\n') : undefined;
-}
-function dedentBlockStringValue(rawString) {
-    // Expand a block string's raw value into independent lines.
-    const lines = rawString.split(/\r\n|[\n\r]/g);
-    // Remove common indentation from all lines but first.
-    const commonIndent = getBlockStringIndentation(lines);
-    if (commonIndent !== 0) {
-        for (let i = 1; i < lines.length; i++) {
-            lines[i] = lines[i].slice(commonIndent);
-        }
-    }
-    // Remove leading and trailing blank lines.
-    while (lines.length > 0 && isBlank(lines[0])) {
-        lines.shift();
-    }
-    while (lines.length > 0 && isBlank(lines[lines.length - 1])) {
-        lines.pop();
-    }
-    // Return a string of the lines joined with U+000A.
-    return lines.join('\n');
-}
-/**
- * @internal
- */
-function getBlockStringIndentation(lines) {
-    let commonIndent = null;
-    for (let i = 1; i < lines.length; i++) {
-        const line = lines[i];
-        const indent = leadingWhitespace(line);
-        if (indent === line.length) {
-            continue; // skip empty lines
-        }
-        if (commonIndent === null || indent < commonIndent) {
-            commonIndent = indent;
-            if (commonIndent === 0) {
-                break;
-            }
-        }
-    }
-    return commonIndent === null ? 0 : commonIndent;
-}
-function leadingWhitespace(str) {
-    let i = 0;
-    while (i < str.length && (str[i] === ' ' || str[i] === '\t')) {
-        i++;
-    }
-    return i;
-}
-function isBlank(str) {
-    return leadingWhitespace(str) === str.length;
-}
-
-function parseGraphQLSDL(location, rawSDL, options = {}) {
-    let document;
-    try {
-        if (options.commentDescriptions && rawSDL.includes('#')) {
-            document = transformCommentsToDescriptions(rawSDL, options);
-            // If noLocation=true, we need to make sure to print and parse it again, to remove locations,
-            // since `transformCommentsToDescriptions` must have locations set in order to transform the comments
-            // into descriptions.
-            if (options.noLocation) {
-                document = graphql.parse(graphql.print(document), options);
-            }
-        }
-        else {
-            document = graphql.parse(new graphql.Source(rawSDL, location), options);
-        }
-    }
-    catch (e) {
-        if (e.message.includes('EOF') && rawSDL.replace(/(\#[^*]*)/g, '').trim() === '') {
-            document = {
-                kind: graphql.Kind.DOCUMENT,
-                definitions: [],
-            };
-        }
-        else {
-            throw e;
-        }
-    }
-    return {
-        location,
-        document,
-    };
-}
-function transformCommentsToDescriptions(sourceSdl, options = {}) {
-    const parsedDoc = graphql.parse(sourceSdl, {
-        ...options,
-        noLocation: false,
-    });
-    const modifiedDoc = graphql.visit(parsedDoc, {
-        leave: (node) => {
-            if (isDescribable(node)) {
-                const rawValue = getLeadingCommentBlock(node);
-                if (rawValue !== undefined) {
-                    const commentsBlock = dedentBlockStringValue('\n' + rawValue);
-                    const isBlock = commentsBlock.includes('\n');
-                    if (!node.description) {
-                        return {
-                            ...node,
-                            description: {
-                                kind: graphql.Kind.STRING,
-                                value: commentsBlock,
-                                block: isBlock,
-                            },
-                        };
-                    }
-                    else {
-                        return {
-                            ...node,
-                            description: {
-                                ...node.description,
-                                value: node.description.value + '\n' + commentsBlock,
-                                block: true,
-                            },
-                        };
-                    }
-                }
-            }
-        },
-    });
-    return modifiedDoc;
-}
-function isDescribable(node) {
-    return (graphql.isTypeSystemDefinitionNode(node) ||
-        node.kind === graphql.Kind.FIELD_DEFINITION ||
-        node.kind === graphql.Kind.INPUT_VALUE_DEFINITION ||
-        node.kind === graphql.Kind.ENUM_VALUE_DEFINITION);
-}
-
-let operationVariables = [];
-let fieldTypeMap = new Map();
-function addOperationVariable(variable) {
-    operationVariables.push(variable);
-}
-function resetOperationVariables() {
-    operationVariables = [];
-}
-function resetFieldMap() {
-    fieldTypeMap = new Map();
-}
-function buildOperationNodeForField({ schema, kind, field, models, ignore = [], depthLimit, circularReferenceDepth, argNames, selectedFields = true, }) {
-    resetOperationVariables();
-    resetFieldMap();
-    const rootTypeNames = getRootTypeNames(schema);
-    const operationNode = buildOperationAndCollectVariables({
-        schema,
-        fieldName: field,
-        kind,
-        models: models || [],
-        ignore,
-        depthLimit: depthLimit || Infinity,
-        circularReferenceDepth: circularReferenceDepth || 1,
-        argNames,
-        selectedFields,
-        rootTypeNames,
-    });
-    // attach variables
-    operationNode.variableDefinitions = [...operationVariables];
-    resetOperationVariables();
-    resetFieldMap();
-    return operationNode;
-}
-function buildOperationAndCollectVariables({ schema, fieldName, kind, models, ignore, depthLimit, circularReferenceDepth, argNames, selectedFields, rootTypeNames, }) {
-    const type = getDefinedRootType(schema, kind);
-    const field = type.getFields()[fieldName];
-    const operationName = `${fieldName}_${kind}`;
-    if (field.args) {
-        for (const arg of field.args) {
-            const argName = arg.name;
-            if (!argNames || argNames.includes(argName)) {
-                addOperationVariable(resolveVariable(arg, argName));
-            }
-        }
-    }
-    return {
-        kind: graphql.Kind.OPERATION_DEFINITION,
-        operation: kind,
-        name: {
-            kind: graphql.Kind.NAME,
-            value: operationName,
-        },
-        variableDefinitions: [],
-        selectionSet: {
-            kind: graphql.Kind.SELECTION_SET,
-            selections: [
-                resolveField({
-                    type,
-                    field,
-                    models,
-                    firstCall: true,
-                    path: [],
-                    ancestors: [],
-                    ignore,
-                    depthLimit,
-                    circularReferenceDepth,
-                    schema,
-                    depth: 0,
-                    argNames,
-                    selectedFields,
-                    rootTypeNames,
-                }),
-            ],
-        },
-    };
-}
-function resolveSelectionSet({ parent, type, models, firstCall, path, ancestors, ignore, depthLimit, circularReferenceDepth, schema, depth, argNames, selectedFields, rootTypeNames, }) {
-    if (typeof selectedFields === 'boolean' && depth > depthLimit) {
-        return;
-    }
-    if (graphql.isUnionType(type)) {
-        const types = type.getTypes();
-        return {
-            kind: graphql.Kind.SELECTION_SET,
-            selections: types
-                .filter(t => !hasCircularRef([...ancestors, t], {
-                depth: circularReferenceDepth,
-            }))
-                .map(t => {
-                return {
-                    kind: graphql.Kind.INLINE_FRAGMENT,
-                    typeCondition: {
-                        kind: graphql.Kind.NAMED_TYPE,
-                        name: {
-                            kind: graphql.Kind.NAME,
-                            value: t.name,
-                        },
-                    },
-                    selectionSet: resolveSelectionSet({
-                        parent: type,
-                        type: t,
-                        models,
-                        path,
-                        ancestors,
-                        ignore,
-                        depthLimit,
-                        circularReferenceDepth,
-                        schema,
-                        depth,
-                        argNames,
-                        selectedFields,
-                        rootTypeNames,
-                    }),
-                };
-            })
-                .filter(fragmentNode => { var _a, _b; return ((_b = (_a = fragmentNode === null || fragmentNode === void 0 ? void 0 : fragmentNode.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length) > 0; }),
-        };
-    }
-    if (graphql.isInterfaceType(type)) {
-        const types = Object.values(schema.getTypeMap()).filter((t) => graphql.isObjectType(t) && t.getInterfaces().includes(type));
-        return {
-            kind: graphql.Kind.SELECTION_SET,
-            selections: types
-                .filter(t => !hasCircularRef([...ancestors, t], {
-                depth: circularReferenceDepth,
-            }))
-                .map(t => {
-                return {
-                    kind: graphql.Kind.INLINE_FRAGMENT,
-                    typeCondition: {
-                        kind: graphql.Kind.NAMED_TYPE,
-                        name: {
-                            kind: graphql.Kind.NAME,
-                            value: t.name,
-                        },
-                    },
-                    selectionSet: resolveSelectionSet({
-                        parent: type,
-                        type: t,
-                        models,
-                        path,
-                        ancestors,
-                        ignore,
-                        depthLimit,
-                        circularReferenceDepth,
-                        schema,
-                        depth,
-                        argNames,
-                        selectedFields,
-                        rootTypeNames,
-                    }),
-                };
-            })
-                .filter(fragmentNode => { var _a, _b; return ((_b = (_a = fragmentNode === null || fragmentNode === void 0 ? void 0 : fragmentNode.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length) > 0; }),
-        };
-    }
-    if (graphql.isObjectType(type) && !rootTypeNames.has(type.name)) {
-        const isIgnored = ignore.includes(type.name) || ignore.includes(`${parent.name}.${path[path.length - 1]}`);
-        const isModel = models.includes(type.name);
-        if (!firstCall && isModel && !isIgnored) {
-            return {
-                kind: graphql.Kind.SELECTION_SET,
-                selections: [
-                    {
-                        kind: graphql.Kind.FIELD,
-                        name: {
-                            kind: graphql.Kind.NAME,
-                            value: 'id',
-                        },
-                    },
-                ],
-            };
-        }
-        const fields = type.getFields();
-        return {
-            kind: graphql.Kind.SELECTION_SET,
-            selections: Object.keys(fields)
-                .filter(fieldName => {
-                return !hasCircularRef([...ancestors, graphql.getNamedType(fields[fieldName].type)], {
-                    depth: circularReferenceDepth,
-                });
-            })
-                .map(fieldName => {
-                const selectedSubFields = typeof selectedFields === 'object' ? selectedFields[fieldName] : true;
-                if (selectedSubFields) {
-                    return resolveField({
-                        type: type,
-                        field: fields[fieldName],
-                        models,
-                        path: [...path, fieldName],
-                        ancestors,
-                        ignore,
-                        depthLimit,
-                        circularReferenceDepth,
-                        schema,
-                        depth,
-                        argNames,
-                        selectedFields: selectedSubFields,
-                        rootTypeNames,
-                    });
-                }
-                return null;
-            })
-                .filter((f) => {
-                var _a, _b;
-                if (f == null) {
-                    return false;
-                }
-                else if ('selectionSet' in f) {
-                    return !!((_b = (_a = f.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length);
-                }
-                return true;
-            }),
-        };
-    }
-}
-function resolveVariable(arg, name) {
-    function resolveVariableType(type) {
-        if (graphql.isListType(type)) {
-            return {
-                kind: graphql.Kind.LIST_TYPE,
-                type: resolveVariableType(type.ofType),
-            };
-        }
-        if (graphql.isNonNullType(type)) {
-            return {
-                kind: graphql.Kind.NON_NULL_TYPE,
-                // for v16 compatibility
-                type: resolveVariableType(type.ofType),
-            };
-        }
-        return {
-            kind: graphql.Kind.NAMED_TYPE,
-            name: {
-                kind: graphql.Kind.NAME,
-                value: type.name,
-            },
-        };
-    }
-    return {
-        kind: graphql.Kind.VARIABLE_DEFINITION,
-        variable: {
-            kind: graphql.Kind.VARIABLE,
-            name: {
-                kind: graphql.Kind.NAME,
-                value: name || arg.name,
-            },
-        },
-        type: resolveVariableType(arg.type),
-    };
-}
-function getArgumentName(name, path) {
-    return [...path, name].join('_');
-}
-function resolveField({ type, field, models, firstCall, path, ancestors, ignore, depthLimit, circularReferenceDepth, schema, depth, argNames, selectedFields, rootTypeNames, }) {
-    const namedType = graphql.getNamedType(field.type);
-    let args = [];
-    let removeField = false;
-    if (field.args && field.args.length) {
-        args = field.args
-            .map(arg => {
-            const argumentName = getArgumentName(arg.name, path);
-            if (argNames && !argNames.includes(argumentName)) {
-                if (graphql.isNonNullType(arg.type)) {
-                    removeField = true;
-                }
-                return null;
-            }
-            if (!firstCall) {
-                addOperationVariable(resolveVariable(arg, argumentName));
-            }
-            return {
-                kind: graphql.Kind.ARGUMENT,
-                name: {
-                    kind: graphql.Kind.NAME,
-                    value: arg.name,
-                },
-                value: {
-                    kind: graphql.Kind.VARIABLE,
-                    name: {
-                        kind: graphql.Kind.NAME,
-                        value: getArgumentName(arg.name, path),
-                    },
-                },
-            };
-        })
-            .filter(Boolean);
-    }
-    if (removeField) {
-        return null;
-    }
-    const fieldPath = [...path, field.name];
-    const fieldPathStr = fieldPath.join('.');
-    let fieldName = field.name;
-    if (fieldTypeMap.has(fieldPathStr) && fieldTypeMap.get(fieldPathStr) !== field.type.toString()) {
-        fieldName += field.type.toString().replace('!', 'NonNull');
-    }
-    fieldTypeMap.set(fieldPathStr, field.type.toString());
-    if (!graphql.isScalarType(namedType) && !graphql.isEnumType(namedType)) {
-        return {
-            kind: graphql.Kind.FIELD,
-            name: {
-                kind: graphql.Kind.NAME,
-                value: field.name,
-            },
-            ...(fieldName !== field.name && { alias: { kind: graphql.Kind.NAME, value: fieldName } }),
-            selectionSet: resolveSelectionSet({
-                parent: type,
-                type: namedType,
-                models,
-                firstCall,
-                path: fieldPath,
-                ancestors: [...ancestors, type],
-                ignore,
-                depthLimit,
-                circularReferenceDepth,
-                schema,
-                depth: depth + 1,
-                argNames,
-                selectedFields,
-                rootTypeNames,
-            }) || undefined,
-            arguments: args,
-        };
-    }
-    return {
-        kind: graphql.Kind.FIELD,
-        name: {
-            kind: graphql.Kind.NAME,
-            value: field.name,
-        },
-        ...(fieldName !== field.name && { alias: { kind: graphql.Kind.NAME, value: fieldName } }),
-        arguments: args,
-    };
-}
-function hasCircularRef(types, config = {
-    depth: 1,
-}) {
-    const type = types[types.length - 1];
-    if (graphql.isScalarType(type)) {
-        return false;
-    }
-    const size = types.filter(t => t.name === type.name).length;
-    return size > config.depth;
-}
-
-(function (MapperKind) {
-    MapperKind["TYPE"] = "MapperKind.TYPE";
-    MapperKind["SCALAR_TYPE"] = "MapperKind.SCALAR_TYPE";
-    MapperKind["ENUM_TYPE"] = "MapperKind.ENUM_TYPE";
-    MapperKind["COMPOSITE_TYPE"] = "MapperKind.COMPOSITE_TYPE";
-    MapperKind["OBJECT_TYPE"] = "MapperKind.OBJECT_TYPE";
-    MapperKind["INPUT_OBJECT_TYPE"] = "MapperKind.INPUT_OBJECT_TYPE";
-    MapperKind["ABSTRACT_TYPE"] = "MapperKind.ABSTRACT_TYPE";
-    MapperKind["UNION_TYPE"] = "MapperKind.UNION_TYPE";
-    MapperKind["INTERFACE_TYPE"] = "MapperKind.INTERFACE_TYPE";
-    MapperKind["ROOT_OBJECT"] = "MapperKind.ROOT_OBJECT";
-    MapperKind["QUERY"] = "MapperKind.QUERY";
-    MapperKind["MUTATION"] = "MapperKind.MUTATION";
-    MapperKind["SUBSCRIPTION"] = "MapperKind.SUBSCRIPTION";
-    MapperKind["DIRECTIVE"] = "MapperKind.DIRECTIVE";
-    MapperKind["FIELD"] = "MapperKind.FIELD";
-    MapperKind["COMPOSITE_FIELD"] = "MapperKind.COMPOSITE_FIELD";
-    MapperKind["OBJECT_FIELD"] = "MapperKind.OBJECT_FIELD";
-    MapperKind["ROOT_FIELD"] = "MapperKind.ROOT_FIELD";
-    MapperKind["QUERY_ROOT_FIELD"] = "MapperKind.QUERY_ROOT_FIELD";
-    MapperKind["MUTATION_ROOT_FIELD"] = "MapperKind.MUTATION_ROOT_FIELD";
-    MapperKind["SUBSCRIPTION_ROOT_FIELD"] = "MapperKind.SUBSCRIPTION_ROOT_FIELD";
-    MapperKind["INTERFACE_FIELD"] = "MapperKind.INTERFACE_FIELD";
-    MapperKind["INPUT_OBJECT_FIELD"] = "MapperKind.INPUT_OBJECT_FIELD";
-    MapperKind["ARGUMENT"] = "MapperKind.ARGUMENT";
-    MapperKind["ENUM_VALUE"] = "MapperKind.ENUM_VALUE";
-})(exports.MapperKind || (exports.MapperKind = {}));
-
-function getObjectTypeFromTypeMap(typeMap, type) {
-    if (type) {
-        const maybeObjectType = typeMap[type.name];
-        if (graphql.isObjectType(maybeObjectType)) {
-            return maybeObjectType;
-        }
-    }
-}
-
-function createNamedStub(name, type) {
-    let constructor;
-    if (type === 'object') {
-        constructor = graphql.GraphQLObjectType;
-    }
-    else if (type === 'interface') {
-        constructor = graphql.GraphQLInterfaceType;
-    }
-    else {
-        constructor = graphql.GraphQLInputObjectType;
-    }
-    return new constructor({
-        name,
-        fields: {
-            _fake: {
-                type: graphql.GraphQLString,
-            },
-        },
-    });
-}
-function createStub(node, type) {
-    switch (node.kind) {
-        case graphql.Kind.LIST_TYPE:
-            return new graphql.GraphQLList(createStub(node.type, type));
-        case graphql.Kind.NON_NULL_TYPE:
-            return new graphql.GraphQLNonNull(createStub(node.type, type));
-        default:
-            if (type === 'output') {
-                return createNamedStub(node.name.value, 'object');
-            }
-            return createNamedStub(node.name.value, 'input');
-    }
-}
-function isNamedStub(type) {
-    if ('getFields' in type) {
-        const fields = type.getFields();
-        // eslint-disable-next-line no-unreachable-loop
-        for (const fieldName in fields) {
-            const field = fields[fieldName];
-            return field.name === '_fake';
-        }
-    }
-    return false;
-}
-function getBuiltInForStub(type) {
-    switch (type.name) {
-        case graphql.GraphQLInt.name:
-            return graphql.GraphQLInt;
-        case graphql.GraphQLFloat.name:
-            return graphql.GraphQLFloat;
-        case graphql.GraphQLString.name:
-            return graphql.GraphQLString;
-        case graphql.GraphQLBoolean.name:
-            return graphql.GraphQLBoolean;
-        case graphql.GraphQLID.name:
-            return graphql.GraphQLID;
-        default:
-            return type;
-    }
-}
-
-function rewireTypes(originalTypeMap, directives) {
-    const referenceTypeMap = Object.create(null);
-    for (const typeName in originalTypeMap) {
-        referenceTypeMap[typeName] = originalTypeMap[typeName];
-    }
-    const newTypeMap = Object.create(null);
-    for (const typeName in referenceTypeMap) {
-        const namedType = referenceTypeMap[typeName];
-        if (namedType == null || typeName.startsWith('__')) {
-            continue;
-        }
-        const newName = namedType.name;
-        if (newName.startsWith('__')) {
-            continue;
-        }
-        if (newTypeMap[newName] != null) {
-            throw new Error(`Duplicate schema type name ${newName}`);
-        }
-        newTypeMap[newName] = namedType;
-    }
-    for (const typeName in newTypeMap) {
-        newTypeMap[typeName] = rewireNamedType(newTypeMap[typeName]);
-    }
-    const newDirectives = directives.map(directive => rewireDirective(directive));
-    return {
-        typeMap: newTypeMap,
-        directives: newDirectives,
-    };
-    function rewireDirective(directive) {
-        if (graphql.isSpecifiedDirective(directive)) {
-            return directive;
-        }
-        const directiveConfig = directive.toConfig();
-        directiveConfig.args = rewireArgs(directiveConfig.args);
-        return new graphql.GraphQLDirective(directiveConfig);
-    }
-    function rewireArgs(args) {
-        const rewiredArgs = {};
-        for (const argName in args) {
-            const arg = args[argName];
-            const rewiredArgType = rewireType(arg.type);
-            if (rewiredArgType != null) {
-                arg.type = rewiredArgType;
-                rewiredArgs[argName] = arg;
-            }
-        }
-        return rewiredArgs;
-    }
-    function rewireNamedType(type) {
-        if (graphql.isObjectType(type)) {
-            const config = type.toConfig();
-            const newConfig = {
-                ...config,
-                fields: () => rewireFields(config.fields),
-                interfaces: () => rewireNamedTypes(config.interfaces),
-            };
-            return new graphql.GraphQLObjectType(newConfig);
-        }
-        else if (graphql.isInterfaceType(type)) {
-            const config = type.toConfig();
-            const newConfig = {
-                ...config,
-                fields: () => rewireFields(config.fields),
-            };
-            if ('interfaces' in newConfig) {
-                newConfig.interfaces = () => rewireNamedTypes(config.interfaces);
-            }
-            return new graphql.GraphQLInterfaceType(newConfig);
-        }
-        else if (graphql.isUnionType(type)) {
-            const config = type.toConfig();
-            const newConfig = {
-                ...config,
-                types: () => rewireNamedTypes(config.types),
-            };
-            return new graphql.GraphQLUnionType(newConfig);
-        }
-        else if (graphql.isInputObjectType(type)) {
-            const config = type.toConfig();
-            const newConfig = {
-                ...config,
-                fields: () => rewireInputFields(config.fields),
-            };
-            return new graphql.GraphQLInputObjectType(newConfig);
-        }
-        else if (graphql.isEnumType(type)) {
-            const enumConfig = type.toConfig();
-            return new graphql.GraphQLEnumType(enumConfig);
-        }
-        else if (graphql.isScalarType(type)) {
-            if (graphql.isSpecifiedScalarType(type)) {
-                return type;
-            }
-            const scalarConfig = type.toConfig();
-            return new graphql.GraphQLScalarType(scalarConfig);
-        }
-        throw new Error(`Unexpected schema type: ${type}`);
-    }
-    function rewireFields(fields) {
-        const rewiredFields = {};
-        for (const fieldName in fields) {
-            const field = fields[fieldName];
-            const rewiredFieldType = rewireType(field.type);
-            if (rewiredFieldType != null && field.args) {
-                field.type = rewiredFieldType;
-                field.args = rewireArgs(field.args);
-                rewiredFields[fieldName] = field;
-            }
-        }
-        return rewiredFields;
-    }
-    function rewireInputFields(fields) {
-        const rewiredFields = {};
-        for (const fieldName in fields) {
-            const field = fields[fieldName];
-            const rewiredFieldType = rewireType(field.type);
-            if (rewiredFieldType != null) {
-                field.type = rewiredFieldType;
-                rewiredFields[fieldName] = field;
-            }
-        }
-        return rewiredFields;
-    }
-    function rewireNamedTypes(namedTypes) {
-        const rewiredTypes = [];
-        for (const namedType of namedTypes) {
-            const rewiredType = rewireType(namedType);
-            if (rewiredType != null) {
-                rewiredTypes.push(rewiredType);
-            }
-        }
-        return rewiredTypes;
-    }
-    function rewireType(type) {
-        if (graphql.isListType(type)) {
-            const rewiredType = rewireType(type.ofType);
-            return rewiredType != null ? new graphql.GraphQLList(rewiredType) : null;
-        }
-        else if (graphql.isNonNullType(type)) {
-            const rewiredType = rewireType(type.ofType);
-            return rewiredType != null ? new graphql.GraphQLNonNull(rewiredType) : null;
-        }
-        else if (graphql.isNamedType(type)) {
-            let rewiredType = referenceTypeMap[type.name];
-            if (rewiredType === undefined) {
-                rewiredType = isNamedStub(type) ? getBuiltInForStub(type) : rewireNamedType(type);
-                newTypeMap[rewiredType.name] = referenceTypeMap[type.name] = rewiredType;
-            }
-            return rewiredType != null ? newTypeMap[rewiredType.name] : null;
-        }
-        return null;
-    }
-}
-
-function transformInputValue(type, value, inputLeafValueTransformer = null, inputObjectValueTransformer = null) {
-    if (value == null) {
-        return value;
-    }
-    const nullableType = graphql.getNullableType(type);
-    if (graphql.isLeafType(nullableType)) {
-        return inputLeafValueTransformer != null ? inputLeafValueTransformer(nullableType, value) : value;
-    }
-    else if (graphql.isListType(nullableType)) {
-        return value.map((listMember) => transformInputValue(nullableType.ofType, listMember, inputLeafValueTransformer, inputObjectValueTransformer));
-    }
-    else if (graphql.isInputObjectType(nullableType)) {
-        const fields = nullableType.getFields();
-        const newValue = {};
-        for (const key in value) {
-            const field = fields[key];
-            if (field != null) {
-                newValue[key] = transformInputValue(field.type, value[key], inputLeafValueTransformer, inputObjectValueTransformer);
-            }
-        }
-        return inputObjectValueTransformer != null ? inputObjectValueTransformer(nullableType, newValue) : newValue;
-    }
-    // unreachable, no other possible return value
-}
-function serializeInputValue(type, value) {
-    return transformInputValue(type, value, (t, v) => {
-        try {
-            return t.serialize(v);
-        }
-        catch (_a) {
-            return v;
-        }
-    });
-}
-function parseInputValue(type, value) {
-    return transformInputValue(type, value, (t, v) => {
-        try {
-            return t.parseValue(v);
-        }
-        catch (_a) {
-            return v;
-        }
-    });
-}
-function parseInputValueLiteral(type, value) {
-    return transformInputValue(type, value, (t, v) => t.parseLiteral(v, {}));
-}
-
-function mapSchema(schema, schemaMapper = {}) {
-    const newTypeMap = mapArguments(mapFields(mapTypes(mapDefaultValues(mapEnumValues(mapTypes(mapDefaultValues(schema.getTypeMap(), schema, serializeInputValue), schema, schemaMapper, type => graphql.isLeafType(type)), schema, schemaMapper), schema, parseInputValue), schema, schemaMapper, type => !graphql.isLeafType(type)), schema, schemaMapper), schema, schemaMapper);
-    const originalDirectives = schema.getDirectives();
-    const newDirectives = mapDirectives(originalDirectives, schema, schemaMapper);
-    const { typeMap, directives } = rewireTypes(newTypeMap, newDirectives);
-    return new graphql.GraphQLSchema({
-        ...schema.toConfig(),
-        query: getObjectTypeFromTypeMap(typeMap, getObjectTypeFromTypeMap(newTypeMap, schema.getQueryType())),
-        mutation: getObjectTypeFromTypeMap(typeMap, getObjectTypeFromTypeMap(newTypeMap, schema.getMutationType())),
-        subscription: getObjectTypeFromTypeMap(typeMap, getObjectTypeFromTypeMap(newTypeMap, schema.getSubscriptionType())),
-        types: Object.values(typeMap),
-        directives,
-    });
-}
-function mapTypes(originalTypeMap, schema, schemaMapper, testFn = () => true) {
-    const newTypeMap = {};
-    for (const typeName in originalTypeMap) {
-        if (!typeName.startsWith('__')) {
-            const originalType = originalTypeMap[typeName];
-            if (originalType == null || !testFn(originalType)) {
-                newTypeMap[typeName] = originalType;
-                continue;
-            }
-            const typeMapper = getTypeMapper(schema, schemaMapper, typeName);
-            if (typeMapper == null) {
-                newTypeMap[typeName] = originalType;
-                continue;
-            }
-            const maybeNewType = typeMapper(originalType, schema);
-            if (maybeNewType === undefined) {
-                newTypeMap[typeName] = originalType;
-                continue;
-            }
-            newTypeMap[typeName] = maybeNewType;
-        }
-    }
-    return newTypeMap;
-}
-function mapEnumValues(originalTypeMap, schema, schemaMapper) {
-    const enumValueMapper = getEnumValueMapper(schemaMapper);
-    if (!enumValueMapper) {
-        return originalTypeMap;
-    }
-    return mapTypes(originalTypeMap, schema, {
-        [exports.MapperKind.ENUM_TYPE]: type => {
-            const config = type.toConfig();
-            const originalEnumValueConfigMap = config.values;
-            const newEnumValueConfigMap = {};
-            for (const externalValue in originalEnumValueConfigMap) {
-                const originalEnumValueConfig = originalEnumValueConfigMap[externalValue];
-                const mappedEnumValue = enumValueMapper(originalEnumValueConfig, type.name, schema, externalValue);
-                if (mappedEnumValue === undefined) {
-                    newEnumValueConfigMap[externalValue] = originalEnumValueConfig;
-                }
-                else if (Array.isArray(mappedEnumValue)) {
-                    const [newExternalValue, newEnumValueConfig] = mappedEnumValue;
-                    newEnumValueConfigMap[newExternalValue] =
-                        newEnumValueConfig === undefined ? originalEnumValueConfig : newEnumValueConfig;
-                }
-                else if (mappedEnumValue !== null) {
-                    newEnumValueConfigMap[externalValue] = mappedEnumValue;
-                }
-            }
-            return correctASTNodes(new graphql.GraphQLEnumType({
-                ...config,
-                values: newEnumValueConfigMap,
-            }));
-        },
-    }, type => graphql.isEnumType(type));
-}
-function mapDefaultValues(originalTypeMap, schema, fn) {
-    const newTypeMap = mapArguments(originalTypeMap, schema, {
-        [exports.MapperKind.ARGUMENT]: argumentConfig => {
-            if (argumentConfig.defaultValue === undefined) {
-                return argumentConfig;
-            }
-            const maybeNewType = getNewType(originalTypeMap, argumentConfig.type);
-            if (maybeNewType != null) {
-                return {
-                    ...argumentConfig,
-                    defaultValue: fn(maybeNewType, argumentConfig.defaultValue),
-                };
-            }
-        },
-    });
-    return mapFields(newTypeMap, schema, {
-        [exports.MapperKind.INPUT_OBJECT_FIELD]: inputFieldConfig => {
-            if (inputFieldConfig.defaultValue === undefined) {
-                return inputFieldConfig;
-            }
-            const maybeNewType = getNewType(newTypeMap, inputFieldConfig.type);
-            if (maybeNewType != null) {
-                return {
-                    ...inputFieldConfig,
-                    defaultValue: fn(maybeNewType, inputFieldConfig.defaultValue),
-                };
-            }
-        },
-    });
-}
-function getNewType(newTypeMap, type) {
-    if (graphql.isListType(type)) {
-        const newType = getNewType(newTypeMap, type.ofType);
-        return newType != null ? new graphql.GraphQLList(newType) : null;
-    }
-    else if (graphql.isNonNullType(type)) {
-        const newType = getNewType(newTypeMap, type.ofType);
-        return newType != null ? new graphql.GraphQLNonNull(newType) : null;
-    }
-    else if (graphql.isNamedType(type)) {
-        const newType = newTypeMap[type.name];
-        return newType != null ? newType : null;
-    }
-    return null;
-}
-function mapFields(originalTypeMap, schema, schemaMapper) {
-    const newTypeMap = {};
-    for (const typeName in originalTypeMap) {
-        if (!typeName.startsWith('__')) {
-            const originalType = originalTypeMap[typeName];
-            if (!graphql.isObjectType(originalType) && !graphql.isInterfaceType(originalType) && !graphql.isInputObjectType(originalType)) {
-                newTypeMap[typeName] = originalType;
-                continue;
-            }
-            const fieldMapper = getFieldMapper(schema, schemaMapper, typeName);
-            if (fieldMapper == null) {
-                newTypeMap[typeName] = originalType;
-                continue;
-            }
-            const config = originalType.toConfig();
-            const originalFieldConfigMap = config.fields;
-            const newFieldConfigMap = {};
-            for (const fieldName in originalFieldConfigMap) {
-                const originalFieldConfig = originalFieldConfigMap[fieldName];
-                const mappedField = fieldMapper(originalFieldConfig, fieldName, typeName, schema);
-                if (mappedField === undefined) {
-                    newFieldConfigMap[fieldName] = originalFieldConfig;
-                }
-                else if (Array.isArray(mappedField)) {
-                    const [newFieldName, newFieldConfig] = mappedField;
-                    if (newFieldConfig.astNode != null) {
-                        newFieldConfig.astNode = {
-                            ...newFieldConfig.astNode,
-                            name: {
-                                ...newFieldConfig.astNode.name,
-                                value: newFieldName,
-                            },
-                        };
-                    }
-                    newFieldConfigMap[newFieldName] = newFieldConfig === undefined ? originalFieldConfig : newFieldConfig;
-                }
-                else if (mappedField !== null) {
-                    newFieldConfigMap[fieldName] = mappedField;
-                }
-            }
-            if (graphql.isObjectType(originalType)) {
-                newTypeMap[typeName] = correctASTNodes(new graphql.GraphQLObjectType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                }));
-            }
-            else if (graphql.isInterfaceType(originalType)) {
-                newTypeMap[typeName] = correctASTNodes(new graphql.GraphQLInterfaceType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                }));
-            }
-            else {
-                newTypeMap[typeName] = correctASTNodes(new graphql.GraphQLInputObjectType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                }));
-            }
-        }
-    }
-    return newTypeMap;
-}
-function mapArguments(originalTypeMap, schema, schemaMapper) {
-    const newTypeMap = {};
-    for (const typeName in originalTypeMap) {
-        if (!typeName.startsWith('__')) {
-            const originalType = originalTypeMap[typeName];
-            if (!graphql.isObjectType(originalType) && !graphql.isInterfaceType(originalType)) {
-                newTypeMap[typeName] = originalType;
-                continue;
-            }
-            const argumentMapper = getArgumentMapper(schemaMapper);
-            if (argumentMapper == null) {
-                newTypeMap[typeName] = originalType;
-                continue;
-            }
-            const config = originalType.toConfig();
-            const originalFieldConfigMap = config.fields;
-            const newFieldConfigMap = {};
-            for (const fieldName in originalFieldConfigMap) {
-                const originalFieldConfig = originalFieldConfigMap[fieldName];
-                const originalArgumentConfigMap = originalFieldConfig.args;
-                if (originalArgumentConfigMap == null) {
-                    newFieldConfigMap[fieldName] = originalFieldConfig;
-                    continue;
-                }
-                const argumentNames = Object.keys(originalArgumentConfigMap);
-                if (!argumentNames.length) {
-                    newFieldConfigMap[fieldName] = originalFieldConfig;
-                    continue;
-                }
-                const newArgumentConfigMap = {};
-                for (const argumentName of argumentNames) {
-                    const originalArgumentConfig = originalArgumentConfigMap[argumentName];
-                    const mappedArgument = argumentMapper(originalArgumentConfig, fieldName, typeName, schema);
-                    if (mappedArgument === undefined) {
-                        newArgumentConfigMap[argumentName] = originalArgumentConfig;
-                    }
-                    else if (Array.isArray(mappedArgument)) {
-                        const [newArgumentName, newArgumentConfig] = mappedArgument;
-                        newArgumentConfigMap[newArgumentName] = newArgumentConfig;
-                    }
-                    else if (mappedArgument !== null) {
-                        newArgumentConfigMap[argumentName] = mappedArgument;
-                    }
-                }
-                newFieldConfigMap[fieldName] = {
-                    ...originalFieldConfig,
-                    args: newArgumentConfigMap,
-                };
-            }
-            if (graphql.isObjectType(originalType)) {
-                newTypeMap[typeName] = new graphql.GraphQLObjectType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                });
-            }
-            else if (graphql.isInterfaceType(originalType)) {
-                newTypeMap[typeName] = new graphql.GraphQLInterfaceType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                });
-            }
-            else {
-                newTypeMap[typeName] = new graphql.GraphQLInputObjectType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                });
-            }
-        }
-    }
-    return newTypeMap;
-}
-function mapDirectives(originalDirectives, schema, schemaMapper) {
-    const directiveMapper = getDirectiveMapper(schemaMapper);
-    if (directiveMapper == null) {
-        return originalDirectives.slice();
-    }
-    const newDirectives = [];
-    for (const directive of originalDirectives) {
-        const mappedDirective = directiveMapper(directive, schema);
-        if (mappedDirective === undefined) {
-            newDirectives.push(directive);
-        }
-        else if (mappedDirective !== null) {
-            newDirectives.push(mappedDirective);
-        }
-    }
-    return newDirectives;
-}
-function getTypeSpecifiers(schema, typeName) {
-    var _a, _b, _c;
-    const type = schema.getType(typeName);
-    const specifiers = [exports.MapperKind.TYPE];
-    if (graphql.isObjectType(type)) {
-        specifiers.push(exports.MapperKind.COMPOSITE_TYPE, exports.MapperKind.OBJECT_TYPE);
-        if (typeName === ((_a = schema.getQueryType()) === null || _a === void 0 ? void 0 : _a.name)) {
-            specifiers.push(exports.MapperKind.ROOT_OBJECT, exports.MapperKind.QUERY);
-        }
-        else if (typeName === ((_b = schema.getMutationType()) === null || _b === void 0 ? void 0 : _b.name)) {
-            specifiers.push(exports.MapperKind.ROOT_OBJECT, exports.MapperKind.MUTATION);
-        }
-        else if (typeName === ((_c = schema.getSubscriptionType()) === null || _c === void 0 ? void 0 : _c.name)) {
-            specifiers.push(exports.MapperKind.ROOT_OBJECT, exports.MapperKind.SUBSCRIPTION);
-        }
-    }
-    else if (graphql.isInputObjectType(type)) {
-        specifiers.push(exports.MapperKind.INPUT_OBJECT_TYPE);
-    }
-    else if (graphql.isInterfaceType(type)) {
-        specifiers.push(exports.MapperKind.COMPOSITE_TYPE, exports.MapperKind.ABSTRACT_TYPE, exports.MapperKind.INTERFACE_TYPE);
-    }
-    else if (graphql.isUnionType(type)) {
-        specifiers.push(exports.MapperKind.COMPOSITE_TYPE, exports.MapperKind.ABSTRACT_TYPE, exports.MapperKind.UNION_TYPE);
-    }
-    else if (graphql.isEnumType(type)) {
-        specifiers.push(exports.MapperKind.ENUM_TYPE);
-    }
-    else if (graphql.isScalarType(type)) {
-        specifiers.push(exports.MapperKind.SCALAR_TYPE);
-    }
-    return specifiers;
-}
-function getTypeMapper(schema, schemaMapper, typeName) {
-    const specifiers = getTypeSpecifiers(schema, typeName);
-    let typeMapper;
-    const stack = [...specifiers];
-    while (!typeMapper && stack.length > 0) {
-        // It is safe to use the ! operator here as we check the length.
-        const next = stack.pop();
-        typeMapper = schemaMapper[next];
-    }
-    return typeMapper != null ? typeMapper : null;
-}
-function getFieldSpecifiers(schema, typeName) {
-    var _a, _b, _c;
-    const type = schema.getType(typeName);
-    const specifiers = [exports.MapperKind.FIELD];
-    if (graphql.isObjectType(type)) {
-        specifiers.push(exports.MapperKind.COMPOSITE_FIELD, exports.MapperKind.OBJECT_FIELD);
-        if (typeName === ((_a = schema.getQueryType()) === null || _a === void 0 ? void 0 : _a.name)) {
-            specifiers.push(exports.MapperKind.ROOT_FIELD, exports.MapperKind.QUERY_ROOT_FIELD);
-        }
-        else if (typeName === ((_b = schema.getMutationType()) === null || _b === void 0 ? void 0 : _b.name)) {
-            specifiers.push(exports.MapperKind.ROOT_FIELD, exports.MapperKind.MUTATION_ROOT_FIELD);
-        }
-        else if (typeName === ((_c = schema.getSubscriptionType()) === null || _c === void 0 ? void 0 : _c.name)) {
-            specifiers.push(exports.MapperKind.ROOT_FIELD, exports.MapperKind.SUBSCRIPTION_ROOT_FIELD);
-        }
-    }
-    else if (graphql.isInterfaceType(type)) {
-        specifiers.push(exports.MapperKind.COMPOSITE_FIELD, exports.MapperKind.INTERFACE_FIELD);
-    }
-    else if (graphql.isInputObjectType(type)) {
-        specifiers.push(exports.MapperKind.INPUT_OBJECT_FIELD);
-    }
-    return specifiers;
-}
-function getFieldMapper(schema, schemaMapper, typeName) {
-    const specifiers = getFieldSpecifiers(schema, typeName);
-    let fieldMapper;
-    const stack = [...specifiers];
-    while (!fieldMapper && stack.length > 0) {
-        // It is safe to use the ! operator here as we check the length.
-        const next = stack.pop();
-        // TODO: fix this as unknown cast
-        fieldMapper = schemaMapper[next];
-    }
-    return fieldMapper !== null && fieldMapper !== void 0 ? fieldMapper : null;
-}
-function getArgumentMapper(schemaMapper) {
-    const argumentMapper = schemaMapper[exports.MapperKind.ARGUMENT];
-    return argumentMapper != null ? argumentMapper : null;
-}
-function getDirectiveMapper(schemaMapper) {
-    const directiveMapper = schemaMapper[exports.MapperKind.DIRECTIVE];
-    return directiveMapper != null ? directiveMapper : null;
-}
-function getEnumValueMapper(schemaMapper) {
-    const enumValueMapper = schemaMapper[exports.MapperKind.ENUM_VALUE];
-    return enumValueMapper != null ? enumValueMapper : null;
-}
-function correctASTNodes(type) {
-    if (graphql.isObjectType(type)) {
-        const config = type.toConfig();
-        if (config.astNode != null) {
-            const fields = [];
-            for (const fieldName in config.fields) {
-                const fieldConfig = config.fields[fieldName];
-                if (fieldConfig.astNode != null) {
-                    fields.push(fieldConfig.astNode);
-                }
-            }
-            config.astNode = {
-                ...config.astNode,
-                kind: graphql.Kind.OBJECT_TYPE_DEFINITION,
-                fields,
-            };
-        }
-        if (config.extensionASTNodes != null) {
-            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
-                ...node,
-                kind: graphql.Kind.OBJECT_TYPE_EXTENSION,
-                fields: undefined,
-            }));
-        }
-        return new graphql.GraphQLObjectType(config);
-    }
-    else if (graphql.isInterfaceType(type)) {
-        const config = type.toConfig();
-        if (config.astNode != null) {
-            const fields = [];
-            for (const fieldName in config.fields) {
-                const fieldConfig = config.fields[fieldName];
-                if (fieldConfig.astNode != null) {
-                    fields.push(fieldConfig.astNode);
-                }
-            }
-            config.astNode = {
-                ...config.astNode,
-                kind: graphql.Kind.INTERFACE_TYPE_DEFINITION,
-                fields,
-            };
-        }
-        if (config.extensionASTNodes != null) {
-            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
-                ...node,
-                kind: graphql.Kind.INTERFACE_TYPE_EXTENSION,
-                fields: undefined,
-            }));
-        }
-        return new graphql.GraphQLInterfaceType(config);
-    }
-    else if (graphql.isInputObjectType(type)) {
-        const config = type.toConfig();
-        if (config.astNode != null) {
-            const fields = [];
-            for (const fieldName in config.fields) {
-                const fieldConfig = config.fields[fieldName];
-                if (fieldConfig.astNode != null) {
-                    fields.push(fieldConfig.astNode);
-                }
-            }
-            config.astNode = {
-                ...config.astNode,
-                kind: graphql.Kind.INPUT_OBJECT_TYPE_DEFINITION,
-                fields,
-            };
-        }
-        if (config.extensionASTNodes != null) {
-            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
-                ...node,
-                kind: graphql.Kind.INPUT_OBJECT_TYPE_EXTENSION,
-                fields: undefined,
-            }));
-        }
-        return new graphql.GraphQLInputObjectType(config);
-    }
-    else if (graphql.isEnumType(type)) {
-        const config = type.toConfig();
-        if (config.astNode != null) {
-            const values = [];
-            for (const enumKey in config.values) {
-                const enumValueConfig = config.values[enumKey];
-                if (enumValueConfig.astNode != null) {
-                    values.push(enumValueConfig.astNode);
-                }
-            }
-            config.astNode = {
-                ...config.astNode,
-                values,
-            };
-        }
-        if (config.extensionASTNodes != null) {
-            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
-                ...node,
-                values: undefined,
-            }));
-        }
-        return new graphql.GraphQLEnumType(config);
-    }
-    else {
-        return type;
-    }
-}
-
-function filterSchema({ schema, typeFilter = () => true, fieldFilter = undefined, rootFieldFilter = undefined, objectFieldFilter = undefined, interfaceFieldFilter = undefined, inputObjectFieldFilter = undefined, argumentFilter = undefined, }) {
-    const filteredSchema = mapSchema(schema, {
-        [exports.MapperKind.QUERY]: (type) => filterRootFields(type, 'Query', rootFieldFilter, argumentFilter),
-        [exports.MapperKind.MUTATION]: (type) => filterRootFields(type, 'Mutation', rootFieldFilter, argumentFilter),
-        [exports.MapperKind.SUBSCRIPTION]: (type) => filterRootFields(type, 'Subscription', rootFieldFilter, argumentFilter),
-        [exports.MapperKind.OBJECT_TYPE]: (type) => typeFilter(type.name, type)
-            ? filterElementFields(graphql.GraphQLObjectType, type, objectFieldFilter || fieldFilter, argumentFilter)
-            : null,
-        [exports.MapperKind.INTERFACE_TYPE]: (type) => typeFilter(type.name, type)
-            ? filterElementFields(graphql.GraphQLInterfaceType, type, interfaceFieldFilter || fieldFilter, argumentFilter)
-            : null,
-        [exports.MapperKind.INPUT_OBJECT_TYPE]: (type) => typeFilter(type.name, type)
-            ? filterElementFields(graphql.GraphQLInputObjectType, type, inputObjectFieldFilter || fieldFilter)
-            : null,
-        [exports.MapperKind.UNION_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
-        [exports.MapperKind.ENUM_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
-        [exports.MapperKind.SCALAR_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
-    });
-    return filteredSchema;
-}
-function filterRootFields(type, operation, rootFieldFilter, argumentFilter) {
-    if (rootFieldFilter || argumentFilter) {
-        const config = type.toConfig();
-        for (const fieldName in config.fields) {
-            const field = config.fields[fieldName];
-            if (rootFieldFilter && !rootFieldFilter(operation, fieldName, config.fields[fieldName])) {
-                delete config.fields[fieldName];
-            }
-            else if (argumentFilter && field.args) {
-                for (const argName in field.args) {
-                    if (!argumentFilter(operation, fieldName, argName, field.args[argName])) {
-                        delete field.args[argName];
-                    }
-                }
-            }
-        }
-        return new graphql.GraphQLObjectType(config);
-    }
-    return type;
-}
-function filterElementFields(ElementConstructor, type, fieldFilter, argumentFilter) {
-    if (fieldFilter || argumentFilter) {
-        const config = type.toConfig();
-        for (const fieldName in config.fields) {
-            const field = config.fields[fieldName];
-            if (fieldFilter && !fieldFilter(type.name, fieldName, config.fields[fieldName])) {
-                delete config.fields[fieldName];
-            }
-            else if (argumentFilter && 'args' in field) {
-                for (const argName in field.args) {
-                    if (!argumentFilter(type.name, fieldName, argName, field.args[argName])) {
-                        delete field.args[argName];
-                    }
-                }
-            }
-        }
-        return new ElementConstructor(config);
-    }
-}
-
-// Update any references to named schema types that disagree with the named
-// types found in schema.getTypeMap().
-//
-// healSchema and its callers (visitSchema/visitSchemaDirectives) all modify the schema in place.
-// Therefore, private variables (such as the stored implementation map and the proper root types)
-// are not updated.
-//
-// If this causes issues, the schema could be more aggressively healed as follows:
-//
-// healSchema(schema);
-// const config = schema.toConfig()
-// const healedSchema = new GraphQLSchema({
-//   ...config,
-//   query: schema.getType('<desired new root query type name>'),
-//   mutation: schema.getType('<desired new root mutation type name>'),
-//   subscription: schema.getType('<desired new root subscription type name>'),
-// });
-//
-// One can then also -- if necessary --  assign the correct private variables to the initial schema
-// as follows:
-// Object.assign(schema, healedSchema);
-//
-// These steps are not taken automatically to preserve backwards compatibility with graphql-tools v4.
-// See https://github.com/ardatan/graphql-tools/issues/1462
-//
-// They were briefly taken in v5, but can now be phased out as they were only required when other
-// areas of the codebase were using healSchema and visitSchema more extensively.
-//
-function healSchema(schema) {
-    healTypes(schema.getTypeMap(), schema.getDirectives());
-    return schema;
-}
-function healTypes(originalTypeMap, directives) {
-    const actualNamedTypeMap = Object.create(null);
-    // If any of the .name properties of the GraphQLNamedType objects in
-    // schema.getTypeMap() have changed, the keys of the type map need to
-    // be updated accordingly.
-    for (const typeName in originalTypeMap) {
-        const namedType = originalTypeMap[typeName];
-        if (namedType == null || typeName.startsWith('__')) {
-            continue;
-        }
-        const actualName = namedType.name;
-        if (actualName.startsWith('__')) {
-            continue;
-        }
-        if (actualName in actualNamedTypeMap) {
-            throw new Error(`Duplicate schema type name ${actualName}`);
-        }
-        actualNamedTypeMap[actualName] = namedType;
-        // Note: we are deliberately leaving namedType in the schema by its
-        // original name (which might be different from actualName), so that
-        // references by that name can be healed.
-    }
-    // Now add back every named type by its actual name.
-    for (const typeName in actualNamedTypeMap) {
-        const namedType = actualNamedTypeMap[typeName];
-        originalTypeMap[typeName] = namedType;
-    }
-    // Directive declaration argument types can refer to named types.
-    for (const decl of directives) {
-        decl.args = decl.args.filter(arg => {
-            arg.type = healType(arg.type);
-            return arg.type !== null;
-        });
-    }
-    for (const typeName in originalTypeMap) {
-        const namedType = originalTypeMap[typeName];
-        // Heal all named types, except for dangling references, kept only to redirect.
-        if (!typeName.startsWith('__') && typeName in actualNamedTypeMap) {
-            if (namedType != null) {
-                healNamedType(namedType);
-            }
-        }
-    }
-    for (const typeName in originalTypeMap) {
-        if (!typeName.startsWith('__') && !(typeName in actualNamedTypeMap)) {
-            delete originalTypeMap[typeName];
-        }
-    }
-    function healNamedType(type) {
-        if (graphql.isObjectType(type)) {
-            healFields(type);
-            healInterfaces(type);
-            return;
-        }
-        else if (graphql.isInterfaceType(type)) {
-            healFields(type);
-            if ('getInterfaces' in type) {
-                healInterfaces(type);
-            }
-            return;
-        }
-        else if (graphql.isUnionType(type)) {
-            healUnderlyingTypes(type);
-            return;
-        }
-        else if (graphql.isInputObjectType(type)) {
-            healInputFields(type);
-            return;
-        }
-        else if (graphql.isLeafType(type)) {
-            return;
-        }
-        throw new Error(`Unexpected schema type: ${type}`);
-    }
-    function healFields(type) {
-        const fieldMap = type.getFields();
-        for (const [key, field] of Object.entries(fieldMap)) {
-            field.args
-                .map(arg => {
-                arg.type = healType(arg.type);
-                return arg.type === null ? null : arg;
-            })
-                .filter(Boolean);
-            field.type = healType(field.type);
-            if (field.type === null) {
-                delete fieldMap[key];
-            }
-        }
-    }
-    function healInterfaces(type) {
-        if ('getInterfaces' in type) {
-            const interfaces = type.getInterfaces();
-            interfaces.push(...interfaces
-                .splice(0)
-                .map(iface => healType(iface))
-                .filter(Boolean));
-        }
-    }
-    function healInputFields(type) {
-        const fieldMap = type.getFields();
-        for (const [key, field] of Object.entries(fieldMap)) {
-            field.type = healType(field.type);
-            if (field.type === null) {
-                delete fieldMap[key];
-            }
-        }
-    }
-    function healUnderlyingTypes(type) {
-        const types = type.getTypes();
-        types.push(...types
-            .splice(0)
-            .map(t => healType(t))
-            .filter(Boolean));
-    }
-    function healType(type) {
-        // Unwrap the two known wrapper types
-        if (graphql.isListType(type)) {
-            const healedType = healType(type.ofType);
-            return healedType != null ? new graphql.GraphQLList(healedType) : null;
-        }
-        else if (graphql.isNonNullType(type)) {
-            const healedType = healType(type.ofType);
-            return healedType != null ? new graphql.GraphQLNonNull(healedType) : null;
-        }
-        else if (graphql.isNamedType(type)) {
-            // If a type annotation on a field or an argument or a union member is
-            // any `GraphQLNamedType` with a `name`, then it must end up identical
-            // to `schema.getType(name)`, since `schema.getTypeMap()` is the source
-            // of truth for all named schema types.
-            // Note that new types can still be simply added by adding a field, as
-            // the official type will be undefined, not null.
-            const officialType = originalTypeMap[type.name];
-            if (officialType && type !== officialType) {
-                return officialType;
-            }
-        }
-        return type;
-    }
-}
-
-function getResolversFromSchema(schema) {
-    var _a, _b;
-    const resolvers = Object.create(null);
-    const typeMap = schema.getTypeMap();
-    for (const typeName in typeMap) {
-        if (!typeName.startsWith('__')) {
-            const type = typeMap[typeName];
-            if (graphql.isScalarType(type)) {
-                if (!graphql.isSpecifiedScalarType(type)) {
-                    const config = type.toConfig();
-                    delete config.astNode; // avoid AST duplication elsewhere
-                    resolvers[typeName] = new graphql.GraphQLScalarType(config);
-                }
-            }
-            else if (graphql.isEnumType(type)) {
-                resolvers[typeName] = {};
-                const values = type.getValues();
-                for (const value of values) {
-                    resolvers[typeName][value.name] = value.value;
-                }
-            }
-            else if (graphql.isInterfaceType(type)) {
-                if (type.resolveType != null) {
-                    resolvers[typeName] = {
-                        __resolveType: type.resolveType,
-                    };
-                }
-            }
-            else if (graphql.isUnionType(type)) {
-                if (type.resolveType != null) {
-                    resolvers[typeName] = {
-                        __resolveType: type.resolveType,
-                    };
-                }
-            }
-            else if (graphql.isObjectType(type)) {
-                resolvers[typeName] = {};
-                if (type.isTypeOf != null) {
-                    resolvers[typeName].__isTypeOf = type.isTypeOf;
-                }
-                const fields = type.getFields();
-                for (const fieldName in fields) {
-                    const field = fields[fieldName];
-                    if (field.subscribe != null) {
-                        resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
-                        resolvers[typeName][fieldName].subscribe = field.subscribe;
-                    }
-                    if (field.resolve != null &&
-                        ((_a = field.resolve) === null || _a === void 0 ? void 0 : _a.name) !== 'defaultFieldResolver' &&
-                        ((_b = field.resolve) === null || _b === void 0 ? void 0 : _b.name) !== 'defaultMergedResolver') {
-                        resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
-                        resolvers[typeName][fieldName].resolve = field.resolve;
-                    }
-                }
-            }
-        }
-    }
-    return resolvers;
-}
-
-function forEachField(schema, fn) {
-    const typeMap = schema.getTypeMap();
-    for (const typeName in typeMap) {
-        const type = typeMap[typeName];
-        // TODO: maybe have an option to include these?
-        if (!graphql.getNamedType(type).name.startsWith('__') && graphql.isObjectType(type)) {
-            const fields = type.getFields();
-            for (const fieldName in fields) {
-                const field = fields[fieldName];
-                fn(field, typeName, fieldName);
-            }
-        }
-    }
-}
-
-function forEachDefaultValue(schema, fn) {
-    const typeMap = schema.getTypeMap();
-    for (const typeName in typeMap) {
-        const type = typeMap[typeName];
-        if (!graphql.getNamedType(type).name.startsWith('__')) {
-            if (graphql.isObjectType(type)) {
-                const fields = type.getFields();
-                for (const fieldName in fields) {
-                    const field = fields[fieldName];
-                    for (const arg of field.args) {
-                        arg.defaultValue = fn(arg.type, arg.defaultValue);
-                    }
-                }
-            }
-            else if (graphql.isInputObjectType(type)) {
-                const fields = type.getFields();
-                for (const fieldName in fields) {
-                    const field = fields[fieldName];
-                    field.defaultValue = fn(field.type, field.defaultValue);
-                }
-            }
-        }
-    }
-}
-
-// addTypes uses toConfig to create a new schema with a new or replaced
-function addTypes(schema, newTypesOrDirectives) {
-    const config = schema.toConfig();
-    const originalTypeMap = {};
-    for (const type of config.types) {
-        originalTypeMap[type.name] = type;
-    }
-    const originalDirectiveMap = {};
-    for (const directive of config.directives) {
-        originalDirectiveMap[directive.name] = directive;
-    }
-    for (const newTypeOrDirective of newTypesOrDirectives) {
-        if (graphql.isNamedType(newTypeOrDirective)) {
-            originalTypeMap[newTypeOrDirective.name] = newTypeOrDirective;
-        }
-        else if (graphql.isDirective(newTypeOrDirective)) {
-            originalDirectiveMap[newTypeOrDirective.name] = newTypeOrDirective;
-        }
-    }
-    const { typeMap, directives } = rewireTypes(originalTypeMap, Object.values(originalDirectiveMap));
-    return new graphql.GraphQLSchema({
-        ...config,
-        query: getObjectTypeFromTypeMap(typeMap, schema.getQueryType()),
-        mutation: getObjectTypeFromTypeMap(typeMap, schema.getMutationType()),
-        subscription: getObjectTypeFromTypeMap(typeMap, schema.getSubscriptionType()),
-        types: Object.values(typeMap),
-        directives,
-    });
-}
-
-/**
- * Prunes the provided schema, removing unused and empty types
- * @param schema The schema to prune
- * @param options Additional options for removing unused types from the schema
- */
-function pruneSchema(schema, options = {}) {
-    const { skipEmptyCompositeTypePruning, skipEmptyUnionPruning, skipPruning, skipUnimplementedInterfacesPruning, skipUnusedTypesPruning, } = options;
-    let prunedTypes = []; // Pruned types during mapping
-    let prunedSchema = schema;
-    do {
-        let visited = visitSchema(prunedSchema);
-        // Custom pruning  was defined, so we need to pre-emptively revisit the schema accounting for this
-        if (skipPruning) {
-            const revisit = [];
-            for (const typeName in prunedSchema.getTypeMap()) {
-                if (typeName.startsWith('__')) {
-                    continue;
-                }
-                const type = prunedSchema.getType(typeName);
-                // if we want to skip pruning for this type, add it to the list of types to revisit
-                if (type && skipPruning(type)) {
-                    revisit.push(typeName);
-                }
-            }
-            visited = visitQueue(revisit, prunedSchema, visited); // visit again
-        }
-        prunedTypes = [];
-        prunedSchema = mapSchema(prunedSchema, {
-            [exports.MapperKind.TYPE]: type => {
-                if (!visited.has(type.name) && !graphql.isSpecifiedScalarType(type)) {
-                    if (graphql.isUnionType(type) ||
-                        graphql.isInputObjectType(type) ||
-                        graphql.isInterfaceType(type) ||
-                        graphql.isObjectType(type) ||
-                        graphql.isScalarType(type)) {
-                        // skipUnusedTypesPruning: skip pruning unused types
-                        if (skipUnusedTypesPruning) {
-                            return type;
-                        }
-                        // skipEmptyUnionPruning: skip pruning empty unions
-                        if (graphql.isUnionType(type) && skipEmptyUnionPruning && !Object.keys(type.getTypes()).length) {
-                            return type;
-                        }
-                        if (graphql.isInputObjectType(type) || graphql.isInterfaceType(type) || graphql.isObjectType(type)) {
-                            // skipEmptyCompositeTypePruning: skip pruning object types or interfaces with no fields
-                            if (skipEmptyCompositeTypePruning && !Object.keys(type.getFields()).length) {
-                                return type;
-                            }
-                        }
-                        // skipUnimplementedInterfacesPruning: skip pruning interfaces that are not implemented by any other types
-                        if (graphql.isInterfaceType(type) && skipUnimplementedInterfacesPruning) {
-                            return type;
-                        }
-                    }
-                    prunedTypes.push(type.name);
-                    visited.delete(type.name);
-                    return null;
-                }
-                return type;
-            },
-        });
-    } while (prunedTypes.length); // Might have empty types and need to prune again
-    return prunedSchema;
-}
-function visitSchema(schema) {
-    const queue = []; // queue of nodes to visit
-    // Grab the root types and start there
-    for (const type of getRootTypes(schema)) {
-        queue.push(type.name);
-    }
-    return visitQueue(queue, schema);
-}
-function visitQueue(queue, schema, visited = new Set()) {
-    // Navigate all types starting with pre-queued types (root types)
-    while (queue.length) {
-        const typeName = queue.pop();
-        // Skip types we already visited
-        if (visited.has(typeName)) {
-            continue;
-        }
-        const type = schema.getType(typeName);
-        if (type) {
-            // Get types for union
-            if (graphql.isUnionType(type)) {
-                queue.push(...type.getTypes().map(type => type.name));
-            }
-            // If the type has files visit those field types
-            if ('getFields' in type) {
-                const fields = type.getFields();
-                const entries = Object.entries(fields);
-                if (!entries.length) {
-                    continue;
-                }
-                for (const [, field] of entries) {
-                    if (graphql.isObjectType(type)) {
-                        for (const arg of field.args) {
-                            queue.push(graphql.getNamedType(arg.type).name); // Visit arg types
-                        }
-                    }
-                    queue.push(graphql.getNamedType(field.type).name);
-                }
-            }
-            // Visit interfaces this type is implementing if they haven't been visited yet
-            if ('getInterfaces' in type) {
-                queue.push(...type.getInterfaces().map(iface => iface.name));
-            }
-            visited.add(typeName); // Mark as visited (and therefore it is used and should be kept)
-        }
-    }
-    return visited;
-}
-
-function mergeDeep(sources, respectPrototype = false) {
-    const target = sources[0] || {};
-    const output = {};
-    if (respectPrototype) {
-        Object.setPrototypeOf(output, Object.create(Object.getPrototypeOf(target)));
-    }
-    for (const source of sources) {
-        if (isObject(target) && isObject(source)) {
-            if (respectPrototype) {
-                const outputPrototype = Object.getPrototypeOf(output);
-                const sourcePrototype = Object.getPrototypeOf(source);
-                if (sourcePrototype) {
-                    for (const key of Object.getOwnPropertyNames(sourcePrototype)) {
-                        const descriptor = Object.getOwnPropertyDescriptor(sourcePrototype, key);
-                        if (isSome(descriptor)) {
-                            Object.defineProperty(outputPrototype, key, descriptor);
-                        }
-                    }
-                }
-            }
-            for (const key in source) {
-                if (isObject(source[key])) {
-                    if (!(key in output)) {
-                        Object.assign(output, { [key]: source[key] });
-                    }
-                    else {
-                        output[key] = mergeDeep([output[key], source[key]], respectPrototype);
-                    }
-                }
-                else {
-                    Object.assign(output, { [key]: source[key] });
-                }
-            }
-        }
-    }
-    return output;
-}
-function isObject(item) {
-    return item && typeof item === 'object' && !Array.isArray(item);
-}
-
-function parseSelectionSet(selectionSet, options) {
-    const query = graphql.parse(selectionSet, options).definitions[0];
-    return query.selectionSet;
-}
-
-/**
- * Get the key under which the result of this resolver will be placed in the response JSON. Basically, just
- * resolves aliases.
- * @param info The info argument to the resolver.
- */
-function getResponseKeyFromInfo(info) {
-    return info.fieldNodes[0].alias != null ? info.fieldNodes[0].alias.value : info.fieldName;
-}
-
-function appendObjectFields(schema, typeName, additionalFields) {
-    if (schema.getType(typeName) == null) {
-        return addTypes(schema, [
-            new graphql.GraphQLObjectType({
-                name: typeName,
-                fields: additionalFields,
-            }),
-        ]);
-    }
-    return mapSchema(schema, {
-        [exports.MapperKind.OBJECT_TYPE]: type => {
-            if (type.name === typeName) {
-                const config = type.toConfig();
-                const originalFieldConfigMap = config.fields;
-                const newFieldConfigMap = {};
-                for (const fieldName in originalFieldConfigMap) {
-                    newFieldConfigMap[fieldName] = originalFieldConfigMap[fieldName];
-                }
-                for (const fieldName in additionalFields) {
-                    newFieldConfigMap[fieldName] = additionalFields[fieldName];
-                }
-                return correctASTNodes(new graphql.GraphQLObjectType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                }));
-            }
-        },
-    });
-}
-function removeObjectFields(schema, typeName, testFn) {
-    const removedFields = {};
-    const newSchema = mapSchema(schema, {
-        [exports.MapperKind.OBJECT_TYPE]: type => {
-            if (type.name === typeName) {
-                const config = type.toConfig();
-                const originalFieldConfigMap = config.fields;
-                const newFieldConfigMap = {};
-                for (const fieldName in originalFieldConfigMap) {
-                    const originalFieldConfig = originalFieldConfigMap[fieldName];
-                    if (testFn(fieldName, originalFieldConfig)) {
-                        removedFields[fieldName] = originalFieldConfig;
-                    }
-                    else {
-                        newFieldConfigMap[fieldName] = originalFieldConfig;
-                    }
-                }
-                return correctASTNodes(new graphql.GraphQLObjectType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                }));
-            }
-        },
-    });
-    return [newSchema, removedFields];
-}
-function selectObjectFields(schema, typeName, testFn) {
-    const selectedFields = {};
-    mapSchema(schema, {
-        [exports.MapperKind.OBJECT_TYPE]: type => {
-            if (type.name === typeName) {
-                const config = type.toConfig();
-                const originalFieldConfigMap = config.fields;
-                for (const fieldName in originalFieldConfigMap) {
-                    const originalFieldConfig = originalFieldConfigMap[fieldName];
-                    if (testFn(fieldName, originalFieldConfig)) {
-                        selectedFields[fieldName] = originalFieldConfig;
-                    }
-                }
-            }
-            return undefined;
-        },
-    });
-    return selectedFields;
-}
-function modifyObjectFields(schema, typeName, testFn, newFields) {
-    const removedFields = {};
-    const newSchema = mapSchema(schema, {
-        [exports.MapperKind.OBJECT_TYPE]: type => {
-            if (type.name === typeName) {
-                const config = type.toConfig();
-                const originalFieldConfigMap = config.fields;
-                const newFieldConfigMap = {};
-                for (const fieldName in originalFieldConfigMap) {
-                    const originalFieldConfig = originalFieldConfigMap[fieldName];
-                    if (testFn(fieldName, originalFieldConfig)) {
-                        removedFields[fieldName] = originalFieldConfig;
-                    }
-                    else {
-                        newFieldConfigMap[fieldName] = originalFieldConfig;
-                    }
-                }
-                for (const fieldName in newFields) {
-                    const fieldConfig = newFields[fieldName];
-                    newFieldConfigMap[fieldName] = fieldConfig;
-                }
-                return correctASTNodes(new graphql.GraphQLObjectType({
-                    ...config,
-                    fields: newFieldConfigMap,
-                }));
-            }
-        },
-    });
-    return [newSchema, removedFields];
-}
-
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.renameType = void 0;
+const graphql_1 = __webpack_require__(232);
 function renameType(type, newTypeName) {
-    if (graphql.isObjectType(type)) {
-        return new graphql.GraphQLObjectType({
+    if ((0, graphql_1.isObjectType)(type)) {
+        return new graphql_1.GraphQLObjectType({
             ...type.toConfig(),
             name: newTypeName,
             astNode: type.astNode == null
@@ -23709,8 +24476,8 @@ function renameType(type, newTypeName) {
                 })),
         });
     }
-    else if (graphql.isInterfaceType(type)) {
-        return new graphql.GraphQLInterfaceType({
+    else if ((0, graphql_1.isInterfaceType)(type)) {
+        return new graphql_1.GraphQLInterfaceType({
             ...type.toConfig(),
             name: newTypeName,
             astNode: type.astNode == null
@@ -23733,8 +24500,8 @@ function renameType(type, newTypeName) {
                 })),
         });
     }
-    else if (graphql.isUnionType(type)) {
-        return new graphql.GraphQLUnionType({
+    else if ((0, graphql_1.isUnionType)(type)) {
+        return new graphql_1.GraphQLUnionType({
             ...type.toConfig(),
             name: newTypeName,
             astNode: type.astNode == null
@@ -23757,8 +24524,8 @@ function renameType(type, newTypeName) {
                 })),
         });
     }
-    else if (graphql.isInputObjectType(type)) {
-        return new graphql.GraphQLInputObjectType({
+    else if ((0, graphql_1.isInputObjectType)(type)) {
+        return new graphql_1.GraphQLInputObjectType({
             ...type.toConfig(),
             name: newTypeName,
             astNode: type.astNode == null
@@ -23781,8 +24548,8 @@ function renameType(type, newTypeName) {
                 })),
         });
     }
-    else if (graphql.isEnumType(type)) {
-        return new graphql.GraphQLEnumType({
+    else if ((0, graphql_1.isEnumType)(type)) {
+        return new graphql_1.GraphQLEnumType({
             ...type.toConfig(),
             name: newTypeName,
             astNode: type.astNode == null
@@ -23805,8 +24572,8 @@ function renameType(type, newTypeName) {
                 })),
         });
     }
-    else if (graphql.isScalarType(type)) {
-        return new graphql.GraphQLScalarType({
+    else if ((0, graphql_1.isScalarType)(type)) {
+        return new graphql_1.GraphQLScalarType({
             ...type.toConfig(),
             name: newTypeName,
             astNode: type.astNode == null
@@ -23831,726 +24598,10 @@ function renameType(type, newTypeName) {
     }
     throw new Error(`Unknown type ${type}.`);
 }
-
-/**
- * Given an AsyncIterable and a callback function, return an AsyncIterator
- * which produces values mapped via calling the callback function.
- */
-function mapAsyncIterator(iterator, callback, rejectCallback) {
-    let $return;
-    let abruptClose;
-    if (typeof iterator.return === 'function') {
-        $return = iterator.return;
-        abruptClose = (error) => {
-            const rethrow = () => Promise.reject(error);
-            return $return.call(iterator).then(rethrow, rethrow);
-        };
-    }
-    function mapResult(result) {
-        return result.done ? result : asyncMapValue(result.value, callback).then(iteratorResult, abruptClose);
-    }
-    let mapReject;
-    if (rejectCallback) {
-        // Capture rejectCallback to ensure it cannot be null.
-        const reject = rejectCallback;
-        mapReject = (error) => asyncMapValue(error, reject).then(iteratorResult, abruptClose);
-    }
-    return {
-        next() {
-            return iterator.next().then(mapResult, mapReject);
-        },
-        return() {
-            return $return
-                ? $return.call(iterator).then(mapResult, mapReject)
-                : Promise.resolve({ value: undefined, done: true });
-        },
-        throw(error) {
-            if (typeof iterator.throw === 'function') {
-                return iterator.throw(error).then(mapResult, mapReject);
-            }
-            return Promise.reject(error).catch(abruptClose);
-        },
-        [Symbol.asyncIterator]() {
-            return this;
-        },
-    };
-}
-function asyncMapValue(value, callback) {
-    return new Promise(resolve => resolve(callback(value)));
-}
-function iteratorResult(value) {
-    return { value, done: false };
-}
-
-function updateArgument(argumentNodes, variableDefinitionsMap, variableValues, argName, varName, type, value) {
-    argumentNodes[argName] = {
-        kind: graphql.Kind.ARGUMENT,
-        name: {
-            kind: graphql.Kind.NAME,
-            value: argName,
-        },
-        value: {
-            kind: graphql.Kind.VARIABLE,
-            name: {
-                kind: graphql.Kind.NAME,
-                value: varName,
-            },
-        },
-    };
-    variableDefinitionsMap[varName] = {
-        kind: graphql.Kind.VARIABLE_DEFINITION,
-        variable: {
-            kind: graphql.Kind.VARIABLE,
-            name: {
-                kind: graphql.Kind.NAME,
-                value: varName,
-            },
-        },
-        type: astFromType(type),
-    };
-    if (value !== undefined) {
-        variableValues[varName] = value;
-        return;
-    }
-    // including the variable in the map with value of `undefined`
-    // will actually be translated by graphql-js into `null`
-    // see https://github.com/graphql/graphql-js/issues/2533
-    if (varName in variableValues) {
-        delete variableValues[varName];
-    }
-}
-function createVariableNameGenerator(variableDefinitionMap) {
-    let varCounter = 0;
-    return (argName) => {
-        let varName;
-        do {
-            varName = `_v${(varCounter++).toString()}_${argName}`;
-        } while (varName in variableDefinitionMap);
-        return varName;
-    };
-}
-
-function implementsAbstractType(schema, typeA, typeB) {
-    if (typeB == null || typeA == null) {
-        return false;
-    }
-    else if (typeA === typeB) {
-        return true;
-    }
-    else if (graphql.isCompositeType(typeA) && graphql.isCompositeType(typeB)) {
-        return graphql.doTypesOverlap(schema, typeA, typeB);
-    }
-    return false;
-}
-
-function relocatedError(originalError, path) {
-    return new graphql.GraphQLError(originalError.message, originalError.nodes, originalError.source, originalError.positions, path === null ? undefined : path === undefined ? originalError.path : path, originalError.originalError, originalError.extensions);
-}
-
-function observableToAsyncIterable(observable) {
-    const pullQueue = [];
-    const pushQueue = [];
-    let listening = true;
-    const pushValue = (value) => {
-        if (pullQueue.length !== 0) {
-            // It is safe to use the ! operator here as we check the length.
-            pullQueue.shift()({ value, done: false });
-        }
-        else {
-            pushQueue.push({ value, done: false });
-        }
-    };
-    const pushError = (error) => {
-        if (pullQueue.length !== 0) {
-            // It is safe to use the ! operator here as we check the length.
-            pullQueue.shift()({ value: { errors: [error] }, done: false });
-        }
-        else {
-            pushQueue.push({ value: { errors: [error] }, done: false });
-        }
-    };
-    const pushDone = () => {
-        if (pullQueue.length !== 0) {
-            // It is safe to use the ! operator here as we check the length.
-            pullQueue.shift()({ done: true });
-        }
-        else {
-            pushQueue.push({ done: true });
-        }
-    };
-    const pullValue = () => new Promise(resolve => {
-        if (pushQueue.length !== 0) {
-            const element = pushQueue.shift();
-            // either {value: {errors: [...]}} or {value: ...}
-            resolve(element);
-        }
-        else {
-            pullQueue.push(resolve);
-        }
-    });
-    const subscription = observable.subscribe({
-        next(value) {
-            pushValue(value);
-        },
-        error(err) {
-            pushError(err);
-        },
-        complete() {
-            pushDone();
-        },
-    });
-    const emptyQueue = () => {
-        if (listening) {
-            listening = false;
-            subscription.unsubscribe();
-            for (const resolve of pullQueue) {
-                resolve({ value: undefined, done: true });
-            }
-            pullQueue.length = 0;
-            pushQueue.length = 0;
-        }
-    };
-    return {
-        next() {
-            // return is a defined method, so it is safe to call it.
-            return listening ? pullValue() : this.return();
-        },
-        return() {
-            emptyQueue();
-            return Promise.resolve({ value: undefined, done: true });
-        },
-        throw(error) {
-            emptyQueue();
-            return Promise.reject(error);
-        },
-        [Symbol.asyncIterator]() {
-            return this;
-        },
-    };
-}
-
-function getOperationASTFromDocument(documentNode, operationName) {
-    const doc = graphql.getOperationAST(documentNode, operationName);
-    if (!doc) {
-        throw new Error(`Cannot infer operation ${operationName || ''}`);
-    }
-    return doc;
-}
-const getOperationASTFromRequest = memoize1(function getOperationASTFromRequest(request) {
-    return getOperationASTFromDocument(request.document, request.operationName);
-});
-
-// Taken from GraphQL-JS v16 for backwards compat
-function collectFields(schema, fragments, variableValues, runtimeType, selectionSet, fields, visitedFragmentNames) {
-    for (const selection of selectionSet.selections) {
-        switch (selection.kind) {
-            case graphql.Kind.FIELD: {
-                if (!shouldIncludeNode(variableValues, selection)) {
-                    continue;
-                }
-                const name = getFieldEntryKey(selection);
-                const fieldList = fields.get(name);
-                if (fieldList !== undefined) {
-                    fieldList.push(selection);
-                }
-                else {
-                    fields.set(name, [selection]);
-                }
-                break;
-            }
-            case graphql.Kind.INLINE_FRAGMENT: {
-                if (!shouldIncludeNode(variableValues, selection) ||
-                    !doesFragmentConditionMatch(schema, selection, runtimeType)) {
-                    continue;
-                }
-                collectFields(schema, fragments, variableValues, runtimeType, selection.selectionSet, fields, visitedFragmentNames);
-                break;
-            }
-            case graphql.Kind.FRAGMENT_SPREAD: {
-                const fragName = selection.name.value;
-                if (visitedFragmentNames.has(fragName) || !shouldIncludeNode(variableValues, selection)) {
-                    continue;
-                }
-                visitedFragmentNames.add(fragName);
-                const fragment = fragments[fragName];
-                if (!fragment || !doesFragmentConditionMatch(schema, fragment, runtimeType)) {
-                    continue;
-                }
-                collectFields(schema, fragments, variableValues, runtimeType, fragment.selectionSet, fields, visitedFragmentNames);
-                break;
-            }
-        }
-    }
-    return fields;
-}
-/**
- * Determines if a field should be included based on the `@include` and `@skip`
- * directives, where `@skip` has higher precedence than `@include`.
- */
-function shouldIncludeNode(variableValues, node) {
-    const skip = graphql.getDirectiveValues(graphql.GraphQLSkipDirective, node, variableValues);
-    if ((skip === null || skip === void 0 ? void 0 : skip['if']) === true) {
-        return false;
-    }
-    const include = graphql.getDirectiveValues(graphql.GraphQLIncludeDirective, node, variableValues);
-    if ((include === null || include === void 0 ? void 0 : include['if']) === false) {
-        return false;
-    }
-    return true;
-}
-/**
- * Determines if a fragment is applicable to the given type.
- */
-function doesFragmentConditionMatch(schema, fragment, type) {
-    const typeConditionNode = fragment.typeCondition;
-    if (!typeConditionNode) {
-        return true;
-    }
-    const conditionalType = graphql.typeFromAST(schema, typeConditionNode);
-    if (conditionalType === type) {
-        return true;
-    }
-    if (graphql.isAbstractType(conditionalType)) {
-        const possibleTypes = schema.getPossibleTypes(conditionalType);
-        return possibleTypes.includes(type);
-    }
-    return false;
-}
-/**
- * Implements the logic to compute the key of a given field's entry
- */
-function getFieldEntryKey(node) {
-    return node.alias ? node.alias.value : node.name.value;
-}
-const collectSubFields = memoize5(function collectSubFields(schema, fragments, variableValues, type, fieldNodes) {
-    const subFieldNodes = new Map();
-    const visitedFragmentNames = new Set();
-    for (const fieldNode of fieldNodes) {
-        if (fieldNode.selectionSet) {
-            collectFields(schema, fragments, variableValues, type, fieldNode.selectionSet, subFieldNodes, visitedFragmentNames);
-        }
-    }
-    return subFieldNodes;
-});
-
-function visitData(data, enter, leave) {
-    if (Array.isArray(data)) {
-        return data.map(value => visitData(value, enter, leave));
-    }
-    else if (typeof data === 'object') {
-        const newData = enter != null ? enter(data) : data;
-        if (newData != null) {
-            for (const key in newData) {
-                const value = newData[key];
-                Object.defineProperty(newData, key, {
-                    value: visitData(value, enter, leave),
-                });
-            }
-        }
-        return leave != null ? leave(newData) : newData;
-    }
-    return data;
-}
-function visitErrors(errors, visitor) {
-    return errors.map(error => visitor(error));
-}
-function visitResult(result, request, schema, resultVisitorMap, errorVisitorMap) {
-    const fragments = request.document.definitions.reduce((acc, def) => {
-        if (def.kind === graphql.Kind.FRAGMENT_DEFINITION) {
-            acc[def.name.value] = def;
-        }
-        return acc;
-    }, {});
-    const variableValues = request.variables || {};
-    const errorInfo = {
-        segmentInfoMap: new Map(),
-        unpathedErrors: new Set(),
-    };
-    const data = result.data;
-    const errors = result.errors;
-    const visitingErrors = errors != null && errorVisitorMap != null;
-    const operationDocumentNode = getOperationASTFromRequest(request);
-    if (data != null && operationDocumentNode != null) {
-        result.data = visitRoot(data, operationDocumentNode, schema, fragments, variableValues, resultVisitorMap, visitingErrors ? errors : undefined, errorInfo);
-    }
-    if (errors != null && errorVisitorMap) {
-        result.errors = visitErrorsByType(errors, errorVisitorMap, errorInfo);
-    }
-    return result;
-}
-function visitErrorsByType(errors, errorVisitorMap, errorInfo) {
-    const segmentInfoMap = errorInfo.segmentInfoMap;
-    const unpathedErrors = errorInfo.unpathedErrors;
-    const unpathedErrorVisitor = errorVisitorMap['__unpathed'];
-    return errors.map(originalError => {
-        const pathSegmentsInfo = segmentInfoMap.get(originalError);
-        const newError = pathSegmentsInfo == null
-            ? originalError
-            : pathSegmentsInfo.reduceRight((acc, segmentInfo) => {
-                const typeName = segmentInfo.type.name;
-                const typeVisitorMap = errorVisitorMap[typeName];
-                if (typeVisitorMap == null) {
-                    return acc;
-                }
-                const errorVisitor = typeVisitorMap[segmentInfo.fieldName];
-                return errorVisitor == null ? acc : errorVisitor(acc, segmentInfo.pathIndex);
-            }, originalError);
-        if (unpathedErrorVisitor && unpathedErrors.has(originalError)) {
-            return unpathedErrorVisitor(newError);
-        }
-        return newError;
-    });
-}
-function visitRoot(root, operation, schema, fragments, variableValues, resultVisitorMap, errors, errorInfo) {
-    const operationRootType = graphql.getOperationRootType(schema, operation);
-    const collectedFields = collectFields(schema, fragments, variableValues, operationRootType, operation.selectionSet, new Map(), new Set());
-    return visitObjectValue(root, operationRootType, collectedFields, schema, fragments, variableValues, resultVisitorMap, 0, errors, errorInfo);
-}
-function visitObjectValue(object, type, fieldNodeMap, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo) {
-    var _a;
-    const fieldMap = type.getFields();
-    const typeVisitorMap = resultVisitorMap === null || resultVisitorMap === void 0 ? void 0 : resultVisitorMap[type.name];
-    const enterObject = typeVisitorMap === null || typeVisitorMap === void 0 ? void 0 : typeVisitorMap.__enter;
-    const newObject = enterObject != null ? enterObject(object) : object;
-    let sortedErrors;
-    let errorMap = null;
-    if (errors != null) {
-        sortedErrors = sortErrorsByPathSegment(errors, pathIndex);
-        errorMap = sortedErrors.errorMap;
-        for (const error of sortedErrors.unpathedErrors) {
-            errorInfo.unpathedErrors.add(error);
-        }
-    }
-    for (const [responseKey, subFieldNodes] of fieldNodeMap) {
-        const fieldName = subFieldNodes[0].name.value;
-        const fieldType = fieldName === '__typename' ? graphql.TypeNameMetaFieldDef.type : (_a = fieldMap[fieldName]) === null || _a === void 0 ? void 0 : _a.type;
-        const newPathIndex = pathIndex + 1;
-        let fieldErrors;
-        if (errorMap) {
-            fieldErrors = errorMap[responseKey];
-            if (fieldErrors != null) {
-                delete errorMap[responseKey];
-            }
-            addPathSegmentInfo(type, fieldName, newPathIndex, fieldErrors, errorInfo);
-        }
-        const newValue = visitFieldValue(object[responseKey], fieldType, subFieldNodes, schema, fragments, variableValues, resultVisitorMap, newPathIndex, fieldErrors, errorInfo);
-        updateObject(newObject, responseKey, newValue, typeVisitorMap, fieldName);
-    }
-    const oldTypename = newObject.__typename;
-    if (oldTypename != null) {
-        updateObject(newObject, '__typename', oldTypename, typeVisitorMap, '__typename');
-    }
-    if (errorMap) {
-        for (const errorsKey in errorMap) {
-            const errors = errorMap[errorsKey];
-            for (const error of errors) {
-                errorInfo.unpathedErrors.add(error);
-            }
-        }
-    }
-    const leaveObject = typeVisitorMap === null || typeVisitorMap === void 0 ? void 0 : typeVisitorMap.__leave;
-    return leaveObject != null ? leaveObject(newObject) : newObject;
-}
-function updateObject(object, responseKey, newValue, typeVisitorMap, fieldName) {
-    if (typeVisitorMap == null) {
-        object[responseKey] = newValue;
-        return;
-    }
-    const fieldVisitor = typeVisitorMap[fieldName];
-    if (fieldVisitor == null) {
-        object[responseKey] = newValue;
-        return;
-    }
-    const visitedValue = fieldVisitor(newValue);
-    if (visitedValue === undefined) {
-        delete object[responseKey];
-        return;
-    }
-    object[responseKey] = visitedValue;
-}
-function visitListValue(list, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo) {
-    return list.map(listMember => visitFieldValue(listMember, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex + 1, errors, errorInfo));
-}
-function visitFieldValue(value, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors = [], errorInfo) {
-    if (value == null) {
-        return value;
-    }
-    const nullableType = graphql.getNullableType(returnType);
-    if (graphql.isListType(nullableType)) {
-        return visitListValue(value, nullableType.ofType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
-    }
-    else if (graphql.isAbstractType(nullableType)) {
-        const finalType = schema.getType(value.__typename);
-        const collectedFields = collectSubFields(schema, fragments, variableValues, finalType, fieldNodes);
-        return visitObjectValue(value, finalType, collectedFields, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
-    }
-    else if (graphql.isObjectType(nullableType)) {
-        const collectedFields = collectSubFields(schema, fragments, variableValues, nullableType, fieldNodes);
-        return visitObjectValue(value, nullableType, collectedFields, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
-    }
-    const typeVisitorMap = resultVisitorMap === null || resultVisitorMap === void 0 ? void 0 : resultVisitorMap[nullableType.name];
-    if (typeVisitorMap == null) {
-        return value;
-    }
-    const visitedValue = typeVisitorMap(value);
-    return visitedValue === undefined ? value : visitedValue;
-}
-function sortErrorsByPathSegment(errors, pathIndex) {
-    var _a;
-    const errorMap = Object.create(null);
-    const unpathedErrors = new Set();
-    for (const error of errors) {
-        const pathSegment = (_a = error.path) === null || _a === void 0 ? void 0 : _a[pathIndex];
-        if (pathSegment == null) {
-            unpathedErrors.add(error);
-            continue;
-        }
-        if (pathSegment in errorMap) {
-            errorMap[pathSegment].push(error);
-        }
-        else {
-            errorMap[pathSegment] = [error];
-        }
-    }
-    return {
-        errorMap,
-        unpathedErrors,
-    };
-}
-function addPathSegmentInfo(type, fieldName, pathIndex, errors = [], errorInfo) {
-    for (const error of errors) {
-        const segmentInfo = {
-            type,
-            fieldName,
-            pathIndex,
-        };
-        const pathSegmentsInfo = errorInfo.segmentInfoMap.get(error);
-        if (pathSegmentsInfo == null) {
-            errorInfo.segmentInfoMap.set(error, [segmentInfo]);
-        }
-        else {
-            pathSegmentsInfo.push(segmentInfo);
-        }
-    }
-}
-
-function valueMatchesCriteria(value, criteria) {
-    if (value == null) {
-        return value === criteria;
-    }
-    else if (Array.isArray(value)) {
-        return Array.isArray(criteria) && value.every((val, index) => valueMatchesCriteria(val, criteria[index]));
-    }
-    else if (typeof value === 'object') {
-        return (typeof criteria === 'object' &&
-            criteria &&
-            Object.keys(criteria).every(propertyName => valueMatchesCriteria(value[propertyName], criteria[propertyName])));
-    }
-    else if (criteria instanceof RegExp) {
-        return criteria.test(value);
-    }
-    return value === criteria;
-}
-
-function isAsyncIterable(value) {
-    return (typeof value === 'object' &&
-        value != null &&
-        Symbol.asyncIterator in value &&
-        typeof value[Symbol.asyncIterator] === 'function');
-}
-
-function isDocumentNode(object) {
-    return object && typeof object === 'object' && 'kind' in object && object.kind === graphql.Kind.DOCUMENT;
-}
-
-async function defaultAsyncIteratorReturn(value) {
-    return { value, done: true };
-}
-const proxyMethodFactory = memoize2(function proxyMethodFactory(target, targetMethod) {
-    return function proxyMethod(...args) {
-        return Reflect.apply(targetMethod, target, args);
-    };
-});
-function getAsyncIteratorWithCancel(asyncIterator, onCancel) {
-    return new Proxy(asyncIterator, {
-        has(asyncIterator, prop) {
-            if (prop === 'return') {
-                return true;
-            }
-            return Reflect.has(asyncIterator, prop);
-        },
-        get(asyncIterator, prop, receiver) {
-            const existingPropValue = Reflect.get(asyncIterator, prop, receiver);
-            if (prop === 'return') {
-                const existingReturn = existingPropValue || defaultAsyncIteratorReturn;
-                return async function returnWithCancel(value) {
-                    const returnValue = await onCancel(value);
-                    return Reflect.apply(existingReturn, asyncIterator, [returnValue]);
-                };
-            }
-            else if (typeof existingPropValue === 'function') {
-                return proxyMethodFactory(asyncIterator, existingPropValue);
-            }
-            return existingPropValue;
-        },
-    });
-}
-function getAsyncIterableWithCancel(asyncIterable, onCancel) {
-    return new Proxy(asyncIterable, {
-        get(asyncIterable, prop, receiver) {
-            const existingPropValue = Reflect.get(asyncIterable, prop, receiver);
-            if (Symbol.asyncIterator === prop) {
-                return function asyncIteratorFactory() {
-                    const asyncIterator = Reflect.apply(existingPropValue, asyncIterable, []);
-                    return getAsyncIteratorWithCancel(asyncIterator, onCancel);
-                };
-            }
-            else if (typeof existingPropValue === 'function') {
-                return proxyMethodFactory(asyncIterable, existingPropValue);
-            }
-            return existingPropValue;
-        },
-    });
-}
-
-function buildFixedSchema(schema, options) {
-    const document = getDocumentNodeFromSchema(schema);
-    return graphql.buildASTSchema(document, {
-        ...(options || {}),
-    });
-}
-function fixSchemaAst(schema, options) {
-    // eslint-disable-next-line no-undef-init
-    let schemaWithValidAst = undefined;
-    if (!schema.astNode || !schema.extensionASTNodes) {
-        schemaWithValidAst = buildFixedSchema(schema, options);
-    }
-    if (!schema.astNode && (schemaWithValidAst === null || schemaWithValidAst === void 0 ? void 0 : schemaWithValidAst.astNode)) {
-        schema.astNode = schemaWithValidAst.astNode;
-    }
-    if (!schema.extensionASTNodes && (schemaWithValidAst === null || schemaWithValidAst === void 0 ? void 0 : schemaWithValidAst.astNode)) {
-        schema.extensionASTNodes = schemaWithValidAst.extensionASTNodes;
-    }
-    return schema;
-}
-
-exports.addTypes = addTypes;
-exports.appendObjectFields = appendObjectFields;
-exports.asArray = asArray;
-exports.assertSome = assertSome;
-exports.astFromArg = astFromArg;
-exports.astFromDirective = astFromDirective;
-exports.astFromEnumType = astFromEnumType;
-exports.astFromEnumValue = astFromEnumValue;
-exports.astFromField = astFromField;
-exports.astFromInputField = astFromInputField;
-exports.astFromInputObjectType = astFromInputObjectType;
-exports.astFromInterfaceType = astFromInterfaceType;
-exports.astFromObjectType = astFromObjectType;
-exports.astFromScalarType = astFromScalarType;
-exports.astFromSchema = astFromSchema;
-exports.astFromUnionType = astFromUnionType;
-exports.astFromValueUntyped = astFromValueUntyped;
-exports.buildOperationNodeForField = buildOperationNodeForField;
-exports.checkValidationErrors = checkValidationErrors;
-exports.collectComment = collectComment;
-exports.collectFields = collectFields;
-exports.collectSubFields = collectSubFields;
-exports.compareNodes = compareNodes;
-exports.compareStrings = compareStrings;
-exports.correctASTNodes = correctASTNodes;
-exports.createDefaultRules = createDefaultRules;
-exports.createNamedStub = createNamedStub;
-exports.createStub = createStub;
-exports.createVariableNameGenerator = createVariableNameGenerator;
-exports.dedentBlockStringValue = dedentBlockStringValue;
-exports.filterSchema = filterSchema;
-exports.fixSchemaAst = fixSchemaAst;
-exports.forEachDefaultValue = forEachDefaultValue;
-exports.forEachField = forEachField;
-exports.getArgumentValues = getArgumentValues;
-exports.getAsyncIterableWithCancel = getAsyncIterableWithCancel;
-exports.getAsyncIteratorWithCancel = getAsyncIteratorWithCancel;
-exports.getBlockStringIndentation = getBlockStringIndentation;
-exports.getBuiltInForStub = getBuiltInForStub;
-exports.getComment = getComment;
-exports.getDefinedRootType = getDefinedRootType;
-exports.getDeprecatableDirectiveNodes = getDeprecatableDirectiveNodes;
-exports.getDescription = getDescription;
-exports.getDirective = getDirective;
-exports.getDirectiveInExtensions = getDirectiveInExtensions;
-exports.getDirectiveNodes = getDirectiveNodes;
-exports.getDirectives = getDirectives;
-exports.getDirectivesInExtensions = getDirectivesInExtensions;
-exports.getDocumentNodeFromSchema = getDocumentNodeFromSchema;
-exports.getFieldsWithDirectives = getFieldsWithDirectives;
-exports.getImplementingTypes = getImplementingTypes;
-exports.getLeadingCommentBlock = getLeadingCommentBlock;
-exports.getOperationASTFromDocument = getOperationASTFromDocument;
-exports.getOperationASTFromRequest = getOperationASTFromRequest;
-exports.getResolversFromSchema = getResolversFromSchema;
-exports.getResponseKeyFromInfo = getResponseKeyFromInfo;
-exports.getRootTypeMap = getRootTypeMap;
-exports.getRootTypeNames = getRootTypeNames;
-exports.getRootTypes = getRootTypes;
-exports.healSchema = healSchema;
-exports.healTypes = healTypes;
-exports.implementsAbstractType = implementsAbstractType;
-exports.inspect = inspect;
-exports.isAggregateError = isAggregateError;
-exports.isAsyncIterable = isAsyncIterable;
-exports.isDescribable = isDescribable;
-exports.isDocumentNode = isDocumentNode;
-exports.isDocumentString = isDocumentString;
-exports.isNamedStub = isNamedStub;
-exports.isSome = isSome;
-exports.isValidPath = isValidPath;
-exports.makeDeprecatedDirective = makeDeprecatedDirective;
-exports.makeDirectiveNode = makeDirectiveNode;
-exports.makeDirectiveNodes = makeDirectiveNodes;
-exports.mapAsyncIterator = mapAsyncIterator;
-exports.mapSchema = mapSchema;
-exports.memoize1 = memoize1;
-exports.memoize2 = memoize2;
-exports.memoize2of4 = memoize2of4;
-exports.memoize3 = memoize3;
-exports.memoize4 = memoize4;
-exports.memoize5 = memoize5;
-exports.mergeDeep = mergeDeep;
-exports.modifyObjectFields = modifyObjectFields;
-exports.nodeToString = nodeToString;
-exports.observableToAsyncIterable = observableToAsyncIterable;
-exports.parseGraphQLJSON = parseGraphQLJSON;
-exports.parseGraphQLSDL = parseGraphQLSDL;
-exports.parseInputValue = parseInputValue;
-exports.parseInputValueLiteral = parseInputValueLiteral;
-exports.parseSelectionSet = parseSelectionSet;
-exports.printComment = printComment;
-exports.printSchemaWithDirectives = printSchemaWithDirectives;
-exports.printWithComments = printWithComments;
-exports.pruneSchema = pruneSchema;
-exports.pushComment = pushComment;
-exports.relocatedError = relocatedError;
-exports.removeObjectFields = removeObjectFields;
 exports.renameType = renameType;
-exports.resetComments = resetComments;
-exports.rewireTypes = rewireTypes;
-exports.selectObjectFields = selectObjectFields;
-exports.serializeInputValue = serializeInputValue;
-exports.transformCommentsToDescriptions = transformCommentsToDescriptions;
-exports.transformInputValue = transformInputValue;
-exports.updateArgument = updateArgument;
-exports.validateGraphQlDocuments = validateGraphQlDocuments;
-exports.valueMatchesCriteria = valueMatchesCriteria;
-exports.visitData = visitData;
-exports.visitErrors = visitErrors;
-exports.visitResult = visitResult;
-exports.withCancel = getAsyncIterableWithCancel;
 
 
 /***/ }),
-/* 417 */,
-/* 418 */,
 /* 419 */,
 /* 420 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -25136,7 +25187,65 @@ function NoUnusedFragmentsRule(context) {
 
 
 /***/ }),
-/* 440 */,
+/* 440 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getFieldsWithDirectives = void 0;
+const graphql_1 = __webpack_require__(232);
+function parseDirectiveValue(value) {
+    switch (value.kind) {
+        case graphql_1.Kind.INT:
+            return parseInt(value.value);
+        case graphql_1.Kind.FLOAT:
+            return parseFloat(value.value);
+        case graphql_1.Kind.BOOLEAN:
+            return Boolean(value.value);
+        case graphql_1.Kind.STRING:
+        case graphql_1.Kind.ENUM:
+            return value.value;
+        case graphql_1.Kind.LIST:
+            return value.values.map(v => parseDirectiveValue(v));
+        case graphql_1.Kind.OBJECT:
+            return value.fields.reduce((prev, v) => ({ ...prev, [v.name.value]: parseDirectiveValue(v.value) }), {});
+        case graphql_1.Kind.NULL:
+            return null;
+        default:
+            return null;
+    }
+}
+function getFieldsWithDirectives(documentNode, options = {}) {
+    const result = {};
+    let selected = ['ObjectTypeDefinition', 'ObjectTypeExtension'];
+    if (options.includeInputTypes) {
+        selected = [...selected, 'InputObjectTypeDefinition', 'InputObjectTypeExtension'];
+    }
+    const allTypes = documentNode.definitions.filter(obj => selected.includes(obj.kind));
+    for (const type of allTypes) {
+        const typeName = type.name.value;
+        if (type.fields == null) {
+            continue;
+        }
+        for (const field of type.fields) {
+            if (field.directives && field.directives.length > 0) {
+                const fieldName = field.name.value;
+                const key = `${typeName}.${fieldName}`;
+                const directives = field.directives.map(d => ({
+                    name: d.name.value,
+                    args: (d.arguments || []).reduce((prev, arg) => ({ ...prev, [arg.name.value]: parseDirectiveValue(arg.value) }), {}),
+                }));
+                result[key] = directives;
+            }
+        }
+    }
+    return result;
+}
+exports.getFieldsWithDirectives = getFieldsWithDirectives;
+
+
+/***/ }),
 /* 441 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -25267,8 +25376,1001 @@ function doTypesOverlap(schema, typeA, typeB) {
 /* 446 */,
 /* 447 */,
 /* 448 */,
-/* 449 */,
-/* 450 */,
+/* 449 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+const minimatch = module.exports = (p, pattern, options = {}) => {
+  assertValidPattern(pattern)
+
+  // shortcut: comments match nothing.
+  if (!options.nocomment && pattern.charAt(0) === '#') {
+    return false
+  }
+
+  return new Minimatch(pattern, options).match(p)
+}
+
+module.exports = minimatch
+
+const path = __webpack_require__(137)
+minimatch.sep = path.sep
+
+const GLOBSTAR = Symbol('globstar **')
+minimatch.GLOBSTAR = GLOBSTAR
+const expand = __webpack_require__(914)
+
+const plTypes = {
+  '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
+  '?': { open: '(?:', close: ')?' },
+  '+': { open: '(?:', close: ')+' },
+  '*': { open: '(?:', close: ')*' },
+  '@': { open: '(?:', close: ')' }
+}
+
+// any single thing other than /
+// don't need to escape / when using new RegExp()
+const qmark = '[^/]'
+
+// * => any number of characters
+const star = qmark + '*?'
+
+// ** when dots are allowed.  Anything goes, except .. and .
+// not (^ or / followed by one or two dots followed by $ or /),
+// followed by anything, any number of times.
+const twoStarDot = '(?:(?!(?:\\\/|^)(?:\\.{1,2})($|\\\/)).)*?'
+
+// not a ^ or / followed by a dot,
+// followed by anything, any number of times.
+const twoStarNoDot = '(?:(?!(?:\\\/|^)\\.).)*?'
+
+// "abc" -> { a:true, b:true, c:true }
+const charSet = s => s.split('').reduce((set, c) => {
+  set[c] = true
+  return set
+}, {})
+
+// characters that need to be escaped in RegExp.
+const reSpecials = charSet('().*{}+?[]^$\\!')
+
+// characters that indicate we have to add the pattern start
+const addPatternStartSet = charSet('[.(')
+
+// normalizes slashes.
+const slashSplit = /\/+/
+
+minimatch.filter = (pattern, options = {}) =>
+  (p, i, list) => minimatch(p, pattern, options)
+
+const ext = (a, b = {}) => {
+  const t = {}
+  Object.keys(a).forEach(k => t[k] = a[k])
+  Object.keys(b).forEach(k => t[k] = b[k])
+  return t
+}
+
+minimatch.defaults = def => {
+  if (!def || typeof def !== 'object' || !Object.keys(def).length) {
+    return minimatch
+  }
+
+  const orig = minimatch
+
+  const m = (p, pattern, options) => orig(p, pattern, ext(def, options))
+  m.Minimatch = class Minimatch extends orig.Minimatch {
+    constructor (pattern, options) {
+      super(pattern, ext(def, options))
+    }
+  }
+  m.Minimatch.defaults = options => orig.defaults(ext(def, options)).Minimatch
+  m.filter = (pattern, options) => orig.filter(pattern, ext(def, options))
+  m.defaults = options => orig.defaults(ext(def, options))
+  m.makeRe = (pattern, options) => orig.makeRe(pattern, ext(def, options))
+  m.braceExpand = (pattern, options) => orig.braceExpand(pattern, ext(def, options))
+  m.match = (list, pattern, options) => orig.match(list, pattern, ext(def, options))
+
+  return m
+}
+
+
+
+
+
+// Brace expansion:
+// a{b,c}d -> abd acd
+// a{b,}c -> abc ac
+// a{0..3}d -> a0d a1d a2d a3d
+// a{b,c{d,e}f}g -> abg acdfg acefg
+// a{b,c}d{e,f}g -> abdeg acdeg abdeg abdfg
+//
+// Invalid sets are not expanded.
+// a{2..}b -> a{2..}b
+// a{b}c -> a{b}c
+minimatch.braceExpand = (pattern, options) => braceExpand(pattern, options)
+
+const braceExpand = (pattern, options = {}) => {
+  assertValidPattern(pattern)
+
+  // Thanks to Yeting Li <https://github.com/yetingli> for
+  // improving this regexp to avoid a ReDOS vulnerability.
+  if (options.nobrace || !/\{(?:(?!\{).)*\}/.test(pattern)) {
+    // shortcut. no need to expand.
+    return [pattern]
+  }
+
+  return expand(pattern)
+}
+
+const MAX_PATTERN_LENGTH = 1024 * 64
+const assertValidPattern = pattern => {
+  if (typeof pattern !== 'string') {
+    throw new TypeError('invalid pattern')
+  }
+
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    throw new TypeError('pattern is too long')
+  }
+}
+
+// parse a component of the expanded set.
+// At this point, no pattern may contain "/" in it
+// so we're going to return a 2d array, where each entry is the full
+// pattern, split on '/', and then turned into a regular expression.
+// A regexp is made at the end which joins each array with an
+// escaped /, and another full one which joins each regexp with |.
+//
+// Following the lead of Bash 4.1, note that "**" only has special meaning
+// when it is the *only* thing in a path portion.  Otherwise, any series
+// of * is equivalent to a single *.  Globstar behavior is enabled by
+// default, and can be disabled by setting options.noglobstar.
+const SUBPARSE = Symbol('subparse')
+
+minimatch.makeRe = (pattern, options) =>
+  new Minimatch(pattern, options || {}).makeRe()
+
+minimatch.match = (list, pattern, options = {}) => {
+  const mm = new Minimatch(pattern, options)
+  list = list.filter(f => mm.match(f))
+  if (mm.options.nonull && !list.length) {
+    list.push(pattern)
+  }
+  return list
+}
+
+// replace stuff like \* with *
+const globUnescape = s => s.replace(/\\(.)/g, '$1')
+const regExpEscape = s => s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')
+
+class Minimatch {
+  constructor (pattern, options) {
+    assertValidPattern(pattern)
+
+    if (!options) options = {}
+
+    this.options = options
+    this.set = []
+    this.pattern = pattern
+    this.windowsPathsNoEscape = !!options.windowsPathsNoEscape ||
+      options.allowWindowsEscape === false
+    if (this.windowsPathsNoEscape) {
+      this.pattern = this.pattern.replace(/\\/g, '/')
+    }
+    this.regexp = null
+    this.negate = false
+    this.comment = false
+    this.empty = false
+    this.partial = !!options.partial
+
+    // make the set of regexps etc.
+    this.make()
+  }
+
+  debug () {}
+
+  make () {
+    const pattern = this.pattern
+    const options = this.options
+
+    // empty patterns and comments match nothing.
+    if (!options.nocomment && pattern.charAt(0) === '#') {
+      this.comment = true
+      return
+    }
+    if (!pattern) {
+      this.empty = true
+      return
+    }
+
+    // step 1: figure out negation, etc.
+    this.parseNegate()
+
+    // step 2: expand braces
+    let set = this.globSet = this.braceExpand()
+
+    if (options.debug) this.debug = (...args) => console.error(...args)
+
+    this.debug(this.pattern, set)
+
+    // step 3: now we have a set, so turn each one into a series of path-portion
+    // matching patterns.
+    // These will be regexps, except in the case of "**", which is
+    // set to the GLOBSTAR object for globstar behavior,
+    // and will not contain any / characters
+    set = this.globParts = set.map(s => s.split(slashSplit))
+
+    this.debug(this.pattern, set)
+
+    // glob --> regexps
+    set = set.map((s, si, set) => s.map(this.parse, this))
+
+    this.debug(this.pattern, set)
+
+    // filter out everything that didn't compile properly.
+    set = set.filter(s => s.indexOf(false) === -1)
+
+    this.debug(this.pattern, set)
+
+    this.set = set
+  }
+
+  parseNegate () {
+    if (this.options.nonegate) return
+
+    const pattern = this.pattern
+    let negate = false
+    let negateOffset = 0
+
+    for (let i = 0; i < pattern.length && pattern.charAt(i) === '!'; i++) {
+      negate = !negate
+      negateOffset++
+    }
+
+    if (negateOffset) this.pattern = pattern.substr(negateOffset)
+    this.negate = negate
+  }
+
+  // set partial to true to test if, for example,
+  // "/a/b" matches the start of "/*/b/*/d"
+  // Partial means, if you run out of file before you run
+  // out of pattern, then that's fine, as long as all
+  // the parts match.
+  matchOne (file, pattern, partial) {
+    var options = this.options
+
+    this.debug('matchOne',
+      { 'this': this, file: file, pattern: pattern })
+
+    this.debug('matchOne', file.length, pattern.length)
+
+    for (var fi = 0,
+        pi = 0,
+        fl = file.length,
+        pl = pattern.length
+        ; (fi < fl) && (pi < pl)
+        ; fi++, pi++) {
+      this.debug('matchOne loop')
+      var p = pattern[pi]
+      var f = file[fi]
+
+      this.debug(pattern, p, f)
+
+      // should be impossible.
+      // some invalid regexp stuff in the set.
+      /* istanbul ignore if */
+      if (p === false) return false
+
+      if (p === GLOBSTAR) {
+        this.debug('GLOBSTAR', [pattern, p, f])
+
+        // "**"
+        // a/**/b/**/c would match the following:
+        // a/b/x/y/z/c
+        // a/x/y/z/b/c
+        // a/b/x/b/x/c
+        // a/b/c
+        // To do this, take the rest of the pattern after
+        // the **, and see if it would match the file remainder.
+        // If so, return success.
+        // If not, the ** "swallows" a segment, and try again.
+        // This is recursively awful.
+        //
+        // a/**/b/**/c matching a/b/x/y/z/c
+        // - a matches a
+        // - doublestar
+        //   - matchOne(b/x/y/z/c, b/**/c)
+        //     - b matches b
+        //     - doublestar
+        //       - matchOne(x/y/z/c, c) -> no
+        //       - matchOne(y/z/c, c) -> no
+        //       - matchOne(z/c, c) -> no
+        //       - matchOne(c, c) yes, hit
+        var fr = fi
+        var pr = pi + 1
+        if (pr === pl) {
+          this.debug('** at the end')
+          // a ** at the end will just swallow the rest.
+          // We have found a match.
+          // however, it will not swallow /.x, unless
+          // options.dot is set.
+          // . and .. are *never* matched by **, for explosively
+          // exponential reasons.
+          for (; fi < fl; fi++) {
+            if (file[fi] === '.' || file[fi] === '..' ||
+              (!options.dot && file[fi].charAt(0) === '.')) return false
+          }
+          return true
+        }
+
+        // ok, let's see if we can swallow whatever we can.
+        while (fr < fl) {
+          var swallowee = file[fr]
+
+          this.debug('\nglobstar while', file, fr, pattern, pr, swallowee)
+
+          // XXX remove this slice.  Just pass the start index.
+          if (this.matchOne(file.slice(fr), pattern.slice(pr), partial)) {
+            this.debug('globstar found match!', fr, fl, swallowee)
+            // found a match.
+            return true
+          } else {
+            // can't swallow "." or ".." ever.
+            // can only swallow ".foo" when explicitly asked.
+            if (swallowee === '.' || swallowee === '..' ||
+              (!options.dot && swallowee.charAt(0) === '.')) {
+              this.debug('dot detected!', file, fr, pattern, pr)
+              break
+            }
+
+            // ** swallows a segment, and continue.
+            this.debug('globstar swallow a segment, and continue')
+            fr++
+          }
+        }
+
+        // no match was found.
+        // However, in partial mode, we can't say this is necessarily over.
+        // If there's more *pattern* left, then
+        /* istanbul ignore if */
+        if (partial) {
+          // ran out of file
+          this.debug('\n>>> no match, partial?', file, fr, pattern, pr)
+          if (fr === fl) return true
+        }
+        return false
+      }
+
+      // something other than **
+      // non-magic patterns just have to match exactly
+      // patterns with magic have been turned into regexps.
+      var hit
+      if (typeof p === 'string') {
+        hit = f === p
+        this.debug('string match', p, f, hit)
+      } else {
+        hit = f.match(p)
+        this.debug('pattern match', p, f, hit)
+      }
+
+      if (!hit) return false
+    }
+
+    // Note: ending in / means that we'll get a final ""
+    // at the end of the pattern.  This can only match a
+    // corresponding "" at the end of the file.
+    // If the file ends in /, then it can only match a
+    // a pattern that ends in /, unless the pattern just
+    // doesn't have any more for it. But, a/b/ should *not*
+    // match "a/b/*", even though "" matches against the
+    // [^/]*? pattern, except in partial mode, where it might
+    // simply not be reached yet.
+    // However, a/b/ should still satisfy a/*
+
+    // now either we fell off the end of the pattern, or we're done.
+    if (fi === fl && pi === pl) {
+      // ran out of pattern and filename at the same time.
+      // an exact hit!
+      return true
+    } else if (fi === fl) {
+      // ran out of file, but still had pattern left.
+      // this is ok if we're doing the match as part of
+      // a glob fs traversal.
+      return partial
+    } else /* istanbul ignore else */ if (pi === pl) {
+      // ran out of pattern, still have file left.
+      // this is only acceptable if we're on the very last
+      // empty segment of a file with a trailing slash.
+      // a/* should match a/b/
+      return (fi === fl - 1) && (file[fi] === '')
+    }
+
+    // should be unreachable.
+    /* istanbul ignore next */
+    throw new Error('wtf?')
+  }
+
+  braceExpand () {
+    return braceExpand(this.pattern, this.options)
+  }
+
+  parse (pattern, isSub) {
+    assertValidPattern(pattern)
+
+    const options = this.options
+
+    // shortcuts
+    if (pattern === '**') {
+      if (!options.noglobstar)
+        return GLOBSTAR
+      else
+        pattern = '*'
+    }
+    if (pattern === '') return ''
+
+    let re = ''
+    let hasMagic = !!options.nocase
+    let escaping = false
+    // ? => one single character
+    const patternListStack = []
+    const negativeLists = []
+    let stateChar
+    let inClass = false
+    let reClassStart = -1
+    let classStart = -1
+    let cs
+    let pl
+    let sp
+    // . and .. never match anything that doesn't start with .,
+    // even when options.dot is set.
+    const patternStart = pattern.charAt(0) === '.' ? '' // anything
+    // not (start or / followed by . or .. followed by / or end)
+    : options.dot ? '(?!(?:^|\\\/)\\.{1,2}(?:$|\\\/))'
+    : '(?!\\.)'
+
+    const clearStateChar = () => {
+      if (stateChar) {
+        // we had some state-tracking character
+        // that wasn't consumed by this pass.
+        switch (stateChar) {
+          case '*':
+            re += star
+            hasMagic = true
+          break
+          case '?':
+            re += qmark
+            hasMagic = true
+          break
+          default:
+            re += '\\' + stateChar
+          break
+        }
+        this.debug('clearStateChar %j %j', stateChar, re)
+        stateChar = false
+      }
+    }
+
+    for (let i = 0, c; (i < pattern.length) && (c = pattern.charAt(i)); i++) {
+      this.debug('%s\t%s %s %j', pattern, i, re, c)
+
+      // skip over any that are escaped.
+      if (escaping) {
+        /* istanbul ignore next - completely not allowed, even escaped. */
+        if (c === '/') {
+          return false
+        }
+
+        if (reSpecials[c]) {
+          re += '\\'
+        }
+        re += c
+        escaping = false
+        continue
+      }
+
+      switch (c) {
+        /* istanbul ignore next */
+        case '/': {
+          // Should already be path-split by now.
+          return false
+        }
+
+        case '\\':
+          clearStateChar()
+          escaping = true
+        continue
+
+        // the various stateChar values
+        // for the "extglob" stuff.
+        case '?':
+        case '*':
+        case '+':
+        case '@':
+        case '!':
+          this.debug('%s\t%s %s %j <-- stateChar', pattern, i, re, c)
+
+          // all of those are literals inside a class, except that
+          // the glob [!a] means [^a] in regexp
+          if (inClass) {
+            this.debug('  in class')
+            if (c === '!' && i === classStart + 1) c = '^'
+            re += c
+            continue
+          }
+
+          // if we already have a stateChar, then it means
+          // that there was something like ** or +? in there.
+          // Handle the stateChar, then proceed with this one.
+          this.debug('call clearStateChar %j', stateChar)
+          clearStateChar()
+          stateChar = c
+          // if extglob is disabled, then +(asdf|foo) isn't a thing.
+          // just clear the statechar *now*, rather than even diving into
+          // the patternList stuff.
+          if (options.noext) clearStateChar()
+        continue
+
+        case '(':
+          if (inClass) {
+            re += '('
+            continue
+          }
+
+          if (!stateChar) {
+            re += '\\('
+            continue
+          }
+
+          patternListStack.push({
+            type: stateChar,
+            start: i - 1,
+            reStart: re.length,
+            open: plTypes[stateChar].open,
+            close: plTypes[stateChar].close
+          })
+          // negation is (?:(?!js)[^/]*)
+          re += stateChar === '!' ? '(?:(?!(?:' : '(?:'
+          this.debug('plType %j %j', stateChar, re)
+          stateChar = false
+        continue
+
+        case ')':
+          if (inClass || !patternListStack.length) {
+            re += '\\)'
+            continue
+          }
+
+          clearStateChar()
+          hasMagic = true
+          pl = patternListStack.pop()
+          // negation is (?:(?!js)[^/]*)
+          // The others are (?:<pattern>)<type>
+          re += pl.close
+          if (pl.type === '!') {
+            negativeLists.push(pl)
+          }
+          pl.reEnd = re.length
+        continue
+
+        case '|':
+          if (inClass || !patternListStack.length) {
+            re += '\\|'
+            continue
+          }
+
+          clearStateChar()
+          re += '|'
+        continue
+
+        // these are mostly the same in regexp and glob
+        case '[':
+          // swallow any state-tracking char before the [
+          clearStateChar()
+
+          if (inClass) {
+            re += '\\' + c
+            continue
+          }
+
+          inClass = true
+          classStart = i
+          reClassStart = re.length
+          re += c
+        continue
+
+        case ']':
+          //  a right bracket shall lose its special
+          //  meaning and represent itself in
+          //  a bracket expression if it occurs
+          //  first in the list.  -- POSIX.2 2.8.3.2
+          if (i === classStart + 1 || !inClass) {
+            re += '\\' + c
+            continue
+          }
+
+          // handle the case where we left a class open.
+          // "[z-a]" is valid, equivalent to "\[z-a\]"
+          // split where the last [ was, make sure we don't have
+          // an invalid re. if so, re-walk the contents of the
+          // would-be class to re-translate any characters that
+          // were passed through as-is
+          // TODO: It would probably be faster to determine this
+          // without a try/catch and a new RegExp, but it's tricky
+          // to do safely.  For now, this is safe and works.
+          cs = pattern.substring(classStart + 1, i)
+          try {
+            RegExp('[' + cs + ']')
+          } catch (er) {
+            // not a valid class!
+            sp = this.parse(cs, SUBPARSE)
+            re = re.substr(0, reClassStart) + '\\[' + sp[0] + '\\]'
+            hasMagic = hasMagic || sp[1]
+            inClass = false
+            continue
+          }
+
+          // finish up the class.
+          hasMagic = true
+          inClass = false
+          re += c
+        continue
+
+        default:
+          // swallow any state char that wasn't consumed
+          clearStateChar()
+
+          if (reSpecials[c] && !(c === '^' && inClass)) {
+            re += '\\'
+          }
+
+          re += c
+          break
+
+      } // switch
+    } // for
+
+    // handle the case where we left a class open.
+    // "[abc" is valid, equivalent to "\[abc"
+    if (inClass) {
+      // split where the last [ was, and escape it
+      // this is a huge pita.  We now have to re-walk
+      // the contents of the would-be class to re-translate
+      // any characters that were passed through as-is
+      cs = pattern.substr(classStart + 1)
+      sp = this.parse(cs, SUBPARSE)
+      re = re.substr(0, reClassStart) + '\\[' + sp[0]
+      hasMagic = hasMagic || sp[1]
+    }
+
+    // handle the case where we had a +( thing at the *end*
+    // of the pattern.
+    // each pattern list stack adds 3 chars, and we need to go through
+    // and escape any | chars that were passed through as-is for the regexp.
+    // Go through and escape them, taking care not to double-escape any
+    // | chars that were already escaped.
+    for (pl = patternListStack.pop(); pl; pl = patternListStack.pop()) {
+      let tail
+      tail = re.slice(pl.reStart + pl.open.length)
+      this.debug('setting tail', re, pl)
+      // maybe some even number of \, then maybe 1 \, followed by a |
+      tail = tail.replace(/((?:\\{2}){0,64})(\\?)\|/g, (_, $1, $2) => {
+        /* istanbul ignore else - should already be done */
+        if (!$2) {
+          // the | isn't already escaped, so escape it.
+          $2 = '\\'
+        }
+
+        // need to escape all those slashes *again*, without escaping the
+        // one that we need for escaping the | character.  As it works out,
+        // escaping an even number of slashes can be done by simply repeating
+        // it exactly after itself.  That's why this trick works.
+        //
+        // I am sorry that you have to see this.
+        return $1 + $1 + $2 + '|'
+      })
+
+      this.debug('tail=%j\n   %s', tail, tail, pl, re)
+      const t = pl.type === '*' ? star
+        : pl.type === '?' ? qmark
+        : '\\' + pl.type
+
+      hasMagic = true
+      re = re.slice(0, pl.reStart) + t + '\\(' + tail
+    }
+
+    // handle trailing things that only matter at the very end.
+    clearStateChar()
+    if (escaping) {
+      // trailing \\
+      re += '\\\\'
+    }
+
+    // only need to apply the nodot start if the re starts with
+    // something that could conceivably capture a dot
+    const addPatternStart = addPatternStartSet[re.charAt(0)]
+
+    // Hack to work around lack of negative lookbehind in JS
+    // A pattern like: *.!(x).!(y|z) needs to ensure that a name
+    // like 'a.xyz.yz' doesn't match.  So, the first negative
+    // lookahead, has to look ALL the way ahead, to the end of
+    // the pattern.
+    for (let n = negativeLists.length - 1; n > -1; n--) {
+      const nl = negativeLists[n]
+
+      const nlBefore = re.slice(0, nl.reStart)
+      const nlFirst = re.slice(nl.reStart, nl.reEnd - 8)
+      let nlAfter = re.slice(nl.reEnd)
+      const nlLast = re.slice(nl.reEnd - 8, nl.reEnd) + nlAfter
+
+      // Handle nested stuff like *(*.js|!(*.json)), where open parens
+      // mean that we should *not* include the ) in the bit that is considered
+      // "after" the negated section.
+      const openParensBefore = nlBefore.split('(').length - 1
+      let cleanAfter = nlAfter
+      for (let i = 0; i < openParensBefore; i++) {
+        cleanAfter = cleanAfter.replace(/\)[+*?]?/, '')
+      }
+      nlAfter = cleanAfter
+
+      const dollar = nlAfter === '' && isSub !== SUBPARSE ? '$' : ''
+      re = nlBefore + nlFirst + nlAfter + dollar + nlLast
+    }
+
+    // if the re is not "" at this point, then we need to make sure
+    // it doesn't match against an empty path part.
+    // Otherwise a/* will match a/, which it should not.
+    if (re !== '' && hasMagic) {
+      re = '(?=.)' + re
+    }
+
+    if (addPatternStart) {
+      re = patternStart + re
+    }
+
+    // parsing just a piece of a larger pattern.
+    if (isSub === SUBPARSE) {
+      return [re, hasMagic]
+    }
+
+    // skip the regexp for non-magical patterns
+    // unescape anything in it, though, so that it'll be
+    // an exact match against a file etc.
+    if (!hasMagic) {
+      return globUnescape(pattern)
+    }
+
+    const flags = options.nocase ? 'i' : ''
+    try {
+      return Object.assign(new RegExp('^' + re + '$', flags), {
+        _glob: pattern,
+        _src: re,
+      })
+    } catch (er) /* istanbul ignore next - should be impossible */ {
+      // If it was an invalid regular expression, then it can't match
+      // anything.  This trick looks for a character after the end of
+      // the string, which is of course impossible, except in multi-line
+      // mode, but it's not a /m regex.
+      return new RegExp('$.')
+    }
+  }
+
+  makeRe () {
+    if (this.regexp || this.regexp === false) return this.regexp
+
+    // at this point, this.set is a 2d array of partial
+    // pattern strings, or "**".
+    //
+    // It's better to use .match().  This function shouldn't
+    // be used, really, but it's pretty convenient sometimes,
+    // when you just want to work with a regex.
+    const set = this.set
+
+    if (!set.length) {
+      this.regexp = false
+      return this.regexp
+    }
+    const options = this.options
+
+    const twoStar = options.noglobstar ? star
+      : options.dot ? twoStarDot
+      : twoStarNoDot
+    const flags = options.nocase ? 'i' : ''
+
+    // coalesce globstars and regexpify non-globstar patterns
+    // if it's the only item, then we just do one twoStar
+    // if it's the first, and there are more, prepend (\/|twoStar\/)? to next
+    // if it's the last, append (\/twoStar|) to previous
+    // if it's in the middle, append (\/|\/twoStar\/) to previous
+    // then filter out GLOBSTAR symbols
+    let re = set.map(pattern => {
+      pattern = pattern.map(p =>
+        typeof p === 'string' ? regExpEscape(p)
+        : p === GLOBSTAR ? GLOBSTAR
+        : p._src
+      ).reduce((set, p) => {
+        if (!(set[set.length - 1] === GLOBSTAR && p === GLOBSTAR)) {
+          set.push(p)
+        }
+        return set
+      }, [])
+      pattern.forEach((p, i) => {
+        if (p !== GLOBSTAR || pattern[i-1] === GLOBSTAR) {
+          return
+        }
+        if (i === 0) {
+          if (pattern.length > 1) {
+            pattern[i+1] = '(?:\\\/|' + twoStar + '\\\/)?' + pattern[i+1]
+          } else {
+            pattern[i] = twoStar
+          }
+        } else if (i === pattern.length - 1) {
+          pattern[i-1] += '(?:\\\/|' + twoStar + ')?'
+        } else {
+          pattern[i-1] += '(?:\\\/|\\\/' + twoStar + '\\\/)' + pattern[i+1]
+          pattern[i+1] = GLOBSTAR
+        }
+      })
+      return pattern.filter(p => p !== GLOBSTAR).join('/')
+    }).join('|')
+
+    // must match entire pattern
+    // ending in a * or ** will make it less strict.
+    re = '^(?:' + re + ')$'
+
+    // can match anything, as long as it's not this.
+    if (this.negate) re = '^(?!' + re + ').*$'
+
+    try {
+      this.regexp = new RegExp(re, flags)
+    } catch (ex) /* istanbul ignore next - should be impossible */ {
+      this.regexp = false
+    }
+    return this.regexp
+  }
+
+  match (f, partial = this.partial) {
+    this.debug('match', f, this.pattern)
+    // short-circuit in the case of busted things.
+    // comments, etc.
+    if (this.comment) return false
+    if (this.empty) return f === ''
+
+    if (f === '/' && partial) return true
+
+    const options = this.options
+
+    // windows: need to use /, not \
+    if (path.sep !== '/') {
+      f = f.split(path.sep).join('/')
+    }
+
+    // treat the test path as a set of pathparts.
+    f = f.split(slashSplit)
+    this.debug(this.pattern, 'split', f)
+
+    // just ONE of the pattern sets in this.set needs to match
+    // in order for it to be valid.  If negating, then just one
+    // match means that we have failed.
+    // Either way, return on the first hit.
+
+    const set = this.set
+    this.debug(this.pattern, 'set', set)
+
+    // Find the basename of the path by looking for the last non-empty segment
+    let filename
+    for (let i = f.length - 1; i >= 0; i--) {
+      filename = f[i]
+      if (filename) break
+    }
+
+    for (let i = 0; i < set.length; i++) {
+      const pattern = set[i]
+      let file = f
+      if (options.matchBase && pattern.length === 1) {
+        file = [filename]
+      }
+      const hit = this.matchOne(file, pattern, partial)
+      if (hit) {
+        if (options.flipNegate) return true
+        return !this.negate
+      }
+    }
+
+    // didn't get any hits.  this is success if it's a negative
+    // pattern, failure otherwise.
+    if (options.flipNegate) return false
+    return this.negate
+  }
+
+  static defaults (def) {
+    return minimatch.defaults(def).Minimatch
+  }
+}
+
+minimatch.Minimatch = Minimatch
+
+
+/***/ }),
+/* 450 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createDefaultRules = exports.checkValidationErrors = exports.validateGraphQlDocuments = void 0;
+const graphql_1 = __webpack_require__(232);
+const AggregateError_js_1 = __webpack_require__(265);
+async function validateGraphQlDocuments(schema, documentFiles, effectiveRules = createDefaultRules()) {
+    const allFragmentMap = new Map();
+    const documentFileObjectsToValidate = [];
+    for (const documentFile of documentFiles) {
+        if (documentFile.document) {
+            const definitionsToValidate = [];
+            for (const definitionNode of documentFile.document.definitions) {
+                if (definitionNode.kind === graphql_1.Kind.FRAGMENT_DEFINITION) {
+                    allFragmentMap.set(definitionNode.name.value, definitionNode);
+                }
+                else {
+                    definitionsToValidate.push(definitionNode);
+                }
+            }
+            documentFileObjectsToValidate.push({
+                location: documentFile.location,
+                document: {
+                    kind: graphql_1.Kind.DOCUMENT,
+                    definitions: definitionsToValidate,
+                },
+            });
+        }
+    }
+    const allErrors = [];
+    const allFragmentsDocument = {
+        kind: graphql_1.Kind.DOCUMENT,
+        definitions: [...allFragmentMap.values()],
+    };
+    await Promise.all(documentFileObjectsToValidate.map(async (documentFile) => {
+        const documentToValidate = (0, graphql_1.concatAST)([allFragmentsDocument, documentFile.document]);
+        const errors = (0, graphql_1.validate)(schema, documentToValidate, effectiveRules);
+        if (errors.length > 0) {
+            allErrors.push({
+                filePath: documentFile.location,
+                errors,
+            });
+        }
+    }));
+    return allErrors;
+}
+exports.validateGraphQlDocuments = validateGraphQlDocuments;
+function checkValidationErrors(loadDocumentErrors) {
+    if (loadDocumentErrors.length > 0) {
+        const errors = [];
+        for (const loadDocumentError of loadDocumentErrors) {
+            for (const graphQLError of loadDocumentError.errors) {
+                const error = new Error();
+                error.name = 'GraphQLDocumentError';
+                error.message = `${error.name}: ${graphQLError.message}`;
+                error.stack = error.message;
+                if (graphQLError.locations) {
+                    for (const location of graphQLError.locations) {
+                        error.stack += `\n    at ${loadDocumentError.filePath}:${location.line}:${location.column}`;
+                    }
+                }
+                errors.push(error);
+            }
+        }
+        throw new AggregateError_js_1.AggregateError(errors, `GraphQL Document Validation failed with ${errors.length} errors;
+  ${errors.map((error, index) => `Error ${index}: ${error.stack}`).join('\n\n')}`);
+    }
+}
+exports.checkValidationErrors = checkValidationErrors;
+function createDefaultRules() {
+    let ignored = ['NoUnusedFragmentsRule', 'NoUnusedVariablesRule', 'KnownDirectivesRule'];
+    if (graphql_1.versionInfo.major < 15) {
+        ignored = ignored.map(rule => rule.replace(/Rule$/, ''));
+    }
+    return graphql_1.specifiedRules.filter((f) => !ignored.includes(f.name));
+}
+exports.createDefaultRules = createDefaultRules;
+
+
+/***/ }),
 /* 451 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -27798,12 +28900,648 @@ function _default(rawLines, lineNumber, colNumber, opts = {}) {
 /***/ }),
 /* 476 */,
 /* 477 */,
-/* 478 */,
+/* 478 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.makeDirectiveNodes = exports.makeDirectiveNode = exports.makeDeprecatedDirective = exports.astFromEnumValue = exports.astFromInputField = exports.astFromField = exports.astFromScalarType = exports.astFromEnumType = exports.astFromInputObjectType = exports.astFromUnionType = exports.astFromInterfaceType = exports.astFromObjectType = exports.astFromArg = exports.getDeprecatableDirectiveNodes = exports.getDirectiveNodes = exports.astFromDirective = exports.astFromSchema = exports.printSchemaWithDirectives = exports.getDocumentNodeFromSchema = void 0;
+const graphql_1 = __webpack_require__(232);
+const astFromType_js_1 = __webpack_require__(355);
+const get_directives_js_1 = __webpack_require__(721);
+const astFromValueUntyped_js_1 = __webpack_require__(576);
+const helpers_js_1 = __webpack_require__(602);
+const rootTypes_js_1 = __webpack_require__(142);
+function getDocumentNodeFromSchema(schema, options = {}) {
+    const pathToDirectivesInExtensions = options.pathToDirectivesInExtensions;
+    const typesMap = schema.getTypeMap();
+    const schemaNode = astFromSchema(schema, pathToDirectivesInExtensions);
+    const definitions = schemaNode != null ? [schemaNode] : [];
+    const directives = schema.getDirectives();
+    for (const directive of directives) {
+        if ((0, graphql_1.isSpecifiedDirective)(directive)) {
+            continue;
+        }
+        definitions.push(astFromDirective(directive, schema, pathToDirectivesInExtensions));
+    }
+    for (const typeName in typesMap) {
+        const type = typesMap[typeName];
+        const isPredefinedScalar = (0, graphql_1.isSpecifiedScalarType)(type);
+        const isIntrospection = (0, graphql_1.isIntrospectionType)(type);
+        if (isPredefinedScalar || isIntrospection) {
+            continue;
+        }
+        if ((0, graphql_1.isObjectType)(type)) {
+            definitions.push(astFromObjectType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if ((0, graphql_1.isInterfaceType)(type)) {
+            definitions.push(astFromInterfaceType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if ((0, graphql_1.isUnionType)(type)) {
+            definitions.push(astFromUnionType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if ((0, graphql_1.isInputObjectType)(type)) {
+            definitions.push(astFromInputObjectType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if ((0, graphql_1.isEnumType)(type)) {
+            definitions.push(astFromEnumType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if ((0, graphql_1.isScalarType)(type)) {
+            definitions.push(astFromScalarType(type, schema, pathToDirectivesInExtensions));
+        }
+        else {
+            throw new Error(`Unknown type ${type}.`);
+        }
+    }
+    return {
+        kind: graphql_1.Kind.DOCUMENT,
+        definitions,
+    };
+}
+exports.getDocumentNodeFromSchema = getDocumentNodeFromSchema;
+// this approach uses the default schema printer rather than a custom solution, so may be more backwards compatible
+// currently does not allow customization of printSchema options having to do with comments.
+function printSchemaWithDirectives(schema, options = {}) {
+    const documentNode = getDocumentNodeFromSchema(schema, options);
+    return (0, graphql_1.print)(documentNode);
+}
+exports.printSchemaWithDirectives = printSchemaWithDirectives;
+function astFromSchema(schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    const operationTypeMap = new Map([
+        ['query', undefined],
+        ['mutation', undefined],
+        ['subscription', undefined],
+    ]);
+    const nodes = [];
+    if (schema.astNode != null) {
+        nodes.push(schema.astNode);
+    }
+    if (schema.extensionASTNodes != null) {
+        for (const extensionASTNode of schema.extensionASTNodes) {
+            nodes.push(extensionASTNode);
+        }
+    }
+    for (const node of nodes) {
+        if (node.operationTypes) {
+            for (const operationTypeDefinitionNode of node.operationTypes) {
+                operationTypeMap.set(operationTypeDefinitionNode.operation, operationTypeDefinitionNode);
+            }
+        }
+    }
+    const rootTypeMap = (0, rootTypes_js_1.getRootTypeMap)(schema);
+    for (const [operationTypeNode, operationTypeDefinitionNode] of operationTypeMap) {
+        const rootType = rootTypeMap.get(operationTypeNode);
+        if (rootType != null) {
+            const rootTypeAST = (0, astFromType_js_1.astFromType)(rootType);
+            if (operationTypeDefinitionNode != null) {
+                operationTypeDefinitionNode.type = rootTypeAST;
+            }
+            else {
+                operationTypeMap.set(operationTypeNode, {
+                    kind: graphql_1.Kind.OPERATION_TYPE_DEFINITION,
+                    operation: operationTypeNode,
+                    type: rootTypeAST,
+                });
+            }
+        }
+    }
+    const operationTypes = [...operationTypeMap.values()].filter(helpers_js_1.isSome);
+    const directives = getDirectiveNodes(schema, schema, pathToDirectivesInExtensions);
+    if (!operationTypes.length && !directives.length) {
+        return null;
+    }
+    const schemaNode = {
+        kind: operationTypes != null ? graphql_1.Kind.SCHEMA_DEFINITION : graphql_1.Kind.SCHEMA_EXTENSION,
+        operationTypes,
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: directives,
+    };
+    // This code is so weird because it needs to support GraphQL.js 14
+    // In GraphQL.js 14 there is no `description` value on schemaNode
+    schemaNode.description =
+        ((_b = (_a = schema.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : schema.description != null)
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: schema.description,
+                block: true,
+            }
+            : undefined;
+    return schemaNode;
+}
+exports.astFromSchema = astFromSchema;
+function astFromDirective(directive, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c, _d;
+    return {
+        kind: graphql_1.Kind.DIRECTIVE_DEFINITION,
+        description: (_b = (_a = directive.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (directive.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: directive.description,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: directive.name,
+        },
+        arguments: (_c = directive.args) === null || _c === void 0 ? void 0 : _c.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions)),
+        repeatable: directive.isRepeatable,
+        locations: ((_d = directive.locations) === null || _d === void 0 ? void 0 : _d.map(location => ({
+            kind: graphql_1.Kind.NAME,
+            value: location,
+        }))) || [],
+    };
+}
+exports.astFromDirective = astFromDirective;
+function getDirectiveNodes(entity, schema, pathToDirectivesInExtensions) {
+    const directivesInExtensions = (0, get_directives_js_1.getDirectivesInExtensions)(entity, pathToDirectivesInExtensions);
+    let nodes = [];
+    if (entity.astNode != null) {
+        nodes.push(entity.astNode);
+    }
+    if ('extensionASTNodes' in entity && entity.extensionASTNodes != null) {
+        nodes = nodes.concat(entity.extensionASTNodes);
+    }
+    let directives;
+    if (directivesInExtensions != null) {
+        directives = makeDirectiveNodes(schema, directivesInExtensions);
+    }
+    else {
+        directives = [];
+        for (const node of nodes) {
+            if (node.directives) {
+                directives.push(...node.directives);
+            }
+        }
+    }
+    return directives;
+}
+exports.getDirectiveNodes = getDirectiveNodes;
+function getDeprecatableDirectiveNodes(entity, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    let directiveNodesBesidesDeprecated = [];
+    let deprecatedDirectiveNode = null;
+    const directivesInExtensions = (0, get_directives_js_1.getDirectivesInExtensions)(entity, pathToDirectivesInExtensions);
+    let directives;
+    if (directivesInExtensions != null) {
+        directives = makeDirectiveNodes(schema, directivesInExtensions);
+    }
+    else {
+        directives = (_a = entity.astNode) === null || _a === void 0 ? void 0 : _a.directives;
+    }
+    if (directives != null) {
+        directiveNodesBesidesDeprecated = directives.filter(directive => directive.name.value !== 'deprecated');
+        if (entity.deprecationReason != null) {
+            deprecatedDirectiveNode = (_b = directives.filter(directive => directive.name.value === 'deprecated')) === null || _b === void 0 ? void 0 : _b[0];
+        }
+    }
+    if (entity.deprecationReason != null &&
+        deprecatedDirectiveNode == null) {
+        deprecatedDirectiveNode = makeDeprecatedDirective(entity.deprecationReason);
+    }
+    return deprecatedDirectiveNode == null
+        ? directiveNodesBesidesDeprecated
+        : [deprecatedDirectiveNode].concat(directiveNodesBesidesDeprecated);
+}
+exports.getDeprecatableDirectiveNodes = getDeprecatableDirectiveNodes;
+function astFromArg(arg, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c;
+    return {
+        kind: graphql_1.Kind.INPUT_VALUE_DEFINITION,
+        description: (_b = (_a = arg.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (arg.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: arg.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: arg.name,
+        },
+        type: (0, astFromType_js_1.astFromType)(arg.type),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        defaultValue: arg.defaultValue !== undefined ? (_c = (0, graphql_1.astFromValue)(arg.defaultValue, arg.type)) !== null && _c !== void 0 ? _c : undefined : undefined,
+        directives: getDeprecatableDirectiveNodes(arg, schema, pathToDirectivesInExtensions),
+    };
+}
+exports.astFromArg = astFromArg;
+function astFromObjectType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql_1.Kind.OBJECT_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: type.name,
+        },
+        fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
+        interfaces: Object.values(type.getInterfaces()).map(iFace => (0, astFromType_js_1.astFromType)(iFace)),
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+}
+exports.astFromObjectType = astFromObjectType;
+function astFromInterfaceType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    const node = {
+        kind: graphql_1.Kind.INTERFACE_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: type.name,
+        },
+        fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+    if ('getInterfaces' in type) {
+        node.interfaces = Object.values(type.getInterfaces()).map(iFace => (0, astFromType_js_1.astFromType)(iFace));
+    }
+    return node;
+}
+exports.astFromInterfaceType = astFromInterfaceType;
+function astFromUnionType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql_1.Kind.UNION_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: type.name,
+        },
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+        types: type.getTypes().map(type => (0, astFromType_js_1.astFromType)(type)),
+    };
+}
+exports.astFromUnionType = astFromUnionType;
+function astFromInputObjectType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql_1.Kind.INPUT_OBJECT_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: type.name,
+        },
+        fields: Object.values(type.getFields()).map(field => astFromInputField(field, schema, pathToDirectivesInExtensions)),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+}
+exports.astFromInputObjectType = astFromInputObjectType;
+function astFromEnumType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql_1.Kind.ENUM_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: type.name,
+        },
+        values: Object.values(type.getValues()).map(value => astFromEnumValue(value, schema, pathToDirectivesInExtensions)),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+}
+exports.astFromEnumType = astFromEnumType;
+function astFromScalarType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c;
+    const directivesInExtensions = (0, get_directives_js_1.getDirectivesInExtensions)(type, pathToDirectivesInExtensions);
+    const directives = directivesInExtensions
+        ? makeDirectiveNodes(schema, directivesInExtensions)
+        : ((_a = type.astNode) === null || _a === void 0 ? void 0 : _a.directives) || [];
+    const specifiedByValue = (type['specifiedByUrl'] || type['specifiedByURL']);
+    if (specifiedByValue && !directives.some(directiveNode => directiveNode.name.value === 'specifiedBy')) {
+        const specifiedByArgs = {
+            url: specifiedByValue,
+        };
+        directives.push(makeDirectiveNode('specifiedBy', specifiedByArgs));
+    }
+    return {
+        kind: graphql_1.Kind.SCALAR_TYPE_DEFINITION,
+        description: (_c = (_b = type.astNode) === null || _b === void 0 ? void 0 : _b.description) !== null && _c !== void 0 ? _c : (type.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: type.name,
+        },
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: directives,
+    };
+}
+exports.astFromScalarType = astFromScalarType;
+function astFromField(field, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql_1.Kind.FIELD_DEFINITION,
+        description: (_b = (_a = field.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (field.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: field.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: field.name,
+        },
+        arguments: field.args.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions)),
+        type: (0, astFromType_js_1.astFromType)(field.type),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
+    };
+}
+exports.astFromField = astFromField;
+function astFromInputField(field, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c;
+    return {
+        kind: graphql_1.Kind.INPUT_VALUE_DEFINITION,
+        description: (_b = (_a = field.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (field.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: field.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: field.name,
+        },
+        type: (0, astFromType_js_1.astFromType)(field.type),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
+        defaultValue: (_c = (0, graphql_1.astFromValue)(field.defaultValue, field.type)) !== null && _c !== void 0 ? _c : undefined,
+    };
+}
+exports.astFromInputField = astFromInputField;
+function astFromEnumValue(value, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql_1.Kind.ENUM_VALUE_DEFINITION,
+        description: (_b = (_a = value.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (value.description
+            ? {
+                kind: graphql_1.Kind.STRING,
+                value: value.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: value.name,
+        },
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDeprecatableDirectiveNodes(value, schema, pathToDirectivesInExtensions),
+    };
+}
+exports.astFromEnumValue = astFromEnumValue;
+function makeDeprecatedDirective(deprecationReason) {
+    return makeDirectiveNode('deprecated', { reason: deprecationReason }, graphql_1.GraphQLDeprecatedDirective);
+}
+exports.makeDeprecatedDirective = makeDeprecatedDirective;
+function makeDirectiveNode(name, args, directive) {
+    const directiveArguments = [];
+    if (directive != null) {
+        for (const arg of directive.args) {
+            const argName = arg.name;
+            const argValue = args[argName];
+            if (argValue !== undefined) {
+                const value = (0, graphql_1.astFromValue)(argValue, arg.type);
+                if (value) {
+                    directiveArguments.push({
+                        kind: graphql_1.Kind.ARGUMENT,
+                        name: {
+                            kind: graphql_1.Kind.NAME,
+                            value: argName,
+                        },
+                        value,
+                    });
+                }
+            }
+        }
+    }
+    else {
+        for (const argName in args) {
+            const argValue = args[argName];
+            const value = (0, astFromValueUntyped_js_1.astFromValueUntyped)(argValue);
+            if (value) {
+                directiveArguments.push({
+                    kind: graphql_1.Kind.ARGUMENT,
+                    name: {
+                        kind: graphql_1.Kind.NAME,
+                        value: argName,
+                    },
+                    value,
+                });
+            }
+        }
+    }
+    return {
+        kind: graphql_1.Kind.DIRECTIVE,
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: name,
+        },
+        arguments: directiveArguments,
+    };
+}
+exports.makeDirectiveNode = makeDirectiveNode;
+function makeDirectiveNodes(schema, directiveValues) {
+    const directiveNodes = [];
+    for (const directiveName in directiveValues) {
+        const arrayOrSingleValue = directiveValues[directiveName];
+        const directive = schema === null || schema === void 0 ? void 0 : schema.getDirective(directiveName);
+        if (Array.isArray(arrayOrSingleValue)) {
+            for (const value of arrayOrSingleValue) {
+                directiveNodes.push(makeDirectiveNode(directiveName, value, directive));
+            }
+        }
+        else {
+            directiveNodes.push(makeDirectiveNode(directiveName, arrayOrSingleValue, directive));
+        }
+    }
+    return directiveNodes;
+}
+exports.makeDirectiveNodes = makeDirectiveNodes;
+
+
+/***/ }),
 /* 479 */,
 /* 480 */,
-/* 481 */,
+/* 481 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.collectSubFields = exports.collectFields = void 0;
+const memoize_js_1 = __webpack_require__(389);
+const graphql_1 = __webpack_require__(232);
+// Taken from GraphQL-JS v16 for backwards compat
+function collectFields(schema, fragments, variableValues, runtimeType, selectionSet, fields, visitedFragmentNames) {
+    for (const selection of selectionSet.selections) {
+        switch (selection.kind) {
+            case graphql_1.Kind.FIELD: {
+                if (!shouldIncludeNode(variableValues, selection)) {
+                    continue;
+                }
+                const name = getFieldEntryKey(selection);
+                const fieldList = fields.get(name);
+                if (fieldList !== undefined) {
+                    fieldList.push(selection);
+                }
+                else {
+                    fields.set(name, [selection]);
+                }
+                break;
+            }
+            case graphql_1.Kind.INLINE_FRAGMENT: {
+                if (!shouldIncludeNode(variableValues, selection) ||
+                    !doesFragmentConditionMatch(schema, selection, runtimeType)) {
+                    continue;
+                }
+                collectFields(schema, fragments, variableValues, runtimeType, selection.selectionSet, fields, visitedFragmentNames);
+                break;
+            }
+            case graphql_1.Kind.FRAGMENT_SPREAD: {
+                const fragName = selection.name.value;
+                if (visitedFragmentNames.has(fragName) || !shouldIncludeNode(variableValues, selection)) {
+                    continue;
+                }
+                visitedFragmentNames.add(fragName);
+                const fragment = fragments[fragName];
+                if (!fragment || !doesFragmentConditionMatch(schema, fragment, runtimeType)) {
+                    continue;
+                }
+                collectFields(schema, fragments, variableValues, runtimeType, fragment.selectionSet, fields, visitedFragmentNames);
+                break;
+            }
+        }
+    }
+    return fields;
+}
+exports.collectFields = collectFields;
+/**
+ * Determines if a field should be included based on the `@include` and `@skip`
+ * directives, where `@skip` has higher precedence than `@include`.
+ */
+function shouldIncludeNode(variableValues, node) {
+    const skip = (0, graphql_1.getDirectiveValues)(graphql_1.GraphQLSkipDirective, node, variableValues);
+    if ((skip === null || skip === void 0 ? void 0 : skip['if']) === true) {
+        return false;
+    }
+    const include = (0, graphql_1.getDirectiveValues)(graphql_1.GraphQLIncludeDirective, node, variableValues);
+    if ((include === null || include === void 0 ? void 0 : include['if']) === false) {
+        return false;
+    }
+    return true;
+}
+/**
+ * Determines if a fragment is applicable to the given type.
+ */
+function doesFragmentConditionMatch(schema, fragment, type) {
+    const typeConditionNode = fragment.typeCondition;
+    if (!typeConditionNode) {
+        return true;
+    }
+    const conditionalType = (0, graphql_1.typeFromAST)(schema, typeConditionNode);
+    if (conditionalType === type) {
+        return true;
+    }
+    if ((0, graphql_1.isAbstractType)(conditionalType)) {
+        const possibleTypes = schema.getPossibleTypes(conditionalType);
+        return possibleTypes.includes(type);
+    }
+    return false;
+}
+/**
+ * Implements the logic to compute the key of a given field's entry
+ */
+function getFieldEntryKey(node) {
+    return node.alias ? node.alias.value : node.name.value;
+}
+exports.collectSubFields = (0, memoize_js_1.memoize5)(function collectSubFields(schema, fragments, variableValues, type, fieldNodes) {
+    const subFieldNodes = new Map();
+    const visitedFragmentNames = new Set();
+    for (const fieldNode of fieldNodes) {
+        if (fieldNode.selectionSet) {
+            collectFields(schema, fragments, variableValues, type, fieldNode.selectionSet, subFieldNodes, visitedFragmentNames);
+        }
+    }
+    return subFieldNodes;
+});
+
+
+/***/ }),
 /* 482 */,
-/* 483 */,
+/* 483 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fixSchemaAst = void 0;
+const graphql_1 = __webpack_require__(232);
+const print_schema_with_directives_js_1 = __webpack_require__(478);
+function buildFixedSchema(schema, options) {
+    const document = (0, print_schema_with_directives_js_1.getDocumentNodeFromSchema)(schema);
+    return (0, graphql_1.buildASTSchema)(document, {
+        ...(options || {}),
+    });
+}
+function fixSchemaAst(schema, options) {
+    // eslint-disable-next-line no-undef-init
+    let schemaWithValidAst = undefined;
+    if (!schema.astNode || !schema.extensionASTNodes) {
+        schemaWithValidAst = buildFixedSchema(schema, options);
+    }
+    if (!schema.astNode && (schemaWithValidAst === null || schemaWithValidAst === void 0 ? void 0 : schemaWithValidAst.astNode)) {
+        schema.astNode = schemaWithValidAst.astNode;
+    }
+    if (!schema.extensionASTNodes && (schemaWithValidAst === null || schemaWithValidAst === void 0 ? void 0 : schemaWithValidAst.astNode)) {
+        schema.extensionASTNodes = schemaWithValidAst.extensionASTNodes;
+    }
+    return schema;
+}
+exports.fixSchemaAst = fixSchemaAst;
+
+
+/***/ }),
 /* 484 */,
 /* 485 */,
 /* 486 */
@@ -27863,7 +29601,69 @@ function shallowEqual(actual, expected) {
 
 /***/ }),
 /* 488 */,
-/* 489 */,
+/* 489 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withCancel = exports.getAsyncIterableWithCancel = exports.getAsyncIteratorWithCancel = void 0;
+const memoize_js_1 = __webpack_require__(389);
+async function defaultAsyncIteratorReturn(value) {
+    return { value, done: true };
+}
+const proxyMethodFactory = (0, memoize_js_1.memoize2)(function proxyMethodFactory(target, targetMethod) {
+    return function proxyMethod(...args) {
+        return Reflect.apply(targetMethod, target, args);
+    };
+});
+function getAsyncIteratorWithCancel(asyncIterator, onCancel) {
+    return new Proxy(asyncIterator, {
+        has(asyncIterator, prop) {
+            if (prop === 'return') {
+                return true;
+            }
+            return Reflect.has(asyncIterator, prop);
+        },
+        get(asyncIterator, prop, receiver) {
+            const existingPropValue = Reflect.get(asyncIterator, prop, receiver);
+            if (prop === 'return') {
+                const existingReturn = existingPropValue || defaultAsyncIteratorReturn;
+                return async function returnWithCancel(value) {
+                    const returnValue = await onCancel(value);
+                    return Reflect.apply(existingReturn, asyncIterator, [returnValue]);
+                };
+            }
+            else if (typeof existingPropValue === 'function') {
+                return proxyMethodFactory(asyncIterator, existingPropValue);
+            }
+            return existingPropValue;
+        },
+    });
+}
+exports.getAsyncIteratorWithCancel = getAsyncIteratorWithCancel;
+function getAsyncIterableWithCancel(asyncIterable, onCancel) {
+    return new Proxy(asyncIterable, {
+        get(asyncIterable, prop, receiver) {
+            const existingPropValue = Reflect.get(asyncIterable, prop, receiver);
+            if (Symbol.asyncIterator === prop) {
+                return function asyncIteratorFactory() {
+                    const asyncIterator = Reflect.apply(existingPropValue, asyncIterable, []);
+                    return getAsyncIteratorWithCancel(asyncIterator, onCancel);
+                };
+            }
+            else if (typeof existingPropValue === 'function') {
+                return proxyMethodFactory(asyncIterable, existingPropValue);
+            }
+            return existingPropValue;
+        },
+    });
+}
+exports.getAsyncIterableWithCancel = getAsyncIterableWithCancel;
+exports.withCancel = getAsyncIterableWithCancel;
+
+
+/***/ }),
 /* 490 */,
 /* 491 */,
 /* 492 */
@@ -28814,7 +30614,120 @@ function identityFunc(x) {
 /* 521 */,
 /* 522 */,
 /* 523 */,
-/* 524 */,
+/* 524 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+// Taken from graphql-js
+// https://github.com/graphql/graphql-js/blob/main/src/jsutils/inspect.ts
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.inspect = void 0;
+const graphql_1 = __webpack_require__(232);
+const AggregateError_js_1 = __webpack_require__(265);
+const MAX_RECURSIVE_DEPTH = 3;
+/**
+ * Used to print values in error messages.
+ */
+function inspect(value) {
+    return formatValue(value, []);
+}
+exports.inspect = inspect;
+function formatValue(value, seenValues) {
+    switch (typeof value) {
+        case 'string':
+            return JSON.stringify(value);
+        case 'function':
+            return value.name ? `[function ${value.name}]` : '[function]';
+        case 'object':
+            return formatObjectValue(value, seenValues);
+        default:
+            return String(value);
+    }
+}
+function formatError(value) {
+    if (value instanceof graphql_1.GraphQLError) {
+        return value.toString();
+    }
+    return `${value.name}: ${value.message};\n ${value.stack}`;
+}
+function formatObjectValue(value, previouslySeenValues) {
+    if (value === null) {
+        return 'null';
+    }
+    if (value instanceof Error) {
+        if ((0, AggregateError_js_1.isAggregateError)(value)) {
+            return formatError(value) + '\n' + formatArray(value.errors, previouslySeenValues);
+        }
+        return formatError(value);
+    }
+    if (previouslySeenValues.includes(value)) {
+        return '[Circular]';
+    }
+    const seenValues = [...previouslySeenValues, value];
+    if (isJSONable(value)) {
+        const jsonValue = value.toJSON();
+        // check for infinite recursion
+        if (jsonValue !== value) {
+            return typeof jsonValue === 'string' ? jsonValue : formatValue(jsonValue, seenValues);
+        }
+    }
+    else if (Array.isArray(value)) {
+        return formatArray(value, seenValues);
+    }
+    return formatObject(value, seenValues);
+}
+function isJSONable(value) {
+    return typeof value.toJSON === 'function';
+}
+function formatObject(object, seenValues) {
+    const entries = Object.entries(object);
+    if (entries.length === 0) {
+        return '{}';
+    }
+    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+        return '[' + getObjectTag(object) + ']';
+    }
+    const properties = entries.map(([key, value]) => key + ': ' + formatValue(value, seenValues));
+    return '{ ' + properties.join(', ') + ' }';
+}
+function formatArray(array, seenValues) {
+    if (array.length === 0) {
+        return '[]';
+    }
+    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+        return '[Array]';
+    }
+    const len = array.length;
+    const remaining = array.length;
+    const items = [];
+    for (let i = 0; i < len; ++i) {
+        items.push(formatValue(array[i], seenValues));
+    }
+    if (remaining === 1) {
+        items.push('... 1 more item');
+    }
+    else if (remaining > 1) {
+        items.push(`... ${remaining} more items`);
+    }
+    return '[' + items.join(', ') + ']';
+}
+function getObjectTag(object) {
+    const tag = Object.prototype.toString
+        .call(object)
+        .replace(/^\[object /, '')
+        .replace(/]$/, '');
+    if (tag === 'Object' && typeof object.constructor === 'function') {
+        const name = object.constructor.name;
+        if (typeof name === 'string' && name !== '') {
+            return name;
+        }
+    }
+    return tag;
+}
+
+
+/***/ }),
 /* 525 */,
 /* 526 */,
 /* 527 */,
@@ -28945,7 +30858,41 @@ function maybeCloneComments(comments, deep, withoutLoc) {
 /***/ }),
 /* 534 */,
 /* 535 */,
-/* 536 */,
+/* 536 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeUnion = void 0;
+const graphql_1 = __webpack_require__(232);
+const directives_js_1 = __webpack_require__(154);
+const merge_named_type_array_js_1 = __webpack_require__(242);
+function mergeUnion(first, second, config) {
+    if (second) {
+        return {
+            name: first.name,
+            description: first['description'] || second['description'],
+            // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+            directives: (0, directives_js_1.mergeDirectives)(first.directives, second.directives, config),
+            kind: (config === null || config === void 0 ? void 0 : config.convertExtensions) || first.kind === 'UnionTypeDefinition' || second.kind === 'UnionTypeDefinition'
+                ? graphql_1.Kind.UNION_TYPE_DEFINITION
+                : graphql_1.Kind.UNION_TYPE_EXTENSION,
+            loc: first.loc,
+            types: (0, merge_named_type_array_js_1.mergeNamedTypeArray)(first.types, second.types, config),
+        };
+    }
+    return (config === null || config === void 0 ? void 0 : config.convertExtensions)
+        ? {
+            ...first,
+            kind: graphql_1.Kind.UNION_TYPE_DEFINITION,
+        }
+        : first;
+}
+exports.mergeUnion = mergeUnion;
+
+
+/***/ }),
 /* 537 */,
 /* 538 */,
 /* 539 */
@@ -29494,7 +31441,80 @@ exports.HttpClient = HttpClient;
 /***/ }),
 /* 540 */,
 /* 541 */,
-/* 542 */,
+/* 542 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeResolvers = void 0;
+const utils_1 = __webpack_require__(971);
+/**
+ * Deep merges multiple resolver definition objects into a single definition.
+ * @param resolversDefinitions Resolver definitions to be merged
+ * @param options Additional options
+ *
+ * ```js
+ * const { mergeResolvers } = require('@graphql-tools/merge');
+ * const clientResolver = require('./clientResolver');
+ * const productResolver = require('./productResolver');
+ *
+ * const resolvers = mergeResolvers([
+ *  clientResolver,
+ *  productResolver,
+ * ]);
+ * ```
+ *
+ * If you don't want to manually create the array of resolver objects, you can
+ * also use this function along with loadFiles:
+ *
+ * ```js
+ * const path = require('path');
+ * const { mergeResolvers } = require('@graphql-tools/merge');
+ * const { loadFilesSync } = require('@graphql-tools/load-files');
+ *
+ * const resolversArray = loadFilesSync(path.join(__dirname, './resolvers'));
+ *
+ * const resolvers = mergeResolvers(resolversArray)
+ * ```
+ */
+function mergeResolvers(resolversDefinitions, options) {
+    if (!resolversDefinitions || (Array.isArray(resolversDefinitions) && resolversDefinitions.length === 0)) {
+        return {};
+    }
+    if (!Array.isArray(resolversDefinitions)) {
+        return resolversDefinitions;
+    }
+    if (resolversDefinitions.length === 1) {
+        return resolversDefinitions[0] || {};
+    }
+    const resolvers = new Array();
+    for (let resolversDefinition of resolversDefinitions) {
+        if (Array.isArray(resolversDefinition)) {
+            resolversDefinition = mergeResolvers(resolversDefinition);
+        }
+        if (typeof resolversDefinition === 'object' && resolversDefinition) {
+            resolvers.push(resolversDefinition);
+        }
+    }
+    const result = (0, utils_1.mergeDeep)(resolvers, true);
+    if (options === null || options === void 0 ? void 0 : options.exclusions) {
+        for (const exclusion of options.exclusions) {
+            const [typeName, fieldName] = exclusion.split('.');
+            if (!fieldName || fieldName === '*') {
+                delete result[typeName];
+            }
+            else if (result[typeName]) {
+                delete result[typeName][fieldName];
+            }
+        }
+    }
+    return result;
+}
+exports.mergeResolvers = mergeResolvers;
+
+
+/***/ }),
 /* 543 */,
 /* 544 */,
 /* 545 */,
@@ -29787,7 +31807,42 @@ exports.markdownSummary = new MarkdownSummary();
 /***/ }),
 /* 549 */,
 /* 550 */,
-/* 551 */,
+/* 551 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.forEachDefaultValue = void 0;
+const graphql_1 = __webpack_require__(232);
+function forEachDefaultValue(schema, fn) {
+    const typeMap = schema.getTypeMap();
+    for (const typeName in typeMap) {
+        const type = typeMap[typeName];
+        if (!(0, graphql_1.getNamedType)(type).name.startsWith('__')) {
+            if ((0, graphql_1.isObjectType)(type)) {
+                const fields = type.getFields();
+                for (const fieldName in fields) {
+                    const field = fields[fieldName];
+                    for (const arg of field.args) {
+                        arg.defaultValue = fn(arg.type, arg.defaultValue);
+                    }
+                }
+            }
+            else if ((0, graphql_1.isInputObjectType)(type)) {
+                const fields = type.getFields();
+                for (const fieldName in fields) {
+                    const field = fields[fieldName];
+                    field.defaultValue = fn(field.type, field.defaultValue);
+                }
+            }
+        }
+    }
+}
+exports.forEachDefaultValue = forEachDefaultValue;
+
+
+/***/ }),
 /* 552 */,
 /* 553 */,
 /* 554 */
@@ -30784,7 +32839,69 @@ class PathHoister {
 exports.default = PathHoister;
 
 /***/ }),
-/* 564 */,
+/* 564 */
+/***/ (function(module) {
+
+/**
+ * Compose a function from a series of other functions applied left-to-right
+ */
+const asyncFlow =
+  (...fns) =>
+  (input) =>
+    fns.reduce(
+      (chain, func) => chain.then(async (...args) => func(...args)),
+      Promise.resolve(input)
+    );
+
+/**
+ * Apply a series of asynchronous OR synchronous functions to an input. Always returns a Promise.
+ */
+const asyncPipe = (input, ...fns) => asyncFlow(...fns)(input);
+
+/**
+ * Apply an asynchronous OR synchronous function to every item in an array. Always returns a Promise.
+ */
+const asyncMap = (fn) => (arr) =>
+  Promise.all(arr.map(async (itm) => asyncPipe(itm, fn)));
+
+/**
+ * Apply a asynchronous OR synchronous predicate to filter out items in an array. Always returns a Promise.
+ */
+const asyncFilter = (fn) => (arr) =>
+  Promise.all(arr.map(fn)).then((results) => arr.filter((v, i) => results[i]));
+
+/**
+ * Sets a value to an object's property
+ */
+const setIn = (obj, prop) => (val) => ({ ...obj, [prop]: val });
+
+/**
+ * Applicative Do: Takes an object where each key value is a promise and returns an
+ * object with the same keys where each value is the resolution of the promise.
+ */
+const ado = async (promiseObject) => {
+  const originalKeys = Object.keys(promiseObject);
+  const promises = Object.values(promiseObject);
+  const resolutions = await Promise.all(promises);
+  return originalKeys.reduce((returnObj, key, keyIndex) => {
+    return {
+      ...returnObj,
+      [key]: resolutions[keyIndex],
+    };
+  }, {});
+};
+
+module.exports = {
+  ado,
+  asyncFlow,
+  asyncPipe,
+  asyncMap,
+  setIn,
+  asyncFilter,
+};
+
+
+/***/ }),
 /* 565 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -32440,7 +34557,39 @@ defineType("StaticBlock", {
 });
 
 /***/ }),
-/* 566 */,
+/* 566 */
+/***/ (function(module) {
+
+if (typeof Object.create === 'function') {
+  // implementation from standard node.js 'util' module
+  module.exports = function inherits(ctor, superCtor) {
+    if (superCtor) {
+      ctor.super_ = superCtor
+      ctor.prototype = Object.create(superCtor.prototype, {
+        constructor: {
+          value: ctor,
+          enumerable: false,
+          writable: true,
+          configurable: true
+        }
+      })
+    }
+  };
+} else {
+  // old school shim for old browsers
+  module.exports = function inherits(ctor, superCtor) {
+    if (superCtor) {
+      ctor.super_ = superCtor
+      var TempCtor = function () {}
+      TempCtor.prototype = superCtor.prototype
+      ctor.prototype = new TempCtor()
+      ctor.prototype.constructor = ctor
+    }
+  }
+}
+
+
+/***/ }),
 /* 567 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -32830,7 +34979,91 @@ function stripIgnoredCharacters(source) {
 
 
 /***/ }),
-/* 576 */,
+/* 576 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.astFromValueUntyped = void 0;
+const graphql_1 = __webpack_require__(232);
+/**
+ * Produces a GraphQL Value AST given a JavaScript object.
+ * Function will match JavaScript/JSON values to GraphQL AST schema format
+ * by using the following mapping.
+ *
+ * | JSON Value    | GraphQL Value        |
+ * | ------------- | -------------------- |
+ * | Object        | Input Object         |
+ * | Array         | List                 |
+ * | Boolean       | Boolean              |
+ * | String        | String               |
+ * | Number        | Int / Float          |
+ * | null          | NullValue            |
+ *
+ */
+function astFromValueUntyped(value) {
+    // only explicit null, not undefined, NaN
+    if (value === null) {
+        return { kind: graphql_1.Kind.NULL };
+    }
+    // undefined
+    if (value === undefined) {
+        return null;
+    }
+    // Convert JavaScript array to GraphQL list. If the GraphQLType is a list, but
+    // the value is not an array, convert the value using the list's item type.
+    if (Array.isArray(value)) {
+        const valuesNodes = [];
+        for (const item of value) {
+            const itemNode = astFromValueUntyped(item);
+            if (itemNode != null) {
+                valuesNodes.push(itemNode);
+            }
+        }
+        return { kind: graphql_1.Kind.LIST, values: valuesNodes };
+    }
+    if (typeof value === 'object') {
+        const fieldNodes = [];
+        for (const fieldName in value) {
+            const fieldValue = value[fieldName];
+            const ast = astFromValueUntyped(fieldValue);
+            if (ast) {
+                fieldNodes.push({
+                    kind: graphql_1.Kind.OBJECT_FIELD,
+                    name: { kind: graphql_1.Kind.NAME, value: fieldName },
+                    value: ast,
+                });
+            }
+        }
+        return { kind: graphql_1.Kind.OBJECT, fields: fieldNodes };
+    }
+    // Others serialize based on their corresponding JavaScript scalar types.
+    if (typeof value === 'boolean') {
+        return { kind: graphql_1.Kind.BOOLEAN, value };
+    }
+    // JavaScript numbers can be Int or Float values.
+    if (typeof value === 'number' && isFinite(value)) {
+        const stringNum = String(value);
+        return integerStringRegExp.test(stringNum)
+            ? { kind: graphql_1.Kind.INT, value: stringNum }
+            : { kind: graphql_1.Kind.FLOAT, value: stringNum };
+    }
+    if (typeof value === 'string') {
+        return { kind: graphql_1.Kind.STRING, value };
+    }
+    throw new TypeError(`Cannot convert value to AST: ${value}.`);
+}
+exports.astFromValueUntyped = astFromValueUntyped;
+/**
+ * IntValue:
+ *   - NegativeSign? 0
+ *   - NegativeSign? NonZeroDigit ( Digit+ )?
+ */
+const integerStringRegExp = /^-?(?:0|[1-9][0-9]*)$/;
+
+
+/***/ }),
 /* 577 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -33907,7 +36140,89 @@ function getFragmentType(context, name) {
 
 
 /***/ }),
-/* 602 */,
+/* 602 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.assertSome = exports.isSome = exports.compareNodes = exports.nodeToString = exports.compareStrings = exports.isValidPath = exports.isDocumentString = exports.asArray = void 0;
+const graphql_1 = __webpack_require__(232);
+const asArray = (fns) => (Array.isArray(fns) ? fns : fns ? [fns] : []);
+exports.asArray = asArray;
+const invalidDocRegex = /\.[a-z0-9]+$/i;
+function isDocumentString(str) {
+    if (typeof str !== 'string') {
+        return false;
+    }
+    // XXX: is-valid-path or is-glob treat SDL as a valid path
+    // (`scalar Date` for example)
+    // this why checking the extension is fast enough
+    // and prevent from parsing the string in order to find out
+    // if the string is a SDL
+    if (invalidDocRegex.test(str)) {
+        return false;
+    }
+    try {
+        (0, graphql_1.parse)(str);
+        return true;
+    }
+    catch (e) { }
+    return false;
+}
+exports.isDocumentString = isDocumentString;
+const invalidPathRegex = /[‘“!%^<=>`]/;
+function isValidPath(str) {
+    return typeof str === 'string' && !invalidPathRegex.test(str);
+}
+exports.isValidPath = isValidPath;
+function compareStrings(a, b) {
+    if (String(a) < String(b)) {
+        return -1;
+    }
+    if (String(a) > String(b)) {
+        return 1;
+    }
+    return 0;
+}
+exports.compareStrings = compareStrings;
+function nodeToString(a) {
+    var _a, _b;
+    let name;
+    if ('alias' in a) {
+        name = (_a = a.alias) === null || _a === void 0 ? void 0 : _a.value;
+    }
+    if (name == null && 'name' in a) {
+        name = (_b = a.name) === null || _b === void 0 ? void 0 : _b.value;
+    }
+    if (name == null) {
+        name = a.kind;
+    }
+    return name;
+}
+exports.nodeToString = nodeToString;
+function compareNodes(a, b, customFn) {
+    const aStr = nodeToString(a);
+    const bStr = nodeToString(b);
+    if (typeof customFn === 'function') {
+        return customFn(aStr, bStr);
+    }
+    return compareStrings(aStr, bStr);
+}
+exports.compareNodes = compareNodes;
+function isSome(input) {
+    return input != null;
+}
+exports.isSome = isSome;
+function assertSome(input, message = 'Value should be something') {
+    if (input == null) {
+        throw new Error(message);
+    }
+}
+exports.assertSome = assertSome;
+
+
+/***/ }),
 /* 603 */
 /***/ (function(__unusedmodule, exports) {
 
@@ -50427,7 +52742,49 @@ exports.tokTypes = tokTypes;
 
 
 /***/ }),
-/* 604 */,
+/* 604 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeType = void 0;
+const graphql_1 = __webpack_require__(232);
+const fields_js_1 = __webpack_require__(663);
+const directives_js_1 = __webpack_require__(154);
+const merge_named_type_array_js_1 = __webpack_require__(242);
+function mergeType(node, existingNode, config) {
+    if (existingNode) {
+        try {
+            return {
+                name: node.name,
+                description: node['description'] || existingNode['description'],
+                kind: (config === null || config === void 0 ? void 0 : config.convertExtensions) ||
+                    node.kind === 'ObjectTypeDefinition' ||
+                    existingNode.kind === 'ObjectTypeDefinition'
+                    ? 'ObjectTypeDefinition'
+                    : 'ObjectTypeExtension',
+                loc: node.loc,
+                fields: (0, fields_js_1.mergeFields)(node, node.fields, existingNode.fields, config),
+                directives: (0, directives_js_1.mergeDirectives)(node.directives, existingNode.directives, config),
+                interfaces: (0, merge_named_type_array_js_1.mergeNamedTypeArray)(node.interfaces, existingNode.interfaces, config),
+            };
+        }
+        catch (e) {
+            throw new Error(`Unable to merge GraphQL type "${node.name.value}": ${e.message}`);
+        }
+    }
+    return (config === null || config === void 0 ? void 0 : config.convertExtensions)
+        ? {
+            ...node,
+            kind: graphql_1.Kind.OBJECT_TYPE_DEFINITION,
+        }
+        : node;
+}
+exports.mergeType = mergeType;
+
+
+/***/ }),
 /* 605 */
 /***/ (function(module) {
 
@@ -50716,7 +53073,75 @@ function valueToNode(value) {
 
 /***/ }),
 /* 620 */,
-/* 621 */,
+/* 621 */
+/***/ (function(module) {
+
+"use strict";
+
+module.exports = balanced;
+function balanced(a, b, str) {
+  if (a instanceof RegExp) a = maybeMatch(a, str);
+  if (b instanceof RegExp) b = maybeMatch(b, str);
+
+  var r = range(a, b, str);
+
+  return r && {
+    start: r[0],
+    end: r[1],
+    pre: str.slice(0, r[0]),
+    body: str.slice(r[0] + a.length, r[1]),
+    post: str.slice(r[1] + b.length)
+  };
+}
+
+function maybeMatch(reg, str) {
+  var m = str.match(reg);
+  return m ? m[0] : null;
+}
+
+balanced.range = range;
+function range(a, b, str) {
+  var begs, beg, left, right, result;
+  var ai = str.indexOf(a);
+  var bi = str.indexOf(b, ai + 1);
+  var i = ai;
+
+  if (ai >= 0 && bi > 0) {
+    if(a===b) {
+      return [ai, bi];
+    }
+    begs = [];
+    left = str.length;
+
+    while (i >= 0 && !result) {
+      if (i == ai) {
+        begs.push(i);
+        ai = str.indexOf(a, i + 1);
+      } else if (begs.length == 1) {
+        result = [ begs.pop(), bi ];
+      } else {
+        beg = begs.pop();
+        if (beg < left) {
+          left = beg;
+          right = bi;
+        }
+
+        bi = str.indexOf(b, i + 1);
+      }
+
+      i = ai < bi && ai >= 0 ? ai : bi;
+    }
+
+    if (begs.length) {
+      result = [ left, right ];
+    }
+  }
+
+  return result;
+}
+
+
+/***/ }),
 /* 622 */
 /***/ (function(module) {
 
@@ -51641,7 +54066,63 @@ convert.rgb.gray = function (rgb) {
 
 
 /***/ }),
-/* 627 */,
+/* 627 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.applyExtensions = exports.mergeExtensions = exports.extractExtensionsFromSchema = void 0;
+const utils_1 = __webpack_require__(971);
+var utils_2 = __webpack_require__(971);
+Object.defineProperty(exports, "extractExtensionsFromSchema", { enumerable: true, get: function () { return utils_2.extractExtensionsFromSchema; } });
+function mergeExtensions(extensions) {
+    return (0, utils_1.mergeDeep)(extensions);
+}
+exports.mergeExtensions = mergeExtensions;
+function applyExtensionObject(obj, extensions) {
+    if (!obj) {
+        return;
+    }
+    obj.extensions = (0, utils_1.mergeDeep)([obj.extensions || {}, extensions || {}]);
+}
+function applyExtensions(schema, extensions) {
+    applyExtensionObject(schema, extensions.schemaExtensions);
+    for (const [typeName, data] of Object.entries(extensions.types || {})) {
+        const type = schema.getType(typeName);
+        if (type) {
+            applyExtensionObject(type, data.extensions);
+            if (data.type === 'object' || data.type === 'interface') {
+                for (const [fieldName, fieldData] of Object.entries(data.fields)) {
+                    const field = type.getFields()[fieldName];
+                    if (field) {
+                        applyExtensionObject(field, fieldData.extensions);
+                        for (const [arg, argData] of Object.entries(fieldData.arguments)) {
+                            applyExtensionObject(field.args.find(a => a.name === arg), argData);
+                        }
+                    }
+                }
+            }
+            else if (data.type === 'input') {
+                for (const [fieldName, fieldData] of Object.entries(data.fields)) {
+                    const field = type.getFields()[fieldName];
+                    applyExtensionObject(field, fieldData.extensions);
+                }
+            }
+            else if (data.type === 'enum') {
+                for (const [valueName, valueData] of Object.entries(data.values)) {
+                    const value = type.getValue(valueName);
+                    applyExtensionObject(value, valueData);
+                }
+            }
+        }
+    }
+    return schema;
+}
+exports.applyExtensions = applyExtensions;
+
+
+/***/ }),
 /* 628 */,
 /* 629 */,
 /* 630 */,
@@ -51653,7 +54134,66 @@ module.exports = require("net");
 /***/ }),
 /* 632 */,
 /* 633 */,
-/* 634 */,
+/* 634 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+var wrappy = __webpack_require__(11)
+var reqs = Object.create(null)
+var once = __webpack_require__(49)
+
+module.exports = wrappy(inflight)
+
+function inflight (key, cb) {
+  if (reqs[key]) {
+    reqs[key].push(cb)
+    return null
+  } else {
+    reqs[key] = [cb]
+    return makeres(key)
+  }
+}
+
+function makeres (key) {
+  return once(function RES () {
+    var cbs = reqs[key]
+    var len = cbs.length
+    var args = slice(arguments)
+
+    // XXX It's somewhat ambiguous whether a new callback added in this
+    // pass should be queued for later execution if something in the
+    // list of callbacks throws, or if it should just be discarded.
+    // However, it's such an edge case that it hardly matters, and either
+    // choice is likely as surprising as the other.
+    // As it happens, we do go ahead and schedule it for later execution.
+    try {
+      for (var i = 0; i < len; i++) {
+        cbs[i].apply(null, args)
+      }
+    } finally {
+      if (cbs.length > len) {
+        // added more in the interim.
+        // de-zalgo, just in case, but don't call again.
+        cbs.splice(0, len)
+        process.nextTick(function () {
+          RES.apply(null, args)
+        })
+      } else {
+        delete reqs[key]
+      }
+    }
+  })
+}
+
+function slice (args) {
+  var length = args.length
+  var array = []
+
+  for (var i = 0; i < length; i++) array[i] = args[i]
+  return array
+}
+
+
+/***/ }),
 /* 635 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -53070,7 +55610,85 @@ function valueFromASTUntyped(valueNode, variables) {
 
 
 /***/ }),
-/* 646 */,
+/* 646 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeGraphQLNodes = exports.isNamedDefinitionNode = exports.schemaDefSymbol = void 0;
+const graphql_1 = __webpack_require__(232);
+const type_js_1 = __webpack_require__(604);
+const enum_js_1 = __webpack_require__(895);
+const scalar_js_1 = __webpack_require__(294);
+const union_js_1 = __webpack_require__(536);
+const input_type_js_1 = __webpack_require__(751);
+const interface_js_1 = __webpack_require__(18);
+const directives_js_1 = __webpack_require__(154);
+const schema_def_js_1 = __webpack_require__(23);
+const utils_1 = __webpack_require__(971);
+exports.schemaDefSymbol = 'SCHEMA_DEF_SYMBOL';
+function isNamedDefinitionNode(definitionNode) {
+    return 'name' in definitionNode;
+}
+exports.isNamedDefinitionNode = isNamedDefinitionNode;
+function mergeGraphQLNodes(nodes, config) {
+    var _a, _b, _c;
+    const mergedResultMap = {};
+    for (const nodeDefinition of nodes) {
+        if (isNamedDefinitionNode(nodeDefinition)) {
+            const name = (_a = nodeDefinition.name) === null || _a === void 0 ? void 0 : _a.value;
+            if (config === null || config === void 0 ? void 0 : config.commentDescriptions) {
+                (0, utils_1.collectComment)(nodeDefinition);
+            }
+            if (name == null) {
+                continue;
+            }
+            if (((_b = config === null || config === void 0 ? void 0 : config.exclusions) === null || _b === void 0 ? void 0 : _b.includes(name + '.*')) || ((_c = config === null || config === void 0 ? void 0 : config.exclusions) === null || _c === void 0 ? void 0 : _c.includes(name))) {
+                delete mergedResultMap[name];
+            }
+            else {
+                switch (nodeDefinition.kind) {
+                    case graphql_1.Kind.OBJECT_TYPE_DEFINITION:
+                    case graphql_1.Kind.OBJECT_TYPE_EXTENSION:
+                        mergedResultMap[name] = (0, type_js_1.mergeType)(nodeDefinition, mergedResultMap[name], config);
+                        break;
+                    case graphql_1.Kind.ENUM_TYPE_DEFINITION:
+                    case graphql_1.Kind.ENUM_TYPE_EXTENSION:
+                        mergedResultMap[name] = (0, enum_js_1.mergeEnum)(nodeDefinition, mergedResultMap[name], config);
+                        break;
+                    case graphql_1.Kind.UNION_TYPE_DEFINITION:
+                    case graphql_1.Kind.UNION_TYPE_EXTENSION:
+                        mergedResultMap[name] = (0, union_js_1.mergeUnion)(nodeDefinition, mergedResultMap[name], config);
+                        break;
+                    case graphql_1.Kind.SCALAR_TYPE_DEFINITION:
+                    case graphql_1.Kind.SCALAR_TYPE_EXTENSION:
+                        mergedResultMap[name] = (0, scalar_js_1.mergeScalar)(nodeDefinition, mergedResultMap[name], config);
+                        break;
+                    case graphql_1.Kind.INPUT_OBJECT_TYPE_DEFINITION:
+                    case graphql_1.Kind.INPUT_OBJECT_TYPE_EXTENSION:
+                        mergedResultMap[name] = (0, input_type_js_1.mergeInputType)(nodeDefinition, mergedResultMap[name], config);
+                        break;
+                    case graphql_1.Kind.INTERFACE_TYPE_DEFINITION:
+                    case graphql_1.Kind.INTERFACE_TYPE_EXTENSION:
+                        mergedResultMap[name] = (0, interface_js_1.mergeInterface)(nodeDefinition, mergedResultMap[name], config);
+                        break;
+                    case graphql_1.Kind.DIRECTIVE_DEFINITION:
+                        mergedResultMap[name] = (0, directives_js_1.mergeDirective)(nodeDefinition, mergedResultMap[name]);
+                        break;
+                }
+            }
+        }
+        else if (nodeDefinition.kind === graphql_1.Kind.SCHEMA_DEFINITION || nodeDefinition.kind === graphql_1.Kind.SCHEMA_EXTENSION) {
+            mergedResultMap[exports.schemaDefSymbol] = (0, schema_def_js_1.mergeSchemaDefs)(nodeDefinition, mergedResultMap[exports.schemaDefSymbol], config);
+        }
+    }
+    return mergedResultMap;
+}
+exports.mergeGraphQLNodes = mergeGraphQLNodes;
+
+
+/***/ }),
 /* 647 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -54006,8 +56624,4455 @@ function ModuleExpression(node) {
 /* 660 */,
 /* 661 */,
 /* 662 */,
-/* 663 */,
-/* 664 */,
+/* 663 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeFields = void 0;
+const utils_js_1 = __webpack_require__(706);
+const directives_js_1 = __webpack_require__(154);
+const utils_1 = __webpack_require__(971);
+const arguments_js_1 = __webpack_require__(125);
+function fieldAlreadyExists(fieldsArr, otherField, config) {
+    const result = fieldsArr.find(field => field.name.value === otherField.name.value);
+    if (result && !(config === null || config === void 0 ? void 0 : config.ignoreFieldConflicts)) {
+        const t1 = (0, utils_js_1.extractType)(result.type);
+        const t2 = (0, utils_js_1.extractType)(otherField.type);
+        if (t1.name.value !== t2.name.value) {
+            throw new Error(`Field "${otherField.name.value}" already defined with a different type. Declared as "${t1.name.value}", but you tried to override with "${t2.name.value}"`);
+        }
+    }
+    return !!result;
+}
+function mergeFields(type, f1, f2, config) {
+    const result = [];
+    if (f2 != null) {
+        result.push(...f2);
+    }
+    if (f1 != null) {
+        for (const field of f1) {
+            if (fieldAlreadyExists(result, field, config)) {
+                const existing = result.find((f) => f.name.value === field.name.value);
+                if (!(config === null || config === void 0 ? void 0 : config.ignoreFieldConflicts)) {
+                    if (config === null || config === void 0 ? void 0 : config.throwOnConflict) {
+                        preventConflicts(type, existing, field, false);
+                    }
+                    else {
+                        preventConflicts(type, existing, field, true);
+                    }
+                    if ((0, utils_js_1.isNonNullTypeNode)(field.type) && !(0, utils_js_1.isNonNullTypeNode)(existing.type)) {
+                        existing.type = field.type;
+                    }
+                }
+                existing.arguments = (0, arguments_js_1.mergeArguments)(field['arguments'] || [], existing.arguments || [], config);
+                existing.directives = (0, directives_js_1.mergeDirectives)(field.directives, existing.directives, config);
+                existing.description = field.description || existing.description;
+            }
+            else {
+                result.push(field);
+            }
+        }
+    }
+    if (config && config.sort) {
+        result.sort(utils_1.compareNodes);
+    }
+    if (config && config.exclusions) {
+        const exclusions = config.exclusions;
+        return result.filter(field => !exclusions.includes(`${type.name.value}.${field.name.value}`));
+    }
+    return result;
+}
+exports.mergeFields = mergeFields;
+function preventConflicts(type, a, b, ignoreNullability = false) {
+    const aType = (0, utils_js_1.printTypeNode)(a.type);
+    const bType = (0, utils_js_1.printTypeNode)(b.type);
+    if (aType !== bType && !safeChangeForFieldType(a.type, b.type, ignoreNullability)) {
+        throw new Error(`Field '${type.name.value}.${a.name.value}' changed type from '${aType}' to '${bType}'`);
+    }
+}
+function safeChangeForFieldType(oldType, newType, ignoreNullability = false) {
+    // both are named
+    if (!(0, utils_js_1.isWrappingTypeNode)(oldType) && !(0, utils_js_1.isWrappingTypeNode)(newType)) {
+        return oldType.toString() === newType.toString();
+    }
+    // new is non-null
+    if ((0, utils_js_1.isNonNullTypeNode)(newType)) {
+        const ofType = (0, utils_js_1.isNonNullTypeNode)(oldType) ? oldType.type : oldType;
+        return safeChangeForFieldType(ofType, newType.type);
+    }
+    // old is non-null
+    if ((0, utils_js_1.isNonNullTypeNode)(oldType)) {
+        return safeChangeForFieldType(newType, oldType, ignoreNullability);
+    }
+    // old is list
+    if ((0, utils_js_1.isListTypeNode)(oldType)) {
+        return (((0, utils_js_1.isListTypeNode)(newType) && safeChangeForFieldType(oldType.type, newType.type)) ||
+            ((0, utils_js_1.isNonNullTypeNode)(newType) && safeChangeForFieldType(oldType, newType['type'])));
+    }
+    return false;
+}
+
+
+/***/ }),
+/* 664 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const graphql = __webpack_require__(232);
+
+const asArray = (fns) => (Array.isArray(fns) ? fns : fns ? [fns] : []);
+const invalidDocRegex = /\.[a-z0-9]+$/i;
+function isDocumentString(str) {
+    if (typeof str !== 'string') {
+        return false;
+    }
+    // XXX: is-valid-path or is-glob treat SDL as a valid path
+    // (`scalar Date` for example)
+    // this why checking the extension is fast enough
+    // and prevent from parsing the string in order to find out
+    // if the string is a SDL
+    if (invalidDocRegex.test(str)) {
+        return false;
+    }
+    try {
+        graphql.parse(str);
+        return true;
+    }
+    catch (e) { }
+    return false;
+}
+const invalidPathRegex = /[‘“!%&^<=>`]/;
+function isValidPath(str) {
+    return typeof str === 'string' && !invalidPathRegex.test(str);
+}
+function compareStrings(a, b) {
+    if (String(a) < String(b)) {
+        return -1;
+    }
+    if (String(a) > String(b)) {
+        return 1;
+    }
+    return 0;
+}
+function nodeToString(a) {
+    var _a, _b;
+    let name;
+    if ('alias' in a) {
+        name = (_a = a.alias) === null || _a === void 0 ? void 0 : _a.value;
+    }
+    if (name == null && 'name' in a) {
+        name = (_b = a.name) === null || _b === void 0 ? void 0 : _b.value;
+    }
+    if (name == null) {
+        name = a.kind;
+    }
+    return name;
+}
+function compareNodes(a, b, customFn) {
+    const aStr = nodeToString(a);
+    const bStr = nodeToString(b);
+    if (typeof customFn === 'function') {
+        return customFn(aStr, bStr);
+    }
+    return compareStrings(aStr, bStr);
+}
+function isSome(input) {
+    return input != null;
+}
+function assertSome(input, message = 'Value should be something') {
+    if (input == null) {
+        throw new Error(message);
+    }
+}
+
+if (typeof AggregateError === 'undefined') {
+    class AggregateErrorClass extends Error {
+        constructor(errors, message = '') {
+            super(message);
+            this.errors = errors;
+            this.name = 'AggregateError';
+            Error.captureStackTrace(this, AggregateErrorClass);
+        }
+    }
+    exports.AggregateError = function (errors, message) {
+        return new AggregateErrorClass(errors, message);
+    };
+}
+else {
+    exports.AggregateError = AggregateError;
+}
+function isAggregateError(error) {
+    return 'errors' in error && Array.isArray(error['errors']);
+}
+
+// Taken from graphql-js
+const MAX_RECURSIVE_DEPTH = 3;
+/**
+ * Used to print values in error messages.
+ */
+function inspect(value) {
+    return formatValue(value, []);
+}
+function formatValue(value, seenValues) {
+    switch (typeof value) {
+        case 'string':
+            return JSON.stringify(value);
+        case 'function':
+            return value.name ? `[function ${value.name}]` : '[function]';
+        case 'object':
+            return formatObjectValue(value, seenValues);
+        default:
+            return String(value);
+    }
+}
+function formatError(value) {
+    if (value instanceof graphql.GraphQLError) {
+        return value.toString();
+    }
+    return `${value.name}: ${value.message};\n ${value.stack}`;
+}
+function formatObjectValue(value, previouslySeenValues) {
+    if (value === null) {
+        return 'null';
+    }
+    if (value instanceof Error) {
+        if (isAggregateError(value)) {
+            return formatError(value) + '\n' + formatArray(value.errors, previouslySeenValues);
+        }
+        return formatError(value);
+    }
+    if (previouslySeenValues.includes(value)) {
+        return '[Circular]';
+    }
+    const seenValues = [...previouslySeenValues, value];
+    if (isJSONable(value)) {
+        const jsonValue = value.toJSON();
+        // check for infinite recursion
+        if (jsonValue !== value) {
+            return typeof jsonValue === 'string' ? jsonValue : formatValue(jsonValue, seenValues);
+        }
+    }
+    else if (Array.isArray(value)) {
+        return formatArray(value, seenValues);
+    }
+    return formatObject(value, seenValues);
+}
+function isJSONable(value) {
+    return typeof value.toJSON === 'function';
+}
+function formatObject(object, seenValues) {
+    const entries = Object.entries(object);
+    if (entries.length === 0) {
+        return '{}';
+    }
+    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+        return '[' + getObjectTag(object) + ']';
+    }
+    const properties = entries.map(([key, value]) => key + ': ' + formatValue(value, seenValues));
+    return '{ ' + properties.join(', ') + ' }';
+}
+function formatArray(array, seenValues) {
+    if (array.length === 0) {
+        return '[]';
+    }
+    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+        return '[Array]';
+    }
+    const len = array.length;
+    const remaining = array.length;
+    const items = [];
+    for (let i = 0; i < len; ++i) {
+        items.push(formatValue(array[i], seenValues));
+    }
+    if (remaining === 1) {
+        items.push('... 1 more item');
+    }
+    else if (remaining > 1) {
+        items.push(`... ${remaining} more items`);
+    }
+    return '[' + items.join(', ') + ']';
+}
+function getObjectTag(object) {
+    const tag = Object.prototype.toString
+        .call(object)
+        .replace(/^\[object /, '')
+        .replace(/]$/, '');
+    if (tag === 'Object' && typeof object.constructor === 'function') {
+        const name = object.constructor.name;
+        if (typeof name === 'string' && name !== '') {
+            return name;
+        }
+    }
+    return tag;
+}
+
+/**
+ * Prepares an object map of argument values given a list of argument
+ * definitions and list of argument AST nodes.
+ *
+ * Note: The returned value is a plain Object with a prototype, since it is
+ * exposed to user code. Care should be taken to not pull values from the
+ * Object prototype.
+ */
+function getArgumentValues(def, node, variableValues = {}) {
+    var _a;
+    const variableMap = Object.entries(variableValues).reduce((prev, [key, value]) => ({
+        ...prev,
+        [key]: value,
+    }), {});
+    const coercedValues = {};
+    const argumentNodes = (_a = node.arguments) !== null && _a !== void 0 ? _a : [];
+    const argNodeMap = argumentNodes.reduce((prev, arg) => ({
+        ...prev,
+        [arg.name.value]: arg,
+    }), {});
+    for (const { name, type: argType, defaultValue } of def.args) {
+        const argumentNode = argNodeMap[name];
+        if (!argumentNode) {
+            if (defaultValue !== undefined) {
+                coercedValues[name] = defaultValue;
+            }
+            else if (graphql.isNonNullType(argType)) {
+                throw new graphql.GraphQLError(`Argument "${name}" of required type "${inspect(argType)}" ` + 'was not provided.', node);
+            }
+            continue;
+        }
+        const valueNode = argumentNode.value;
+        let isNull = valueNode.kind === graphql.Kind.NULL;
+        if (valueNode.kind === graphql.Kind.VARIABLE) {
+            const variableName = valueNode.name.value;
+            if (variableValues == null || variableMap[variableName] == null) {
+                if (defaultValue !== undefined) {
+                    coercedValues[name] = defaultValue;
+                }
+                else if (graphql.isNonNullType(argType)) {
+                    throw new graphql.GraphQLError(`Argument "${name}" of required type "${inspect(argType)}" ` +
+                        `was provided the variable "$${variableName}" which was not provided a runtime value.`, valueNode);
+                }
+                continue;
+            }
+            isNull = variableValues[variableName] == null;
+        }
+        if (isNull && graphql.isNonNullType(argType)) {
+            throw new graphql.GraphQLError(`Argument "${name}" of non-null type "${inspect(argType)}" ` + 'must not be null.', valueNode);
+        }
+        const coercedValue = graphql.valueFromAST(valueNode, argType, variableValues);
+        if (coercedValue === undefined) {
+            // Note: ValuesOfCorrectTypeRule validation should catch this before
+            // execution. This is a runtime check to ensure execution does not
+            // continue with an invalid argument value.
+            throw new graphql.GraphQLError(`Argument "${name}" has invalid value ${graphql.print(valueNode)}.`, valueNode);
+        }
+        coercedValues[name] = coercedValue;
+    }
+    return coercedValues;
+}
+
+function getDirectivesInExtensions(node, pathToDirectivesInExtensions = ['directives']) {
+    return pathToDirectivesInExtensions.reduce((acc, pathSegment) => (acc == null ? acc : acc[pathSegment]), node === null || node === void 0 ? void 0 : node.extensions);
+}
+function _getDirectiveInExtensions(directivesInExtensions, directiveName) {
+    const directiveInExtensions = directivesInExtensions.filter(directiveAnnotation => directiveAnnotation.name === directiveName);
+    if (!directiveInExtensions.length) {
+        return undefined;
+    }
+    return directiveInExtensions.map(directive => { var _a; return (_a = directive.args) !== null && _a !== void 0 ? _a : {}; });
+}
+function getDirectiveInExtensions(node, directiveName, pathToDirectivesInExtensions = ['directives']) {
+    const directivesInExtensions = pathToDirectivesInExtensions.reduce((acc, pathSegment) => (acc == null ? acc : acc[pathSegment]), node === null || node === void 0 ? void 0 : node.extensions);
+    if (directivesInExtensions === undefined) {
+        return undefined;
+    }
+    if (Array.isArray(directivesInExtensions)) {
+        return _getDirectiveInExtensions(directivesInExtensions, directiveName);
+    }
+    // Support condensed format by converting to longer format
+    // The condensed format does not preserve ordering of directives when  repeatable directives are used.
+    // See https://github.com/ardatan/graphql-tools/issues/2534
+    const reformattedDirectivesInExtensions = [];
+    for (const [name, argsOrArrayOfArgs] of Object.entries(directivesInExtensions)) {
+        if (Array.isArray(argsOrArrayOfArgs)) {
+            for (const args of argsOrArrayOfArgs) {
+                reformattedDirectivesInExtensions.push({ name, args });
+            }
+        }
+        else {
+            reformattedDirectivesInExtensions.push({ name, args: argsOrArrayOfArgs });
+        }
+    }
+    return _getDirectiveInExtensions(reformattedDirectivesInExtensions, directiveName);
+}
+function getDirectives(schema, node, pathToDirectivesInExtensions = ['directives']) {
+    const directivesInExtensions = getDirectivesInExtensions(node, pathToDirectivesInExtensions);
+    if (directivesInExtensions != null && directivesInExtensions.length > 0) {
+        return directivesInExtensions;
+    }
+    const schemaDirectives = schema && schema.getDirectives ? schema.getDirectives() : [];
+    const schemaDirectiveMap = schemaDirectives.reduce((schemaDirectiveMap, schemaDirective) => {
+        schemaDirectiveMap[schemaDirective.name] = schemaDirective;
+        return schemaDirectiveMap;
+    }, {});
+    let astNodes = [];
+    if (node.astNode) {
+        astNodes.push(node.astNode);
+    }
+    if ('extensionASTNodes' in node && node.extensionASTNodes) {
+        astNodes = [...astNodes, ...node.extensionASTNodes];
+    }
+    const result = [];
+    for (const astNode of astNodes) {
+        if (astNode.directives) {
+            for (const directiveNode of astNode.directives) {
+                const schemaDirective = schemaDirectiveMap[directiveNode.name.value];
+                if (schemaDirective) {
+                    result.push({ name: directiveNode.name.value, args: getArgumentValues(schemaDirective, directiveNode) });
+                }
+            }
+        }
+    }
+    return result;
+}
+function getDirective(schema, node, directiveName, pathToDirectivesInExtensions = ['directives']) {
+    const directiveInExtensions = getDirectiveInExtensions(node, directiveName, pathToDirectivesInExtensions);
+    if (directiveInExtensions != null) {
+        return directiveInExtensions;
+    }
+    const schemaDirective = schema && schema.getDirective ? schema.getDirective(directiveName) : undefined;
+    if (schemaDirective == null) {
+        return undefined;
+    }
+    let astNodes = [];
+    if (node.astNode) {
+        astNodes.push(node.astNode);
+    }
+    if ('extensionASTNodes' in node && node.extensionASTNodes) {
+        astNodes = [...astNodes, ...node.extensionASTNodes];
+    }
+    const result = [];
+    for (const astNode of astNodes) {
+        if (astNode.directives) {
+            for (const directiveNode of astNode.directives) {
+                if (directiveNode.name.value === directiveName) {
+                    result.push(getArgumentValues(schemaDirective, directiveNode));
+                }
+            }
+        }
+    }
+    if (!result.length) {
+        return undefined;
+    }
+    return result;
+}
+
+function parseDirectiveValue(value) {
+    switch (value.kind) {
+        case graphql.Kind.INT:
+            return parseInt(value.value);
+        case graphql.Kind.FLOAT:
+            return parseFloat(value.value);
+        case graphql.Kind.BOOLEAN:
+            return Boolean(value.value);
+        case graphql.Kind.STRING:
+        case graphql.Kind.ENUM:
+            return value.value;
+        case graphql.Kind.LIST:
+            return value.values.map(v => parseDirectiveValue(v));
+        case graphql.Kind.OBJECT:
+            return value.fields.reduce((prev, v) => ({ ...prev, [v.name.value]: parseDirectiveValue(v.value) }), {});
+        case graphql.Kind.NULL:
+            return null;
+        default:
+            return null;
+    }
+}
+function getFieldsWithDirectives(documentNode, options = {}) {
+    const result = {};
+    let selected = ['ObjectTypeDefinition', 'ObjectTypeExtension'];
+    if (options.includeInputTypes) {
+        selected = [...selected, 'InputObjectTypeDefinition', 'InputObjectTypeExtension'];
+    }
+    const allTypes = documentNode.definitions.filter(obj => selected.includes(obj.kind));
+    for (const type of allTypes) {
+        const typeName = type.name.value;
+        if (type.fields == null) {
+            continue;
+        }
+        for (const field of type.fields) {
+            if (field.directives && field.directives.length > 0) {
+                const fieldName = field.name.value;
+                const key = `${typeName}.${fieldName}`;
+                const directives = field.directives.map(d => ({
+                    name: d.name.value,
+                    args: (d.arguments || []).reduce((prev, arg) => ({ ...prev, [arg.name.value]: parseDirectiveValue(arg.value) }), {}),
+                }));
+                result[key] = directives;
+            }
+        }
+    }
+    return result;
+}
+
+function getImplementingTypes(interfaceName, schema) {
+    const allTypesMap = schema.getTypeMap();
+    const result = [];
+    for (const graphqlTypeName in allTypesMap) {
+        const graphqlType = allTypesMap[graphqlTypeName];
+        if (graphql.isObjectType(graphqlType)) {
+            const allInterfaces = graphqlType.getInterfaces();
+            if (allInterfaces.find(int => int.name === interfaceName)) {
+                result.push(graphqlType.name);
+            }
+        }
+    }
+    return result;
+}
+
+function astFromType(type) {
+    if (graphql.isNonNullType(type)) {
+        const innerType = astFromType(type.ofType);
+        if (innerType.kind === graphql.Kind.NON_NULL_TYPE) {
+            throw new Error(`Invalid type node ${inspect(type)}. Inner type of non-null type cannot be a non-null type.`);
+        }
+        return {
+            kind: graphql.Kind.NON_NULL_TYPE,
+            type: innerType,
+        };
+    }
+    else if (graphql.isListType(type)) {
+        return {
+            kind: graphql.Kind.LIST_TYPE,
+            type: astFromType(type.ofType),
+        };
+    }
+    return {
+        kind: graphql.Kind.NAMED_TYPE,
+        name: {
+            kind: graphql.Kind.NAME,
+            value: type.name,
+        },
+    };
+}
+
+/**
+ * Produces a GraphQL Value AST given a JavaScript object.
+ * Function will match JavaScript/JSON values to GraphQL AST schema format
+ * by using the following mapping.
+ *
+ * | JSON Value    | GraphQL Value        |
+ * | ------------- | -------------------- |
+ * | Object        | Input Object         |
+ * | Array         | List                 |
+ * | Boolean       | Boolean              |
+ * | String        | String               |
+ * | Number        | Int / Float          |
+ * | null          | NullValue            |
+ *
+ */
+function astFromValueUntyped(value) {
+    // only explicit null, not undefined, NaN
+    if (value === null) {
+        return { kind: graphql.Kind.NULL };
+    }
+    // undefined
+    if (value === undefined) {
+        return null;
+    }
+    // Convert JavaScript array to GraphQL list. If the GraphQLType is a list, but
+    // the value is not an array, convert the value using the list's item type.
+    if (Array.isArray(value)) {
+        const valuesNodes = [];
+        for (const item of value) {
+            const itemNode = astFromValueUntyped(item);
+            if (itemNode != null) {
+                valuesNodes.push(itemNode);
+            }
+        }
+        return { kind: graphql.Kind.LIST, values: valuesNodes };
+    }
+    if (typeof value === 'object') {
+        const fieldNodes = [];
+        for (const fieldName in value) {
+            const fieldValue = value[fieldName];
+            const ast = astFromValueUntyped(fieldValue);
+            if (ast) {
+                fieldNodes.push({
+                    kind: graphql.Kind.OBJECT_FIELD,
+                    name: { kind: graphql.Kind.NAME, value: fieldName },
+                    value: ast,
+                });
+            }
+        }
+        return { kind: graphql.Kind.OBJECT, fields: fieldNodes };
+    }
+    // Others serialize based on their corresponding JavaScript scalar types.
+    if (typeof value === 'boolean') {
+        return { kind: graphql.Kind.BOOLEAN, value };
+    }
+    // JavaScript numbers can be Int or Float values.
+    if (typeof value === 'number' && isFinite(value)) {
+        const stringNum = String(value);
+        return integerStringRegExp.test(stringNum)
+            ? { kind: graphql.Kind.INT, value: stringNum }
+            : { kind: graphql.Kind.FLOAT, value: stringNum };
+    }
+    if (typeof value === 'string') {
+        return { kind: graphql.Kind.STRING, value };
+    }
+    throw new TypeError(`Cannot convert value to AST: ${value}.`);
+}
+/**
+ * IntValue:
+ *   - NegativeSign? 0
+ *   - NegativeSign? NonZeroDigit ( Digit+ )?
+ */
+const integerStringRegExp = /^-?(?:0|[1-9][0-9]*)$/;
+
+function memoize1(fn) {
+    const memoize1cache = new WeakMap();
+    return function memoized(a1) {
+        const cachedValue = memoize1cache.get(a1);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1);
+            memoize1cache.set(a1, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+function memoize2(fn) {
+    const memoize2cache = new WeakMap();
+    return function memoized(a1, a2) {
+        let cache2 = memoize2cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize2cache.set(a1, cache2);
+            const newValue = fn(a1, a2);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        const cachedValue = cache2.get(a2);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+function memoize3(fn) {
+    const memoize3Cache = new WeakMap();
+    return function memoized(a1, a2, a3) {
+        let cache2 = memoize3Cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize3Cache.set(a1, cache2);
+            const cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const newValue = fn(a1, a2, a3);
+            cache3.set(a3, newValue);
+            return newValue;
+        }
+        let cache3 = cache2.get(a2);
+        if (!cache3) {
+            cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const newValue = fn(a1, a2, a3);
+            cache3.set(a3, newValue);
+            return newValue;
+        }
+        const cachedValue = cache3.get(a3);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3);
+            cache3.set(a3, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+function memoize4(fn) {
+    const memoize4Cache = new WeakMap();
+    return function memoized(a1, a2, a3, a4) {
+        let cache2 = memoize4Cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize4Cache.set(a1, cache2);
+            const cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        let cache3 = cache2.get(a2);
+        if (!cache3) {
+            cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        const cache4 = cache3.get(a3);
+        if (!cache4) {
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        const cachedValue = cache4.get(a4);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3, a4);
+            cache4.set(a4, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+function memoize5(fn) {
+    const memoize5Cache = new WeakMap();
+    return function memoized(a1, a2, a3, a4, a5) {
+        let cache2 = memoize5Cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize5Cache.set(a1, cache2);
+            const cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        let cache3 = cache2.get(a2);
+        if (!cache3) {
+            cache3 = new WeakMap();
+            cache2.set(a2, cache3);
+            const cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        let cache4 = cache3.get(a3);
+        if (!cache4) {
+            cache4 = new WeakMap();
+            cache3.set(a3, cache4);
+            const cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        let cache5 = cache4.get(a4);
+        if (!cache5) {
+            cache5 = new WeakMap();
+            cache4.set(a4, cache5);
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        const cachedValue = cache5.get(a5);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3, a4, a5);
+            cache5.set(a5, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+const memoize2of4cache = new WeakMap();
+function memoize2of4(fn) {
+    return function memoized(a1, a2, a3, a4) {
+        let cache2 = memoize2of4cache.get(a1);
+        if (!cache2) {
+            cache2 = new WeakMap();
+            memoize2of4cache.set(a1, cache2);
+            const newValue = fn(a1, a2, a3, a4);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        const cachedValue = cache2.get(a2);
+        if (cachedValue === undefined) {
+            const newValue = fn(a1, a2, a3, a4);
+            cache2.set(a2, newValue);
+            return newValue;
+        }
+        return cachedValue;
+    };
+}
+
+function getDefinedRootType(schema, operation) {
+    const rootTypeMap = getRootTypeMap(schema);
+    const rootType = rootTypeMap.get(operation);
+    if (rootType == null) {
+        throw new Error(`Root type for operation "${operation}" not defined by the given schema.`);
+    }
+    return rootType;
+}
+const getRootTypeNames = memoize1(function getRootTypeNames(schema) {
+    const rootTypes = getRootTypes(schema);
+    return new Set([...rootTypes].map(type => type.name));
+});
+const getRootTypes = memoize1(function getRootTypes(schema) {
+    const rootTypeMap = getRootTypeMap(schema);
+    return new Set(rootTypeMap.values());
+});
+const getRootTypeMap = memoize1(function getRootTypeMap(schema) {
+    const rootTypeMap = new Map();
+    const queryType = schema.getQueryType();
+    if (queryType) {
+        rootTypeMap.set('query', queryType);
+    }
+    const mutationType = schema.getMutationType();
+    if (mutationType) {
+        rootTypeMap.set('mutation', mutationType);
+    }
+    const subscriptionType = schema.getSubscriptionType();
+    if (subscriptionType) {
+        rootTypeMap.set('subscription', subscriptionType);
+    }
+    return rootTypeMap;
+});
+
+function getDocumentNodeFromSchema(schema, options = {}) {
+    const pathToDirectivesInExtensions = options.pathToDirectivesInExtensions;
+    const typesMap = schema.getTypeMap();
+    const schemaNode = astFromSchema(schema, pathToDirectivesInExtensions);
+    const definitions = schemaNode != null ? [schemaNode] : [];
+    const directives = schema.getDirectives();
+    for (const directive of directives) {
+        if (graphql.isSpecifiedDirective(directive)) {
+            continue;
+        }
+        definitions.push(astFromDirective(directive, schema, pathToDirectivesInExtensions));
+    }
+    for (const typeName in typesMap) {
+        const type = typesMap[typeName];
+        const isPredefinedScalar = graphql.isSpecifiedScalarType(type);
+        const isIntrospection = graphql.isIntrospectionType(type);
+        if (isPredefinedScalar || isIntrospection) {
+            continue;
+        }
+        if (graphql.isObjectType(type)) {
+            definitions.push(astFromObjectType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if (graphql.isInterfaceType(type)) {
+            definitions.push(astFromInterfaceType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if (graphql.isUnionType(type)) {
+            definitions.push(astFromUnionType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if (graphql.isInputObjectType(type)) {
+            definitions.push(astFromInputObjectType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if (graphql.isEnumType(type)) {
+            definitions.push(astFromEnumType(type, schema, pathToDirectivesInExtensions));
+        }
+        else if (graphql.isScalarType(type)) {
+            definitions.push(astFromScalarType(type, schema, pathToDirectivesInExtensions));
+        }
+        else {
+            throw new Error(`Unknown type ${type}.`);
+        }
+    }
+    return {
+        kind: graphql.Kind.DOCUMENT,
+        definitions,
+    };
+}
+// this approach uses the default schema printer rather than a custom solution, so may be more backwards compatible
+// currently does not allow customization of printSchema options having to do with comments.
+function printSchemaWithDirectives(schema, options = {}) {
+    const documentNode = getDocumentNodeFromSchema(schema, options);
+    return graphql.print(documentNode);
+}
+function astFromSchema(schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    const operationTypeMap = new Map([
+        ['query', undefined],
+        ['mutation', undefined],
+        ['subscription', undefined],
+    ]);
+    const nodes = [];
+    if (schema.astNode != null) {
+        nodes.push(schema.astNode);
+    }
+    if (schema.extensionASTNodes != null) {
+        for (const extensionASTNode of schema.extensionASTNodes) {
+            nodes.push(extensionASTNode);
+        }
+    }
+    for (const node of nodes) {
+        if (node.operationTypes) {
+            for (const operationTypeDefinitionNode of node.operationTypes) {
+                operationTypeMap.set(operationTypeDefinitionNode.operation, operationTypeDefinitionNode);
+            }
+        }
+    }
+    const rootTypeMap = getRootTypeMap(schema);
+    for (const [operationTypeNode, operationTypeDefinitionNode] of operationTypeMap) {
+        const rootType = rootTypeMap.get(operationTypeNode);
+        if (rootType != null) {
+            const rootTypeAST = astFromType(rootType);
+            if (operationTypeDefinitionNode != null) {
+                operationTypeDefinitionNode.type = rootTypeAST;
+            }
+            else {
+                operationTypeMap.set(operationTypeNode, {
+                    kind: graphql.Kind.OPERATION_TYPE_DEFINITION,
+                    operation: operationTypeNode,
+                    type: rootTypeAST,
+                });
+            }
+        }
+    }
+    const operationTypes = [...operationTypeMap.values()].filter(isSome);
+    const directives = getDirectiveNodes(schema, schema, pathToDirectivesInExtensions);
+    if (!operationTypes.length && !directives.length) {
+        return null;
+    }
+    const schemaNode = {
+        kind: operationTypes != null ? graphql.Kind.SCHEMA_DEFINITION : graphql.Kind.SCHEMA_EXTENSION,
+        operationTypes,
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: directives,
+    };
+    // This code is so weird because it needs to support GraphQL.js 14
+    // In GraphQL.js 14 there is no `description` value on schemaNode
+    schemaNode.description =
+        ((_b = (_a = schema.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : schema.description != null)
+            ? {
+                kind: graphql.Kind.STRING,
+                value: schema.description,
+                block: true,
+            }
+            : undefined;
+    return schemaNode;
+}
+function astFromDirective(directive, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c, _d;
+    return {
+        kind: graphql.Kind.DIRECTIVE_DEFINITION,
+        description: (_b = (_a = directive.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (directive.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: directive.description,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: directive.name,
+        },
+        arguments: (_c = directive.args) === null || _c === void 0 ? void 0 : _c.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions)),
+        repeatable: directive.isRepeatable,
+        locations: ((_d = directive.locations) === null || _d === void 0 ? void 0 : _d.map(location => ({
+            kind: graphql.Kind.NAME,
+            value: location,
+        }))) || [],
+    };
+}
+function getDirectiveNodes(entity, schema, pathToDirectivesInExtensions) {
+    const directivesInExtensions = getDirectivesInExtensions(entity, pathToDirectivesInExtensions);
+    let nodes = [];
+    if (entity.astNode != null) {
+        nodes.push(entity.astNode);
+    }
+    if ('extensionASTNodes' in entity && entity.extensionASTNodes != null) {
+        nodes = nodes.concat(entity.extensionASTNodes);
+    }
+    let directives;
+    if (directivesInExtensions != null) {
+        directives = makeDirectiveNodes(schema, directivesInExtensions);
+    }
+    else {
+        directives = [];
+        for (const node of nodes) {
+            if (node.directives) {
+                directives.push(...node.directives);
+            }
+        }
+    }
+    return directives;
+}
+function getDeprecatableDirectiveNodes(entity, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    let directiveNodesBesidesDeprecated = [];
+    let deprecatedDirectiveNode = null;
+    const directivesInExtensions = getDirectivesInExtensions(entity, pathToDirectivesInExtensions);
+    let directives;
+    if (directivesInExtensions != null) {
+        directives = makeDirectiveNodes(schema, directivesInExtensions);
+    }
+    else {
+        directives = (_a = entity.astNode) === null || _a === void 0 ? void 0 : _a.directives;
+    }
+    if (directives != null) {
+        directiveNodesBesidesDeprecated = directives.filter(directive => directive.name.value !== 'deprecated');
+        if (entity.deprecationReason != null) {
+            deprecatedDirectiveNode = (_b = directives.filter(directive => directive.name.value === 'deprecated')) === null || _b === void 0 ? void 0 : _b[0];
+        }
+    }
+    if (entity.deprecationReason != null &&
+        deprecatedDirectiveNode == null) {
+        deprecatedDirectiveNode = makeDeprecatedDirective(entity.deprecationReason);
+    }
+    return deprecatedDirectiveNode == null
+        ? directiveNodesBesidesDeprecated
+        : [deprecatedDirectiveNode].concat(directiveNodesBesidesDeprecated);
+}
+function astFromArg(arg, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c;
+    return {
+        kind: graphql.Kind.INPUT_VALUE_DEFINITION,
+        description: (_b = (_a = arg.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (arg.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: arg.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: arg.name,
+        },
+        type: astFromType(arg.type),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        defaultValue: arg.defaultValue !== undefined ? (_c = graphql.astFromValue(arg.defaultValue, arg.type)) !== null && _c !== void 0 ? _c : undefined : undefined,
+        directives: getDeprecatableDirectiveNodes(arg, schema, pathToDirectivesInExtensions),
+    };
+}
+function astFromObjectType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql.Kind.OBJECT_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: type.name,
+        },
+        fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
+        interfaces: Object.values(type.getInterfaces()).map(iFace => astFromType(iFace)),
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+}
+function astFromInterfaceType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    const node = {
+        kind: graphql.Kind.INTERFACE_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: type.name,
+        },
+        fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+    if ('getInterfaces' in type) {
+        node.interfaces = Object.values(type.getInterfaces()).map(iFace => astFromType(iFace));
+    }
+    return node;
+}
+function astFromUnionType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql.Kind.UNION_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: type.name,
+        },
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+        types: type.getTypes().map(type => astFromType(type)),
+    };
+}
+function astFromInputObjectType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql.Kind.INPUT_OBJECT_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: type.name,
+        },
+        fields: Object.values(type.getFields()).map(field => astFromInputField(field, schema, pathToDirectivesInExtensions)),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+}
+function astFromEnumType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql.Kind.ENUM_TYPE_DEFINITION,
+        description: (_b = (_a = type.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (type.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: type.name,
+        },
+        values: Object.values(type.getValues()).map(value => astFromEnumValue(value, schema, pathToDirectivesInExtensions)),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    };
+}
+function astFromScalarType(type, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c;
+    const directivesInExtensions = getDirectivesInExtensions(type, pathToDirectivesInExtensions);
+    const directives = directivesInExtensions
+        ? makeDirectiveNodes(schema, directivesInExtensions)
+        : ((_a = type.astNode) === null || _a === void 0 ? void 0 : _a.directives) || [];
+    const specifiedByValue = (type['specifiedByUrl'] || type['specifiedByURL']);
+    if (specifiedByValue && !directives.some(directiveNode => directiveNode.name.value === 'specifiedBy')) {
+        const specifiedByArgs = {
+            url: specifiedByValue,
+        };
+        directives.push(makeDirectiveNode('specifiedBy', specifiedByArgs));
+    }
+    return {
+        kind: graphql.Kind.SCALAR_TYPE_DEFINITION,
+        description: (_c = (_b = type.astNode) === null || _b === void 0 ? void 0 : _b.description) !== null && _c !== void 0 ? _c : (type.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: type.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: type.name,
+        },
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: directives,
+    };
+}
+function astFromField(field, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql.Kind.FIELD_DEFINITION,
+        description: (_b = (_a = field.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (field.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: field.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: field.name,
+        },
+        arguments: field.args.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions)),
+        type: astFromType(field.type),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
+    };
+}
+function astFromInputField(field, schema, pathToDirectivesInExtensions) {
+    var _a, _b, _c;
+    return {
+        kind: graphql.Kind.INPUT_VALUE_DEFINITION,
+        description: (_b = (_a = field.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (field.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: field.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: field.name,
+        },
+        type: astFromType(field.type),
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
+        defaultValue: (_c = graphql.astFromValue(field.defaultValue, field.type)) !== null && _c !== void 0 ? _c : undefined,
+    };
+}
+function astFromEnumValue(value, schema, pathToDirectivesInExtensions) {
+    var _a, _b;
+    return {
+        kind: graphql.Kind.ENUM_VALUE_DEFINITION,
+        description: (_b = (_a = value.astNode) === null || _a === void 0 ? void 0 : _a.description) !== null && _b !== void 0 ? _b : (value.description
+            ? {
+                kind: graphql.Kind.STRING,
+                value: value.description,
+                block: true,
+            }
+            : undefined),
+        name: {
+            kind: graphql.Kind.NAME,
+            value: value.name,
+        },
+        // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
+        directives: getDeprecatableDirectiveNodes(value, schema, pathToDirectivesInExtensions),
+    };
+}
+function makeDeprecatedDirective(deprecationReason) {
+    return makeDirectiveNode('deprecated', { reason: deprecationReason }, graphql.GraphQLDeprecatedDirective);
+}
+function makeDirectiveNode(name, args, directive) {
+    const directiveArguments = [];
+    if (directive != null) {
+        for (const arg of directive.args) {
+            const argName = arg.name;
+            const argValue = args[argName];
+            if (argValue !== undefined) {
+                const value = graphql.astFromValue(argValue, arg.type);
+                if (value) {
+                    directiveArguments.push({
+                        kind: graphql.Kind.ARGUMENT,
+                        name: {
+                            kind: graphql.Kind.NAME,
+                            value: argName,
+                        },
+                        value,
+                    });
+                }
+            }
+        }
+    }
+    else {
+        for (const argName in args) {
+            const argValue = args[argName];
+            const value = astFromValueUntyped(argValue);
+            if (value) {
+                directiveArguments.push({
+                    kind: graphql.Kind.ARGUMENT,
+                    name: {
+                        kind: graphql.Kind.NAME,
+                        value: argName,
+                    },
+                    value,
+                });
+            }
+        }
+    }
+    return {
+        kind: graphql.Kind.DIRECTIVE,
+        name: {
+            kind: graphql.Kind.NAME,
+            value: name,
+        },
+        arguments: directiveArguments,
+    };
+}
+function makeDirectiveNodes(schema, directiveValues) {
+    const directiveNodes = [];
+    for (const directiveName in directiveValues) {
+        const arrayOrSingleValue = directiveValues[directiveName];
+        const directive = schema === null || schema === void 0 ? void 0 : schema.getDirective(directiveName);
+        if (Array.isArray(arrayOrSingleValue)) {
+            for (const value of arrayOrSingleValue) {
+                directiveNodes.push(makeDirectiveNode(directiveName, value, directive));
+            }
+        }
+        else {
+            directiveNodes.push(makeDirectiveNode(directiveName, arrayOrSingleValue, directive));
+        }
+    }
+    return directiveNodes;
+}
+
+async function validateGraphQlDocuments(schema, documentFiles, effectiveRules = createDefaultRules()) {
+    const allFragmentMap = new Map();
+    const documentFileObjectsToValidate = [];
+    for (const documentFile of documentFiles) {
+        if (documentFile.document) {
+            const definitionsToValidate = [];
+            for (const definitionNode of documentFile.document.definitions) {
+                if (definitionNode.kind === graphql.Kind.FRAGMENT_DEFINITION) {
+                    allFragmentMap.set(definitionNode.name.value, definitionNode);
+                }
+                else {
+                    definitionsToValidate.push(definitionNode);
+                }
+            }
+            documentFileObjectsToValidate.push({
+                location: documentFile.location,
+                document: {
+                    kind: graphql.Kind.DOCUMENT,
+                    definitions: definitionsToValidate,
+                },
+            });
+        }
+    }
+    const allErrors = [];
+    const allFragmentsDocument = {
+        kind: graphql.Kind.DOCUMENT,
+        definitions: [...allFragmentMap.values()],
+    };
+    await Promise.all(documentFileObjectsToValidate.map(async (documentFile) => {
+        const documentToValidate = graphql.concatAST([allFragmentsDocument, documentFile.document]);
+        const errors = graphql.validate(schema, documentToValidate, effectiveRules);
+        if (errors.length > 0) {
+            allErrors.push({
+                filePath: documentFile.location,
+                errors,
+            });
+        }
+    }));
+    return allErrors;
+}
+function checkValidationErrors(loadDocumentErrors) {
+    if (loadDocumentErrors.length > 0) {
+        const errors = [];
+        for (const loadDocumentError of loadDocumentErrors) {
+            for (const graphQLError of loadDocumentError.errors) {
+                const error = new Error();
+                error.name = 'GraphQLDocumentError';
+                error.message = `${error.name}: ${graphQLError.message}`;
+                error.stack = error.message;
+                if (graphQLError.locations) {
+                    for (const location of graphQLError.locations) {
+                        error.stack += `\n    at ${loadDocumentError.filePath}:${location.line}:${location.column}`;
+                    }
+                }
+                errors.push(error);
+            }
+        }
+        throw new exports.AggregateError(errors, `GraphQL Document Validation failed with ${errors.length} errors;
+  ${errors.map((error, index) => `Error ${index}: ${error.stack}`).join('\n\n')}`);
+    }
+}
+function createDefaultRules() {
+    let ignored = ['NoUnusedFragmentsRule', 'NoUnusedVariablesRule', 'KnownDirectivesRule'];
+    if (graphql.versionInfo.major < 15) {
+        ignored = ignored.map(rule => rule.replace(/Rule$/, ''));
+    }
+    return graphql.specifiedRules.filter((f) => !ignored.includes(f.name));
+}
+
+function stripBOM(content) {
+    content = content.toString();
+    // Remove byte order marker. This catches EF BB BF (the UTF-8 BOM)
+    // because the buffer-to-string conversion in `fs.readFileSync()`
+    // translates it to FEFF, the UTF-16 BOM.
+    if (content.charCodeAt(0) === 0xfeff) {
+        content = content.slice(1);
+    }
+    return content;
+}
+function parseBOM(content) {
+    return JSON.parse(stripBOM(content));
+}
+function parseGraphQLJSON(location, jsonContent, options) {
+    let parsedJson = parseBOM(jsonContent);
+    if (parsedJson.data) {
+        parsedJson = parsedJson.data;
+    }
+    if (parsedJson.kind === 'Document') {
+        return {
+            location,
+            document: parsedJson,
+        };
+    }
+    else if (parsedJson.__schema) {
+        const schema = graphql.buildClientSchema(parsedJson, options);
+        return {
+            location,
+            schema,
+        };
+    }
+    else if (typeof parsedJson === 'string') {
+        return {
+            location,
+            rawSDL: parsedJson,
+        };
+    }
+    throw new Error(`Not valid JSON content`);
+}
+
+const MAX_LINE_LENGTH = 80;
+let commentsRegistry = {};
+function resetComments() {
+    commentsRegistry = {};
+}
+function collectComment(node) {
+    var _a;
+    const entityName = (_a = node.name) === null || _a === void 0 ? void 0 : _a.value;
+    if (entityName == null) {
+        return;
+    }
+    pushComment(node, entityName);
+    switch (node.kind) {
+        case 'EnumTypeDefinition':
+            if (node.values) {
+                for (const value of node.values) {
+                    pushComment(value, entityName, value.name.value);
+                }
+            }
+            break;
+        case 'ObjectTypeDefinition':
+        case 'InputObjectTypeDefinition':
+        case 'InterfaceTypeDefinition':
+            if (node.fields) {
+                for (const field of node.fields) {
+                    pushComment(field, entityName, field.name.value);
+                    if (isFieldDefinitionNode(field) && field.arguments) {
+                        for (const arg of field.arguments) {
+                            pushComment(arg, entityName, field.name.value, arg.name.value);
+                        }
+                    }
+                }
+            }
+            break;
+    }
+}
+function pushComment(node, entity, field, argument) {
+    const comment = getComment(node);
+    if (typeof comment !== 'string' || comment.length === 0) {
+        return;
+    }
+    const keys = [entity];
+    if (field) {
+        keys.push(field);
+        if (argument) {
+            keys.push(argument);
+        }
+    }
+    const path = keys.join('.');
+    if (!commentsRegistry[path]) {
+        commentsRegistry[path] = [];
+    }
+    commentsRegistry[path].push(comment);
+}
+function printComment(comment) {
+    return '\n# ' + comment.replace(/\n/g, '\n# ');
+}
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/**
+ * NOTE: ==> This file has been modified just to add comments to the printed AST
+ * This is a temp measure, we will move to using the original non modified printer.js ASAP.
+ */
+/**
+ * Given maybeArray, print an empty string if it is null or empty, otherwise
+ * print all items together separated by separator if provided
+ */
+function join(maybeArray, separator) {
+    return maybeArray ? maybeArray.filter(x => x).join(separator || '') : '';
+}
+function hasMultilineItems(maybeArray) {
+    var _a;
+    return (_a = maybeArray === null || maybeArray === void 0 ? void 0 : maybeArray.some(str => str.includes('\n'))) !== null && _a !== void 0 ? _a : false;
+}
+function addDescription(cb) {
+    return (node, _key, _parent, path, ancestors) => {
+        var _a;
+        const keys = [];
+        const parent = path.reduce((prev, key) => {
+            if (['fields', 'arguments', 'values'].includes(key) && prev.name) {
+                keys.push(prev.name.value);
+            }
+            return prev[key];
+        }, ancestors[0]);
+        const key = [...keys, (_a = parent === null || parent === void 0 ? void 0 : parent.name) === null || _a === void 0 ? void 0 : _a.value].filter(Boolean).join('.');
+        const items = [];
+        if (node.kind.includes('Definition') && commentsRegistry[key]) {
+            items.push(...commentsRegistry[key]);
+        }
+        return join([...items.map(printComment), node.description, cb(node, _key, _parent, path, ancestors)], '\n');
+    };
+}
+function indent(maybeString) {
+    return maybeString && `  ${maybeString.replace(/\n/g, '\n  ')}`;
+}
+/**
+ * Given array, print each item on its own line, wrapped in an
+ * indented "{ }" block.
+ */
+function block(array) {
+    return array && array.length !== 0 ? `{\n${indent(join(array, '\n'))}\n}` : '';
+}
+/**
+ * If maybeString is not null or empty, then wrap with start and end, otherwise
+ * print an empty string.
+ */
+function wrap(start, maybeString, end) {
+    return maybeString ? start + maybeString + (end || '') : '';
+}
+/**
+ * Print a block string in the indented block form by adding a leading and
+ * trailing blank line. However, if a block string starts with whitespace and is
+ * a single-line, adding a leading blank line would strip that whitespace.
+ */
+function printBlockString(value, isDescription = false) {
+    const escaped = value.replace(/"""/g, '\\"""');
+    return (value[0] === ' ' || value[0] === '\t') && value.indexOf('\n') === -1
+        ? `"""${escaped.replace(/"$/, '"\n')}"""`
+        : `"""\n${isDescription ? escaped : indent(escaped)}\n"""`;
+}
+const printDocASTReducer = {
+    Name: { leave: node => node.value },
+    Variable: { leave: node => '$' + node.name },
+    // Document
+    Document: {
+        leave: node => join(node.definitions, '\n\n'),
+    },
+    OperationDefinition: {
+        leave: node => {
+            const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
+            const prefix = join([node.operation, join([node.name, varDefs]), join(node.directives, ' ')], ' ');
+            // the query short form.
+            return prefix + ' ' + node.selectionSet;
+        },
+    },
+    VariableDefinition: {
+        leave: ({ variable, type, defaultValue, directives }) => variable + ': ' + type + wrap(' = ', defaultValue) + wrap(' ', join(directives, ' ')),
+    },
+    SelectionSet: { leave: ({ selections }) => block(selections) },
+    Field: {
+        leave({ alias, name, arguments: args, directives, selectionSet }) {
+            const prefix = wrap('', alias, ': ') + name;
+            let argsLine = prefix + wrap('(', join(args, ', '), ')');
+            if (argsLine.length > MAX_LINE_LENGTH) {
+                argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)');
+            }
+            return join([argsLine, join(directives, ' '), selectionSet], ' ');
+        },
+    },
+    Argument: { leave: ({ name, value }) => name + ': ' + value },
+    // Fragments
+    FragmentSpread: {
+        leave: ({ name, directives }) => '...' + name + wrap(' ', join(directives, ' ')),
+    },
+    InlineFragment: {
+        leave: ({ typeCondition, directives, selectionSet }) => join(['...', wrap('on ', typeCondition), join(directives, ' '), selectionSet], ' '),
+    },
+    FragmentDefinition: {
+        leave: ({ name, typeCondition, variableDefinitions, directives, selectionSet }) => 
+        // Note: fragment variable definitions are experimental and may be changed
+        // or removed in the future.
+        `fragment ${name}${wrap('(', join(variableDefinitions, ', '), ')')} ` +
+            `on ${typeCondition} ${wrap('', join(directives, ' '), ' ')}` +
+            selectionSet,
+    },
+    // Value
+    IntValue: { leave: ({ value }) => value },
+    FloatValue: { leave: ({ value }) => value },
+    StringValue: {
+        leave: ({ value, block: isBlockString }) => {
+            if (isBlockString) {
+                return printBlockString(value);
+            }
+            return JSON.stringify(value);
+        },
+    },
+    BooleanValue: { leave: ({ value }) => (value ? 'true' : 'false') },
+    NullValue: { leave: () => 'null' },
+    EnumValue: { leave: ({ value }) => value },
+    ListValue: { leave: ({ values }) => '[' + join(values, ', ') + ']' },
+    ObjectValue: { leave: ({ fields }) => '{' + join(fields, ', ') + '}' },
+    ObjectField: { leave: ({ name, value }) => name + ': ' + value },
+    // Directive
+    Directive: {
+        leave: ({ name, arguments: args }) => '@' + name + wrap('(', join(args, ', '), ')'),
+    },
+    // Type
+    NamedType: { leave: ({ name }) => name },
+    ListType: { leave: ({ type }) => '[' + type + ']' },
+    NonNullType: { leave: ({ type }) => type + '!' },
+    // Type System Definitions
+    SchemaDefinition: {
+        leave: ({ directives, operationTypes }) => join(['schema', join(directives, ' '), block(operationTypes)], ' '),
+    },
+    OperationTypeDefinition: {
+        leave: ({ operation, type }) => operation + ': ' + type,
+    },
+    ScalarTypeDefinition: {
+        leave: ({ name, directives }) => join(['scalar', name, join(directives, ' ')], ' '),
+    },
+    ObjectTypeDefinition: {
+        leave: ({ name, interfaces, directives, fields }) => join(['type', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    FieldDefinition: {
+        leave: ({ name, arguments: args, type, directives }) => name +
+            (hasMultilineItems(args)
+                ? wrap('(\n', indent(join(args, '\n')), '\n)')
+                : wrap('(', join(args, ', '), ')')) +
+            ': ' +
+            type +
+            wrap(' ', join(directives, ' ')),
+    },
+    InputValueDefinition: {
+        leave: ({ name, type, defaultValue, directives }) => join([name + ': ' + type, wrap('= ', defaultValue), join(directives, ' ')], ' '),
+    },
+    InterfaceTypeDefinition: {
+        leave: ({ name, interfaces, directives, fields }) => join(['interface', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    UnionTypeDefinition: {
+        leave: ({ name, directives, types }) => join(['union', name, join(directives, ' '), wrap('= ', join(types, ' | '))], ' '),
+    },
+    EnumTypeDefinition: {
+        leave: ({ name, directives, values }) => join(['enum', name, join(directives, ' '), block(values)], ' '),
+    },
+    EnumValueDefinition: {
+        leave: ({ name, directives }) => join([name, join(directives, ' ')], ' '),
+    },
+    InputObjectTypeDefinition: {
+        leave: ({ name, directives, fields }) => join(['input', name, join(directives, ' '), block(fields)], ' '),
+    },
+    DirectiveDefinition: {
+        leave: ({ name, arguments: args, repeatable, locations }) => 'directive @' +
+            name +
+            (hasMultilineItems(args)
+                ? wrap('(\n', indent(join(args, '\n')), '\n)')
+                : wrap('(', join(args, ', '), ')')) +
+            (repeatable ? ' repeatable' : '') +
+            ' on ' +
+            join(locations, ' | '),
+    },
+    SchemaExtension: {
+        leave: ({ directives, operationTypes }) => join(['extend schema', join(directives, ' '), block(operationTypes)], ' '),
+    },
+    ScalarTypeExtension: {
+        leave: ({ name, directives }) => join(['extend scalar', name, join(directives, ' ')], ' '),
+    },
+    ObjectTypeExtension: {
+        leave: ({ name, interfaces, directives, fields }) => join(['extend type', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    InterfaceTypeExtension: {
+        leave: ({ name, interfaces, directives, fields }) => join(['extend interface', name, wrap('implements ', join(interfaces, ' & ')), join(directives, ' '), block(fields)], ' '),
+    },
+    UnionTypeExtension: {
+        leave: ({ name, directives, types }) => join(['extend union', name, join(directives, ' '), wrap('= ', join(types, ' | '))], ' '),
+    },
+    EnumTypeExtension: {
+        leave: ({ name, directives, values }) => join(['extend enum', name, join(directives, ' '), block(values)], ' '),
+    },
+    InputObjectTypeExtension: {
+        leave: ({ name, directives, fields }) => join(['extend input', name, join(directives, ' '), block(fields)], ' '),
+    },
+};
+const printDocASTReducerWithComments = Object.keys(printDocASTReducer).reduce((prev, key) => ({
+    ...prev,
+    [key]: {
+        leave: addDescription(printDocASTReducer[key].leave),
+    },
+}), {});
+/**
+ * Converts an AST into a string, using one set of reasonable
+ * formatting rules.
+ */
+function printWithComments(ast) {
+    return graphql.visit(ast, printDocASTReducerWithComments);
+}
+function isFieldDefinitionNode(node) {
+    return node.kind === 'FieldDefinition';
+}
+// graphql < v13 and > v15 does not export getDescription
+function getDescription(node, options) {
+    if (node.description != null) {
+        return node.description.value;
+    }
+    if (options === null || options === void 0 ? void 0 : options.commentDescriptions) {
+        return getComment(node);
+    }
+}
+function getComment(node) {
+    const rawValue = getLeadingCommentBlock(node);
+    if (rawValue !== undefined) {
+        return dedentBlockStringValue(`\n${rawValue}`);
+    }
+}
+function getLeadingCommentBlock(node) {
+    const loc = node.loc;
+    if (!loc) {
+        return;
+    }
+    const comments = [];
+    let token = loc.startToken.prev;
+    while (token != null &&
+        token.kind === graphql.TokenKind.COMMENT &&
+        token.next != null &&
+        token.prev != null &&
+        token.line + 1 === token.next.line &&
+        token.line !== token.prev.line) {
+        const value = String(token.value);
+        comments.push(value);
+        token = token.prev;
+    }
+    return comments.length > 0 ? comments.reverse().join('\n') : undefined;
+}
+function dedentBlockStringValue(rawString) {
+    // Expand a block string's raw value into independent lines.
+    const lines = rawString.split(/\r\n|[\n\r]/g);
+    // Remove common indentation from all lines but first.
+    const commonIndent = getBlockStringIndentation(lines);
+    if (commonIndent !== 0) {
+        for (let i = 1; i < lines.length; i++) {
+            lines[i] = lines[i].slice(commonIndent);
+        }
+    }
+    // Remove leading and trailing blank lines.
+    while (lines.length > 0 && isBlank(lines[0])) {
+        lines.shift();
+    }
+    while (lines.length > 0 && isBlank(lines[lines.length - 1])) {
+        lines.pop();
+    }
+    // Return a string of the lines joined with U+000A.
+    return lines.join('\n');
+}
+/**
+ * @internal
+ */
+function getBlockStringIndentation(lines) {
+    let commonIndent = null;
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        const indent = leadingWhitespace(line);
+        if (indent === line.length) {
+            continue; // skip empty lines
+        }
+        if (commonIndent === null || indent < commonIndent) {
+            commonIndent = indent;
+            if (commonIndent === 0) {
+                break;
+            }
+        }
+    }
+    return commonIndent === null ? 0 : commonIndent;
+}
+function leadingWhitespace(str) {
+    let i = 0;
+    while (i < str.length && (str[i] === ' ' || str[i] === '\t')) {
+        i++;
+    }
+    return i;
+}
+function isBlank(str) {
+    return leadingWhitespace(str) === str.length;
+}
+
+function parseGraphQLSDL(location, rawSDL, options = {}) {
+    let document;
+    try {
+        if (options.commentDescriptions && rawSDL.includes('#')) {
+            document = transformCommentsToDescriptions(rawSDL, options);
+            // If noLocation=true, we need to make sure to print and parse it again, to remove locations,
+            // since `transformCommentsToDescriptions` must have locations set in order to transform the comments
+            // into descriptions.
+            if (options.noLocation) {
+                document = graphql.parse(graphql.print(document), options);
+            }
+        }
+        else {
+            document = graphql.parse(new graphql.Source(rawSDL, location), options);
+        }
+    }
+    catch (e) {
+        if (e.message.includes('EOF') && rawSDL.replace(/(\#[^*]*)/g, '').trim() === '') {
+            document = {
+                kind: graphql.Kind.DOCUMENT,
+                definitions: [],
+            };
+        }
+        else {
+            throw e;
+        }
+    }
+    return {
+        location,
+        document,
+    };
+}
+function transformCommentsToDescriptions(sourceSdl, options = {}) {
+    const parsedDoc = graphql.parse(sourceSdl, {
+        ...options,
+        noLocation: false,
+    });
+    const modifiedDoc = graphql.visit(parsedDoc, {
+        leave: (node) => {
+            if (isDescribable(node)) {
+                const rawValue = getLeadingCommentBlock(node);
+                if (rawValue !== undefined) {
+                    const commentsBlock = dedentBlockStringValue('\n' + rawValue);
+                    const isBlock = commentsBlock.includes('\n');
+                    if (!node.description) {
+                        return {
+                            ...node,
+                            description: {
+                                kind: graphql.Kind.STRING,
+                                value: commentsBlock,
+                                block: isBlock,
+                            },
+                        };
+                    }
+                    else {
+                        return {
+                            ...node,
+                            description: {
+                                ...node.description,
+                                value: node.description.value + '\n' + commentsBlock,
+                                block: true,
+                            },
+                        };
+                    }
+                }
+            }
+        },
+    });
+    return modifiedDoc;
+}
+function isDescribable(node) {
+    return (graphql.isTypeSystemDefinitionNode(node) ||
+        node.kind === graphql.Kind.FIELD_DEFINITION ||
+        node.kind === graphql.Kind.INPUT_VALUE_DEFINITION ||
+        node.kind === graphql.Kind.ENUM_VALUE_DEFINITION);
+}
+
+let operationVariables = [];
+let fieldTypeMap = new Map();
+function addOperationVariable(variable) {
+    operationVariables.push(variable);
+}
+function resetOperationVariables() {
+    operationVariables = [];
+}
+function resetFieldMap() {
+    fieldTypeMap = new Map();
+}
+function buildOperationNodeForField({ schema, kind, field, models, ignore = [], depthLimit, circularReferenceDepth, argNames, selectedFields = true, }) {
+    resetOperationVariables();
+    resetFieldMap();
+    const rootTypeNames = getRootTypeNames(schema);
+    const operationNode = buildOperationAndCollectVariables({
+        schema,
+        fieldName: field,
+        kind,
+        models: models || [],
+        ignore,
+        depthLimit: depthLimit || Infinity,
+        circularReferenceDepth: circularReferenceDepth || 1,
+        argNames,
+        selectedFields,
+        rootTypeNames,
+    });
+    // attach variables
+    operationNode.variableDefinitions = [...operationVariables];
+    resetOperationVariables();
+    resetFieldMap();
+    return operationNode;
+}
+function buildOperationAndCollectVariables({ schema, fieldName, kind, models, ignore, depthLimit, circularReferenceDepth, argNames, selectedFields, rootTypeNames, }) {
+    const type = getDefinedRootType(schema, kind);
+    const field = type.getFields()[fieldName];
+    const operationName = `${fieldName}_${kind}`;
+    if (field.args) {
+        for (const arg of field.args) {
+            const argName = arg.name;
+            if (!argNames || argNames.includes(argName)) {
+                addOperationVariable(resolveVariable(arg, argName));
+            }
+        }
+    }
+    return {
+        kind: graphql.Kind.OPERATION_DEFINITION,
+        operation: kind,
+        name: {
+            kind: graphql.Kind.NAME,
+            value: operationName,
+        },
+        variableDefinitions: [],
+        selectionSet: {
+            kind: graphql.Kind.SELECTION_SET,
+            selections: [
+                resolveField({
+                    type,
+                    field,
+                    models,
+                    firstCall: true,
+                    path: [],
+                    ancestors: [],
+                    ignore,
+                    depthLimit,
+                    circularReferenceDepth,
+                    schema,
+                    depth: 0,
+                    argNames,
+                    selectedFields,
+                    rootTypeNames,
+                }),
+            ],
+        },
+    };
+}
+function resolveSelectionSet({ parent, type, models, firstCall, path, ancestors, ignore, depthLimit, circularReferenceDepth, schema, depth, argNames, selectedFields, rootTypeNames, }) {
+    if (typeof selectedFields === 'boolean' && depth > depthLimit) {
+        return;
+    }
+    if (graphql.isUnionType(type)) {
+        const types = type.getTypes();
+        return {
+            kind: graphql.Kind.SELECTION_SET,
+            selections: types
+                .filter(t => !hasCircularRef([...ancestors, t], {
+                depth: circularReferenceDepth,
+            }))
+                .map(t => {
+                return {
+                    kind: graphql.Kind.INLINE_FRAGMENT,
+                    typeCondition: {
+                        kind: graphql.Kind.NAMED_TYPE,
+                        name: {
+                            kind: graphql.Kind.NAME,
+                            value: t.name,
+                        },
+                    },
+                    selectionSet: resolveSelectionSet({
+                        parent: type,
+                        type: t,
+                        models,
+                        path,
+                        ancestors,
+                        ignore,
+                        depthLimit,
+                        circularReferenceDepth,
+                        schema,
+                        depth,
+                        argNames,
+                        selectedFields,
+                        rootTypeNames,
+                    }),
+                };
+            })
+                .filter(fragmentNode => { var _a, _b; return ((_b = (_a = fragmentNode === null || fragmentNode === void 0 ? void 0 : fragmentNode.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length) > 0; }),
+        };
+    }
+    if (graphql.isInterfaceType(type)) {
+        const types = Object.values(schema.getTypeMap()).filter((t) => graphql.isObjectType(t) && t.getInterfaces().includes(type));
+        return {
+            kind: graphql.Kind.SELECTION_SET,
+            selections: types
+                .filter(t => !hasCircularRef([...ancestors, t], {
+                depth: circularReferenceDepth,
+            }))
+                .map(t => {
+                return {
+                    kind: graphql.Kind.INLINE_FRAGMENT,
+                    typeCondition: {
+                        kind: graphql.Kind.NAMED_TYPE,
+                        name: {
+                            kind: graphql.Kind.NAME,
+                            value: t.name,
+                        },
+                    },
+                    selectionSet: resolveSelectionSet({
+                        parent: type,
+                        type: t,
+                        models,
+                        path,
+                        ancestors,
+                        ignore,
+                        depthLimit,
+                        circularReferenceDepth,
+                        schema,
+                        depth,
+                        argNames,
+                        selectedFields,
+                        rootTypeNames,
+                    }),
+                };
+            })
+                .filter(fragmentNode => { var _a, _b; return ((_b = (_a = fragmentNode === null || fragmentNode === void 0 ? void 0 : fragmentNode.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length) > 0; }),
+        };
+    }
+    if (graphql.isObjectType(type) && !rootTypeNames.has(type.name)) {
+        const isIgnored = ignore.includes(type.name) || ignore.includes(`${parent.name}.${path[path.length - 1]}`);
+        const isModel = models.includes(type.name);
+        if (!firstCall && isModel && !isIgnored) {
+            return {
+                kind: graphql.Kind.SELECTION_SET,
+                selections: [
+                    {
+                        kind: graphql.Kind.FIELD,
+                        name: {
+                            kind: graphql.Kind.NAME,
+                            value: 'id',
+                        },
+                    },
+                ],
+            };
+        }
+        const fields = type.getFields();
+        return {
+            kind: graphql.Kind.SELECTION_SET,
+            selections: Object.keys(fields)
+                .filter(fieldName => {
+                return !hasCircularRef([...ancestors, graphql.getNamedType(fields[fieldName].type)], {
+                    depth: circularReferenceDepth,
+                });
+            })
+                .map(fieldName => {
+                const selectedSubFields = typeof selectedFields === 'object' ? selectedFields[fieldName] : true;
+                if (selectedSubFields) {
+                    return resolveField({
+                        type: type,
+                        field: fields[fieldName],
+                        models,
+                        path: [...path, fieldName],
+                        ancestors,
+                        ignore,
+                        depthLimit,
+                        circularReferenceDepth,
+                        schema,
+                        depth,
+                        argNames,
+                        selectedFields: selectedSubFields,
+                        rootTypeNames,
+                    });
+                }
+                return null;
+            })
+                .filter((f) => {
+                var _a, _b;
+                if (f == null) {
+                    return false;
+                }
+                else if ('selectionSet' in f) {
+                    return !!((_b = (_a = f.selectionSet) === null || _a === void 0 ? void 0 : _a.selections) === null || _b === void 0 ? void 0 : _b.length);
+                }
+                return true;
+            }),
+        };
+    }
+}
+function resolveVariable(arg, name) {
+    function resolveVariableType(type) {
+        if (graphql.isListType(type)) {
+            return {
+                kind: graphql.Kind.LIST_TYPE,
+                type: resolveVariableType(type.ofType),
+            };
+        }
+        if (graphql.isNonNullType(type)) {
+            return {
+                kind: graphql.Kind.NON_NULL_TYPE,
+                // for v16 compatibility
+                type: resolveVariableType(type.ofType),
+            };
+        }
+        return {
+            kind: graphql.Kind.NAMED_TYPE,
+            name: {
+                kind: graphql.Kind.NAME,
+                value: type.name,
+            },
+        };
+    }
+    return {
+        kind: graphql.Kind.VARIABLE_DEFINITION,
+        variable: {
+            kind: graphql.Kind.VARIABLE,
+            name: {
+                kind: graphql.Kind.NAME,
+                value: name || arg.name,
+            },
+        },
+        type: resolveVariableType(arg.type),
+    };
+}
+function getArgumentName(name, path) {
+    return [...path, name].join('_');
+}
+function resolveField({ type, field, models, firstCall, path, ancestors, ignore, depthLimit, circularReferenceDepth, schema, depth, argNames, selectedFields, rootTypeNames, }) {
+    const namedType = graphql.getNamedType(field.type);
+    let args = [];
+    let removeField = false;
+    if (field.args && field.args.length) {
+        args = field.args
+            .map(arg => {
+            const argumentName = getArgumentName(arg.name, path);
+            if (argNames && !argNames.includes(argumentName)) {
+                if (graphql.isNonNullType(arg.type)) {
+                    removeField = true;
+                }
+                return null;
+            }
+            if (!firstCall) {
+                addOperationVariable(resolveVariable(arg, argumentName));
+            }
+            return {
+                kind: graphql.Kind.ARGUMENT,
+                name: {
+                    kind: graphql.Kind.NAME,
+                    value: arg.name,
+                },
+                value: {
+                    kind: graphql.Kind.VARIABLE,
+                    name: {
+                        kind: graphql.Kind.NAME,
+                        value: getArgumentName(arg.name, path),
+                    },
+                },
+            };
+        })
+            .filter(Boolean);
+    }
+    if (removeField) {
+        return null;
+    }
+    const fieldPath = [...path, field.name];
+    const fieldPathStr = fieldPath.join('.');
+    let fieldName = field.name;
+    if (fieldTypeMap.has(fieldPathStr) && fieldTypeMap.get(fieldPathStr) !== field.type.toString()) {
+        fieldName += field.type.toString().replace('!', 'NonNull');
+    }
+    fieldTypeMap.set(fieldPathStr, field.type.toString());
+    if (!graphql.isScalarType(namedType) && !graphql.isEnumType(namedType)) {
+        return {
+            kind: graphql.Kind.FIELD,
+            name: {
+                kind: graphql.Kind.NAME,
+                value: field.name,
+            },
+            ...(fieldName !== field.name && { alias: { kind: graphql.Kind.NAME, value: fieldName } }),
+            selectionSet: resolveSelectionSet({
+                parent: type,
+                type: namedType,
+                models,
+                firstCall,
+                path: fieldPath,
+                ancestors: [...ancestors, type],
+                ignore,
+                depthLimit,
+                circularReferenceDepth,
+                schema,
+                depth: depth + 1,
+                argNames,
+                selectedFields,
+                rootTypeNames,
+            }) || undefined,
+            arguments: args,
+        };
+    }
+    return {
+        kind: graphql.Kind.FIELD,
+        name: {
+            kind: graphql.Kind.NAME,
+            value: field.name,
+        },
+        ...(fieldName !== field.name && { alias: { kind: graphql.Kind.NAME, value: fieldName } }),
+        arguments: args,
+    };
+}
+function hasCircularRef(types, config = {
+    depth: 1,
+}) {
+    const type = types[types.length - 1];
+    if (graphql.isScalarType(type)) {
+        return false;
+    }
+    const size = types.filter(t => t.name === type.name).length;
+    return size > config.depth;
+}
+
+(function (MapperKind) {
+    MapperKind["TYPE"] = "MapperKind.TYPE";
+    MapperKind["SCALAR_TYPE"] = "MapperKind.SCALAR_TYPE";
+    MapperKind["ENUM_TYPE"] = "MapperKind.ENUM_TYPE";
+    MapperKind["COMPOSITE_TYPE"] = "MapperKind.COMPOSITE_TYPE";
+    MapperKind["OBJECT_TYPE"] = "MapperKind.OBJECT_TYPE";
+    MapperKind["INPUT_OBJECT_TYPE"] = "MapperKind.INPUT_OBJECT_TYPE";
+    MapperKind["ABSTRACT_TYPE"] = "MapperKind.ABSTRACT_TYPE";
+    MapperKind["UNION_TYPE"] = "MapperKind.UNION_TYPE";
+    MapperKind["INTERFACE_TYPE"] = "MapperKind.INTERFACE_TYPE";
+    MapperKind["ROOT_OBJECT"] = "MapperKind.ROOT_OBJECT";
+    MapperKind["QUERY"] = "MapperKind.QUERY";
+    MapperKind["MUTATION"] = "MapperKind.MUTATION";
+    MapperKind["SUBSCRIPTION"] = "MapperKind.SUBSCRIPTION";
+    MapperKind["DIRECTIVE"] = "MapperKind.DIRECTIVE";
+    MapperKind["FIELD"] = "MapperKind.FIELD";
+    MapperKind["COMPOSITE_FIELD"] = "MapperKind.COMPOSITE_FIELD";
+    MapperKind["OBJECT_FIELD"] = "MapperKind.OBJECT_FIELD";
+    MapperKind["ROOT_FIELD"] = "MapperKind.ROOT_FIELD";
+    MapperKind["QUERY_ROOT_FIELD"] = "MapperKind.QUERY_ROOT_FIELD";
+    MapperKind["MUTATION_ROOT_FIELD"] = "MapperKind.MUTATION_ROOT_FIELD";
+    MapperKind["SUBSCRIPTION_ROOT_FIELD"] = "MapperKind.SUBSCRIPTION_ROOT_FIELD";
+    MapperKind["INTERFACE_FIELD"] = "MapperKind.INTERFACE_FIELD";
+    MapperKind["INPUT_OBJECT_FIELD"] = "MapperKind.INPUT_OBJECT_FIELD";
+    MapperKind["ARGUMENT"] = "MapperKind.ARGUMENT";
+    MapperKind["ENUM_VALUE"] = "MapperKind.ENUM_VALUE";
+})(exports.MapperKind || (exports.MapperKind = {}));
+
+function getObjectTypeFromTypeMap(typeMap, type) {
+    if (type) {
+        const maybeObjectType = typeMap[type.name];
+        if (graphql.isObjectType(maybeObjectType)) {
+            return maybeObjectType;
+        }
+    }
+}
+
+function createNamedStub(name, type) {
+    let constructor;
+    if (type === 'object') {
+        constructor = graphql.GraphQLObjectType;
+    }
+    else if (type === 'interface') {
+        constructor = graphql.GraphQLInterfaceType;
+    }
+    else {
+        constructor = graphql.GraphQLInputObjectType;
+    }
+    return new constructor({
+        name,
+        fields: {
+            _fake: {
+                type: graphql.GraphQLString,
+            },
+        },
+    });
+}
+function createStub(node, type) {
+    switch (node.kind) {
+        case graphql.Kind.LIST_TYPE:
+            return new graphql.GraphQLList(createStub(node.type, type));
+        case graphql.Kind.NON_NULL_TYPE:
+            return new graphql.GraphQLNonNull(createStub(node.type, type));
+        default:
+            if (type === 'output') {
+                return createNamedStub(node.name.value, 'object');
+            }
+            return createNamedStub(node.name.value, 'input');
+    }
+}
+function isNamedStub(type) {
+    if ('getFields' in type) {
+        const fields = type.getFields();
+        // eslint-disable-next-line no-unreachable-loop
+        for (const fieldName in fields) {
+            const field = fields[fieldName];
+            return field.name === '_fake';
+        }
+    }
+    return false;
+}
+function getBuiltInForStub(type) {
+    switch (type.name) {
+        case graphql.GraphQLInt.name:
+            return graphql.GraphQLInt;
+        case graphql.GraphQLFloat.name:
+            return graphql.GraphQLFloat;
+        case graphql.GraphQLString.name:
+            return graphql.GraphQLString;
+        case graphql.GraphQLBoolean.name:
+            return graphql.GraphQLBoolean;
+        case graphql.GraphQLID.name:
+            return graphql.GraphQLID;
+        default:
+            return type;
+    }
+}
+
+function rewireTypes(originalTypeMap, directives) {
+    const referenceTypeMap = Object.create(null);
+    for (const typeName in originalTypeMap) {
+        referenceTypeMap[typeName] = originalTypeMap[typeName];
+    }
+    const newTypeMap = Object.create(null);
+    for (const typeName in referenceTypeMap) {
+        const namedType = referenceTypeMap[typeName];
+        if (namedType == null || typeName.startsWith('__')) {
+            continue;
+        }
+        const newName = namedType.name;
+        if (newName.startsWith('__')) {
+            continue;
+        }
+        if (newTypeMap[newName] != null) {
+            throw new Error(`Duplicate schema type name ${newName}`);
+        }
+        newTypeMap[newName] = namedType;
+    }
+    for (const typeName in newTypeMap) {
+        newTypeMap[typeName] = rewireNamedType(newTypeMap[typeName]);
+    }
+    const newDirectives = directives.map(directive => rewireDirective(directive));
+    return {
+        typeMap: newTypeMap,
+        directives: newDirectives,
+    };
+    function rewireDirective(directive) {
+        if (graphql.isSpecifiedDirective(directive)) {
+            return directive;
+        }
+        const directiveConfig = directive.toConfig();
+        directiveConfig.args = rewireArgs(directiveConfig.args);
+        return new graphql.GraphQLDirective(directiveConfig);
+    }
+    function rewireArgs(args) {
+        const rewiredArgs = {};
+        for (const argName in args) {
+            const arg = args[argName];
+            const rewiredArgType = rewireType(arg.type);
+            if (rewiredArgType != null) {
+                arg.type = rewiredArgType;
+                rewiredArgs[argName] = arg;
+            }
+        }
+        return rewiredArgs;
+    }
+    function rewireNamedType(type) {
+        if (graphql.isObjectType(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                fields: () => rewireFields(config.fields),
+                interfaces: () => rewireNamedTypes(config.interfaces),
+            };
+            return new graphql.GraphQLObjectType(newConfig);
+        }
+        else if (graphql.isInterfaceType(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                fields: () => rewireFields(config.fields),
+            };
+            if ('interfaces' in newConfig) {
+                newConfig.interfaces = () => rewireNamedTypes(config.interfaces);
+            }
+            return new graphql.GraphQLInterfaceType(newConfig);
+        }
+        else if (graphql.isUnionType(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                types: () => rewireNamedTypes(config.types),
+            };
+            return new graphql.GraphQLUnionType(newConfig);
+        }
+        else if (graphql.isInputObjectType(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                fields: () => rewireInputFields(config.fields),
+            };
+            return new graphql.GraphQLInputObjectType(newConfig);
+        }
+        else if (graphql.isEnumType(type)) {
+            const enumConfig = type.toConfig();
+            return new graphql.GraphQLEnumType(enumConfig);
+        }
+        else if (graphql.isScalarType(type)) {
+            if (graphql.isSpecifiedScalarType(type)) {
+                return type;
+            }
+            const scalarConfig = type.toConfig();
+            return new graphql.GraphQLScalarType(scalarConfig);
+        }
+        throw new Error(`Unexpected schema type: ${type}`);
+    }
+    function rewireFields(fields) {
+        const rewiredFields = {};
+        for (const fieldName in fields) {
+            const field = fields[fieldName];
+            const rewiredFieldType = rewireType(field.type);
+            if (rewiredFieldType != null && field.args) {
+                field.type = rewiredFieldType;
+                field.args = rewireArgs(field.args);
+                rewiredFields[fieldName] = field;
+            }
+        }
+        return rewiredFields;
+    }
+    function rewireInputFields(fields) {
+        const rewiredFields = {};
+        for (const fieldName in fields) {
+            const field = fields[fieldName];
+            const rewiredFieldType = rewireType(field.type);
+            if (rewiredFieldType != null) {
+                field.type = rewiredFieldType;
+                rewiredFields[fieldName] = field;
+            }
+        }
+        return rewiredFields;
+    }
+    function rewireNamedTypes(namedTypes) {
+        const rewiredTypes = [];
+        for (const namedType of namedTypes) {
+            const rewiredType = rewireType(namedType);
+            if (rewiredType != null) {
+                rewiredTypes.push(rewiredType);
+            }
+        }
+        return rewiredTypes;
+    }
+    function rewireType(type) {
+        if (graphql.isListType(type)) {
+            const rewiredType = rewireType(type.ofType);
+            return rewiredType != null ? new graphql.GraphQLList(rewiredType) : null;
+        }
+        else if (graphql.isNonNullType(type)) {
+            const rewiredType = rewireType(type.ofType);
+            return rewiredType != null ? new graphql.GraphQLNonNull(rewiredType) : null;
+        }
+        else if (graphql.isNamedType(type)) {
+            let rewiredType = referenceTypeMap[type.name];
+            if (rewiredType === undefined) {
+                rewiredType = isNamedStub(type) ? getBuiltInForStub(type) : rewireNamedType(type);
+                newTypeMap[rewiredType.name] = referenceTypeMap[type.name] = rewiredType;
+            }
+            return rewiredType != null ? newTypeMap[rewiredType.name] : null;
+        }
+        return null;
+    }
+}
+
+function transformInputValue(type, value, inputLeafValueTransformer = null, inputObjectValueTransformer = null) {
+    if (value == null) {
+        return value;
+    }
+    const nullableType = graphql.getNullableType(type);
+    if (graphql.isLeafType(nullableType)) {
+        return inputLeafValueTransformer != null ? inputLeafValueTransformer(nullableType, value) : value;
+    }
+    else if (graphql.isListType(nullableType)) {
+        return value.map((listMember) => transformInputValue(nullableType.ofType, listMember, inputLeafValueTransformer, inputObjectValueTransformer));
+    }
+    else if (graphql.isInputObjectType(nullableType)) {
+        const fields = nullableType.getFields();
+        const newValue = {};
+        for (const key in value) {
+            const field = fields[key];
+            if (field != null) {
+                newValue[key] = transformInputValue(field.type, value[key], inputLeafValueTransformer, inputObjectValueTransformer);
+            }
+        }
+        return inputObjectValueTransformer != null ? inputObjectValueTransformer(nullableType, newValue) : newValue;
+    }
+    // unreachable, no other possible return value
+}
+function serializeInputValue(type, value) {
+    return transformInputValue(type, value, (t, v) => {
+        try {
+            return t.serialize(v);
+        }
+        catch (_a) {
+            return v;
+        }
+    });
+}
+function parseInputValue(type, value) {
+    return transformInputValue(type, value, (t, v) => {
+        try {
+            return t.parseValue(v);
+        }
+        catch (_a) {
+            return v;
+        }
+    });
+}
+function parseInputValueLiteral(type, value) {
+    return transformInputValue(type, value, (t, v) => t.parseLiteral(v, {}));
+}
+
+function mapSchema(schema, schemaMapper = {}) {
+    const newTypeMap = mapArguments(mapFields(mapTypes(mapDefaultValues(mapEnumValues(mapTypes(mapDefaultValues(schema.getTypeMap(), schema, serializeInputValue), schema, schemaMapper, type => graphql.isLeafType(type)), schema, schemaMapper), schema, parseInputValue), schema, schemaMapper, type => !graphql.isLeafType(type)), schema, schemaMapper), schema, schemaMapper);
+    const originalDirectives = schema.getDirectives();
+    const newDirectives = mapDirectives(originalDirectives, schema, schemaMapper);
+    const { typeMap, directives } = rewireTypes(newTypeMap, newDirectives);
+    return new graphql.GraphQLSchema({
+        ...schema.toConfig(),
+        query: getObjectTypeFromTypeMap(typeMap, getObjectTypeFromTypeMap(newTypeMap, schema.getQueryType())),
+        mutation: getObjectTypeFromTypeMap(typeMap, getObjectTypeFromTypeMap(newTypeMap, schema.getMutationType())),
+        subscription: getObjectTypeFromTypeMap(typeMap, getObjectTypeFromTypeMap(newTypeMap, schema.getSubscriptionType())),
+        types: Object.values(typeMap),
+        directives,
+    });
+}
+function mapTypes(originalTypeMap, schema, schemaMapper, testFn = () => true) {
+    const newTypeMap = {};
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__')) {
+            const originalType = originalTypeMap[typeName];
+            if (originalType == null || !testFn(originalType)) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const typeMapper = getTypeMapper(schema, schemaMapper, typeName);
+            if (typeMapper == null) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const maybeNewType = typeMapper(originalType, schema);
+            if (maybeNewType === undefined) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            newTypeMap[typeName] = maybeNewType;
+        }
+    }
+    return newTypeMap;
+}
+function mapEnumValues(originalTypeMap, schema, schemaMapper) {
+    const enumValueMapper = getEnumValueMapper(schemaMapper);
+    if (!enumValueMapper) {
+        return originalTypeMap;
+    }
+    return mapTypes(originalTypeMap, schema, {
+        [exports.MapperKind.ENUM_TYPE]: type => {
+            const config = type.toConfig();
+            const originalEnumValueConfigMap = config.values;
+            const newEnumValueConfigMap = {};
+            for (const externalValue in originalEnumValueConfigMap) {
+                const originalEnumValueConfig = originalEnumValueConfigMap[externalValue];
+                const mappedEnumValue = enumValueMapper(originalEnumValueConfig, type.name, schema, externalValue);
+                if (mappedEnumValue === undefined) {
+                    newEnumValueConfigMap[externalValue] = originalEnumValueConfig;
+                }
+                else if (Array.isArray(mappedEnumValue)) {
+                    const [newExternalValue, newEnumValueConfig] = mappedEnumValue;
+                    newEnumValueConfigMap[newExternalValue] =
+                        newEnumValueConfig === undefined ? originalEnumValueConfig : newEnumValueConfig;
+                }
+                else if (mappedEnumValue !== null) {
+                    newEnumValueConfigMap[externalValue] = mappedEnumValue;
+                }
+            }
+            return correctASTNodes(new graphql.GraphQLEnumType({
+                ...config,
+                values: newEnumValueConfigMap,
+            }));
+        },
+    }, type => graphql.isEnumType(type));
+}
+function mapDefaultValues(originalTypeMap, schema, fn) {
+    const newTypeMap = mapArguments(originalTypeMap, schema, {
+        [exports.MapperKind.ARGUMENT]: argumentConfig => {
+            if (argumentConfig.defaultValue === undefined) {
+                return argumentConfig;
+            }
+            const maybeNewType = getNewType(originalTypeMap, argumentConfig.type);
+            if (maybeNewType != null) {
+                return {
+                    ...argumentConfig,
+                    defaultValue: fn(maybeNewType, argumentConfig.defaultValue),
+                };
+            }
+        },
+    });
+    return mapFields(newTypeMap, schema, {
+        [exports.MapperKind.INPUT_OBJECT_FIELD]: inputFieldConfig => {
+            if (inputFieldConfig.defaultValue === undefined) {
+                return inputFieldConfig;
+            }
+            const maybeNewType = getNewType(newTypeMap, inputFieldConfig.type);
+            if (maybeNewType != null) {
+                return {
+                    ...inputFieldConfig,
+                    defaultValue: fn(maybeNewType, inputFieldConfig.defaultValue),
+                };
+            }
+        },
+    });
+}
+function getNewType(newTypeMap, type) {
+    if (graphql.isListType(type)) {
+        const newType = getNewType(newTypeMap, type.ofType);
+        return newType != null ? new graphql.GraphQLList(newType) : null;
+    }
+    else if (graphql.isNonNullType(type)) {
+        const newType = getNewType(newTypeMap, type.ofType);
+        return newType != null ? new graphql.GraphQLNonNull(newType) : null;
+    }
+    else if (graphql.isNamedType(type)) {
+        const newType = newTypeMap[type.name];
+        return newType != null ? newType : null;
+    }
+    return null;
+}
+function mapFields(originalTypeMap, schema, schemaMapper) {
+    const newTypeMap = {};
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__')) {
+            const originalType = originalTypeMap[typeName];
+            if (!graphql.isObjectType(originalType) && !graphql.isInterfaceType(originalType) && !graphql.isInputObjectType(originalType)) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const fieldMapper = getFieldMapper(schema, schemaMapper, typeName);
+            if (fieldMapper == null) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const config = originalType.toConfig();
+            const originalFieldConfigMap = config.fields;
+            const newFieldConfigMap = {};
+            for (const fieldName in originalFieldConfigMap) {
+                const originalFieldConfig = originalFieldConfigMap[fieldName];
+                const mappedField = fieldMapper(originalFieldConfig, fieldName, typeName, schema);
+                if (mappedField === undefined) {
+                    newFieldConfigMap[fieldName] = originalFieldConfig;
+                }
+                else if (Array.isArray(mappedField)) {
+                    const [newFieldName, newFieldConfig] = mappedField;
+                    if (newFieldConfig.astNode != null) {
+                        newFieldConfig.astNode = {
+                            ...newFieldConfig.astNode,
+                            name: {
+                                ...newFieldConfig.astNode.name,
+                                value: newFieldName,
+                            },
+                        };
+                    }
+                    newFieldConfigMap[newFieldName] = newFieldConfig === undefined ? originalFieldConfig : newFieldConfig;
+                }
+                else if (mappedField !== null) {
+                    newFieldConfigMap[fieldName] = mappedField;
+                }
+            }
+            if (graphql.isObjectType(originalType)) {
+                newTypeMap[typeName] = correctASTNodes(new graphql.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+            else if (graphql.isInterfaceType(originalType)) {
+                newTypeMap[typeName] = correctASTNodes(new graphql.GraphQLInterfaceType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+            else {
+                newTypeMap[typeName] = correctASTNodes(new graphql.GraphQLInputObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        }
+    }
+    return newTypeMap;
+}
+function mapArguments(originalTypeMap, schema, schemaMapper) {
+    const newTypeMap = {};
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__')) {
+            const originalType = originalTypeMap[typeName];
+            if (!graphql.isObjectType(originalType) && !graphql.isInterfaceType(originalType)) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const argumentMapper = getArgumentMapper(schemaMapper);
+            if (argumentMapper == null) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const config = originalType.toConfig();
+            const originalFieldConfigMap = config.fields;
+            const newFieldConfigMap = {};
+            for (const fieldName in originalFieldConfigMap) {
+                const originalFieldConfig = originalFieldConfigMap[fieldName];
+                const originalArgumentConfigMap = originalFieldConfig.args;
+                if (originalArgumentConfigMap == null) {
+                    newFieldConfigMap[fieldName] = originalFieldConfig;
+                    continue;
+                }
+                const argumentNames = Object.keys(originalArgumentConfigMap);
+                if (!argumentNames.length) {
+                    newFieldConfigMap[fieldName] = originalFieldConfig;
+                    continue;
+                }
+                const newArgumentConfigMap = {};
+                for (const argumentName of argumentNames) {
+                    const originalArgumentConfig = originalArgumentConfigMap[argumentName];
+                    const mappedArgument = argumentMapper(originalArgumentConfig, fieldName, typeName, schema);
+                    if (mappedArgument === undefined) {
+                        newArgumentConfigMap[argumentName] = originalArgumentConfig;
+                    }
+                    else if (Array.isArray(mappedArgument)) {
+                        const [newArgumentName, newArgumentConfig] = mappedArgument;
+                        newArgumentConfigMap[newArgumentName] = newArgumentConfig;
+                    }
+                    else if (mappedArgument !== null) {
+                        newArgumentConfigMap[argumentName] = mappedArgument;
+                    }
+                }
+                newFieldConfigMap[fieldName] = {
+                    ...originalFieldConfig,
+                    args: newArgumentConfigMap,
+                };
+            }
+            if (graphql.isObjectType(originalType)) {
+                newTypeMap[typeName] = new graphql.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                });
+            }
+            else if (graphql.isInterfaceType(originalType)) {
+                newTypeMap[typeName] = new graphql.GraphQLInterfaceType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                });
+            }
+            else {
+                newTypeMap[typeName] = new graphql.GraphQLInputObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                });
+            }
+        }
+    }
+    return newTypeMap;
+}
+function mapDirectives(originalDirectives, schema, schemaMapper) {
+    const directiveMapper = getDirectiveMapper(schemaMapper);
+    if (directiveMapper == null) {
+        return originalDirectives.slice();
+    }
+    const newDirectives = [];
+    for (const directive of originalDirectives) {
+        const mappedDirective = directiveMapper(directive, schema);
+        if (mappedDirective === undefined) {
+            newDirectives.push(directive);
+        }
+        else if (mappedDirective !== null) {
+            newDirectives.push(mappedDirective);
+        }
+    }
+    return newDirectives;
+}
+function getTypeSpecifiers(schema, typeName) {
+    var _a, _b, _c;
+    const type = schema.getType(typeName);
+    const specifiers = [exports.MapperKind.TYPE];
+    if (graphql.isObjectType(type)) {
+        specifiers.push(exports.MapperKind.COMPOSITE_TYPE, exports.MapperKind.OBJECT_TYPE);
+        if (typeName === ((_a = schema.getQueryType()) === null || _a === void 0 ? void 0 : _a.name)) {
+            specifiers.push(exports.MapperKind.ROOT_OBJECT, exports.MapperKind.QUERY);
+        }
+        else if (typeName === ((_b = schema.getMutationType()) === null || _b === void 0 ? void 0 : _b.name)) {
+            specifiers.push(exports.MapperKind.ROOT_OBJECT, exports.MapperKind.MUTATION);
+        }
+        else if (typeName === ((_c = schema.getSubscriptionType()) === null || _c === void 0 ? void 0 : _c.name)) {
+            specifiers.push(exports.MapperKind.ROOT_OBJECT, exports.MapperKind.SUBSCRIPTION);
+        }
+    }
+    else if (graphql.isInputObjectType(type)) {
+        specifiers.push(exports.MapperKind.INPUT_OBJECT_TYPE);
+    }
+    else if (graphql.isInterfaceType(type)) {
+        specifiers.push(exports.MapperKind.COMPOSITE_TYPE, exports.MapperKind.ABSTRACT_TYPE, exports.MapperKind.INTERFACE_TYPE);
+    }
+    else if (graphql.isUnionType(type)) {
+        specifiers.push(exports.MapperKind.COMPOSITE_TYPE, exports.MapperKind.ABSTRACT_TYPE, exports.MapperKind.UNION_TYPE);
+    }
+    else if (graphql.isEnumType(type)) {
+        specifiers.push(exports.MapperKind.ENUM_TYPE);
+    }
+    else if (graphql.isScalarType(type)) {
+        specifiers.push(exports.MapperKind.SCALAR_TYPE);
+    }
+    return specifiers;
+}
+function getTypeMapper(schema, schemaMapper, typeName) {
+    const specifiers = getTypeSpecifiers(schema, typeName);
+    let typeMapper;
+    const stack = [...specifiers];
+    while (!typeMapper && stack.length > 0) {
+        // It is safe to use the ! operator here as we check the length.
+        const next = stack.pop();
+        typeMapper = schemaMapper[next];
+    }
+    return typeMapper != null ? typeMapper : null;
+}
+function getFieldSpecifiers(schema, typeName) {
+    var _a, _b, _c;
+    const type = schema.getType(typeName);
+    const specifiers = [exports.MapperKind.FIELD];
+    if (graphql.isObjectType(type)) {
+        specifiers.push(exports.MapperKind.COMPOSITE_FIELD, exports.MapperKind.OBJECT_FIELD);
+        if (typeName === ((_a = schema.getQueryType()) === null || _a === void 0 ? void 0 : _a.name)) {
+            specifiers.push(exports.MapperKind.ROOT_FIELD, exports.MapperKind.QUERY_ROOT_FIELD);
+        }
+        else if (typeName === ((_b = schema.getMutationType()) === null || _b === void 0 ? void 0 : _b.name)) {
+            specifiers.push(exports.MapperKind.ROOT_FIELD, exports.MapperKind.MUTATION_ROOT_FIELD);
+        }
+        else if (typeName === ((_c = schema.getSubscriptionType()) === null || _c === void 0 ? void 0 : _c.name)) {
+            specifiers.push(exports.MapperKind.ROOT_FIELD, exports.MapperKind.SUBSCRIPTION_ROOT_FIELD);
+        }
+    }
+    else if (graphql.isInterfaceType(type)) {
+        specifiers.push(exports.MapperKind.COMPOSITE_FIELD, exports.MapperKind.INTERFACE_FIELD);
+    }
+    else if (graphql.isInputObjectType(type)) {
+        specifiers.push(exports.MapperKind.INPUT_OBJECT_FIELD);
+    }
+    return specifiers;
+}
+function getFieldMapper(schema, schemaMapper, typeName) {
+    const specifiers = getFieldSpecifiers(schema, typeName);
+    let fieldMapper;
+    const stack = [...specifiers];
+    while (!fieldMapper && stack.length > 0) {
+        // It is safe to use the ! operator here as we check the length.
+        const next = stack.pop();
+        // TODO: fix this as unknown cast
+        fieldMapper = schemaMapper[next];
+    }
+    return fieldMapper !== null && fieldMapper !== void 0 ? fieldMapper : null;
+}
+function getArgumentMapper(schemaMapper) {
+    const argumentMapper = schemaMapper[exports.MapperKind.ARGUMENT];
+    return argumentMapper != null ? argumentMapper : null;
+}
+function getDirectiveMapper(schemaMapper) {
+    const directiveMapper = schemaMapper[exports.MapperKind.DIRECTIVE];
+    return directiveMapper != null ? directiveMapper : null;
+}
+function getEnumValueMapper(schemaMapper) {
+    const enumValueMapper = schemaMapper[exports.MapperKind.ENUM_VALUE];
+    return enumValueMapper != null ? enumValueMapper : null;
+}
+function correctASTNodes(type) {
+    if (graphql.isObjectType(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const fields = [];
+            for (const fieldName in config.fields) {
+                const fieldConfig = config.fields[fieldName];
+                if (fieldConfig.astNode != null) {
+                    fields.push(fieldConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                kind: graphql.Kind.OBJECT_TYPE_DEFINITION,
+                fields,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                kind: graphql.Kind.OBJECT_TYPE_EXTENSION,
+                fields: undefined,
+            }));
+        }
+        return new graphql.GraphQLObjectType(config);
+    }
+    else if (graphql.isInterfaceType(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const fields = [];
+            for (const fieldName in config.fields) {
+                const fieldConfig = config.fields[fieldName];
+                if (fieldConfig.astNode != null) {
+                    fields.push(fieldConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                kind: graphql.Kind.INTERFACE_TYPE_DEFINITION,
+                fields,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                kind: graphql.Kind.INTERFACE_TYPE_EXTENSION,
+                fields: undefined,
+            }));
+        }
+        return new graphql.GraphQLInterfaceType(config);
+    }
+    else if (graphql.isInputObjectType(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const fields = [];
+            for (const fieldName in config.fields) {
+                const fieldConfig = config.fields[fieldName];
+                if (fieldConfig.astNode != null) {
+                    fields.push(fieldConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                kind: graphql.Kind.INPUT_OBJECT_TYPE_DEFINITION,
+                fields,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                kind: graphql.Kind.INPUT_OBJECT_TYPE_EXTENSION,
+                fields: undefined,
+            }));
+        }
+        return new graphql.GraphQLInputObjectType(config);
+    }
+    else if (graphql.isEnumType(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const values = [];
+            for (const enumKey in config.values) {
+                const enumValueConfig = config.values[enumKey];
+                if (enumValueConfig.astNode != null) {
+                    values.push(enumValueConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                values,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                values: undefined,
+            }));
+        }
+        return new graphql.GraphQLEnumType(config);
+    }
+    else {
+        return type;
+    }
+}
+
+function filterSchema({ schema, typeFilter = () => true, fieldFilter = undefined, rootFieldFilter = undefined, objectFieldFilter = undefined, interfaceFieldFilter = undefined, inputObjectFieldFilter = undefined, argumentFilter = undefined, }) {
+    const filteredSchema = mapSchema(schema, {
+        [exports.MapperKind.QUERY]: (type) => filterRootFields(type, 'Query', rootFieldFilter, argumentFilter),
+        [exports.MapperKind.MUTATION]: (type) => filterRootFields(type, 'Mutation', rootFieldFilter, argumentFilter),
+        [exports.MapperKind.SUBSCRIPTION]: (type) => filterRootFields(type, 'Subscription', rootFieldFilter, argumentFilter),
+        [exports.MapperKind.OBJECT_TYPE]: (type) => typeFilter(type.name, type)
+            ? filterElementFields(graphql.GraphQLObjectType, type, objectFieldFilter || fieldFilter, argumentFilter)
+            : null,
+        [exports.MapperKind.INTERFACE_TYPE]: (type) => typeFilter(type.name, type)
+            ? filterElementFields(graphql.GraphQLInterfaceType, type, interfaceFieldFilter || fieldFilter, argumentFilter)
+            : null,
+        [exports.MapperKind.INPUT_OBJECT_TYPE]: (type) => typeFilter(type.name, type)
+            ? filterElementFields(graphql.GraphQLInputObjectType, type, inputObjectFieldFilter || fieldFilter)
+            : null,
+        [exports.MapperKind.UNION_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
+        [exports.MapperKind.ENUM_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
+        [exports.MapperKind.SCALAR_TYPE]: (type) => (typeFilter(type.name, type) ? undefined : null),
+    });
+    return filteredSchema;
+}
+function filterRootFields(type, operation, rootFieldFilter, argumentFilter) {
+    if (rootFieldFilter || argumentFilter) {
+        const config = type.toConfig();
+        for (const fieldName in config.fields) {
+            const field = config.fields[fieldName];
+            if (rootFieldFilter && !rootFieldFilter(operation, fieldName, config.fields[fieldName])) {
+                delete config.fields[fieldName];
+            }
+            else if (argumentFilter && field.args) {
+                for (const argName in field.args) {
+                    if (!argumentFilter(operation, fieldName, argName, field.args[argName])) {
+                        delete field.args[argName];
+                    }
+                }
+            }
+        }
+        return new graphql.GraphQLObjectType(config);
+    }
+    return type;
+}
+function filterElementFields(ElementConstructor, type, fieldFilter, argumentFilter) {
+    if (fieldFilter || argumentFilter) {
+        const config = type.toConfig();
+        for (const fieldName in config.fields) {
+            const field = config.fields[fieldName];
+            if (fieldFilter && !fieldFilter(type.name, fieldName, config.fields[fieldName])) {
+                delete config.fields[fieldName];
+            }
+            else if (argumentFilter && 'args' in field) {
+                for (const argName in field.args) {
+                    if (!argumentFilter(type.name, fieldName, argName, field.args[argName])) {
+                        delete field.args[argName];
+                    }
+                }
+            }
+        }
+        return new ElementConstructor(config);
+    }
+}
+
+// Update any references to named schema types that disagree with the named
+// types found in schema.getTypeMap().
+//
+// healSchema and its callers (visitSchema/visitSchemaDirectives) all modify the schema in place.
+// Therefore, private variables (such as the stored implementation map and the proper root types)
+// are not updated.
+//
+// If this causes issues, the schema could be more aggressively healed as follows:
+//
+// healSchema(schema);
+// const config = schema.toConfig()
+// const healedSchema = new GraphQLSchema({
+//   ...config,
+//   query: schema.getType('<desired new root query type name>'),
+//   mutation: schema.getType('<desired new root mutation type name>'),
+//   subscription: schema.getType('<desired new root subscription type name>'),
+// });
+//
+// One can then also -- if necessary --  assign the correct private variables to the initial schema
+// as follows:
+// Object.assign(schema, healedSchema);
+//
+// These steps are not taken automatically to preserve backwards compatibility with graphql-tools v4.
+// See https://github.com/ardatan/graphql-tools/issues/1462
+//
+// They were briefly taken in v5, but can now be phased out as they were only required when other
+// areas of the codebase were using healSchema and visitSchema more extensively.
+//
+function healSchema(schema) {
+    healTypes(schema.getTypeMap(), schema.getDirectives());
+    return schema;
+}
+function healTypes(originalTypeMap, directives) {
+    const actualNamedTypeMap = Object.create(null);
+    // If any of the .name properties of the GraphQLNamedType objects in
+    // schema.getTypeMap() have changed, the keys of the type map need to
+    // be updated accordingly.
+    for (const typeName in originalTypeMap) {
+        const namedType = originalTypeMap[typeName];
+        if (namedType == null || typeName.startsWith('__')) {
+            continue;
+        }
+        const actualName = namedType.name;
+        if (actualName.startsWith('__')) {
+            continue;
+        }
+        if (actualName in actualNamedTypeMap) {
+            throw new Error(`Duplicate schema type name ${actualName}`);
+        }
+        actualNamedTypeMap[actualName] = namedType;
+        // Note: we are deliberately leaving namedType in the schema by its
+        // original name (which might be different from actualName), so that
+        // references by that name can be healed.
+    }
+    // Now add back every named type by its actual name.
+    for (const typeName in actualNamedTypeMap) {
+        const namedType = actualNamedTypeMap[typeName];
+        originalTypeMap[typeName] = namedType;
+    }
+    // Directive declaration argument types can refer to named types.
+    for (const decl of directives) {
+        decl.args = decl.args.filter(arg => {
+            arg.type = healType(arg.type);
+            return arg.type !== null;
+        });
+    }
+    for (const typeName in originalTypeMap) {
+        const namedType = originalTypeMap[typeName];
+        // Heal all named types, except for dangling references, kept only to redirect.
+        if (!typeName.startsWith('__') && typeName in actualNamedTypeMap) {
+            if (namedType != null) {
+                healNamedType(namedType);
+            }
+        }
+    }
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__') && !(typeName in actualNamedTypeMap)) {
+            delete originalTypeMap[typeName];
+        }
+    }
+    function healNamedType(type) {
+        if (graphql.isObjectType(type)) {
+            healFields(type);
+            healInterfaces(type);
+            return;
+        }
+        else if (graphql.isInterfaceType(type)) {
+            healFields(type);
+            if ('getInterfaces' in type) {
+                healInterfaces(type);
+            }
+            return;
+        }
+        else if (graphql.isUnionType(type)) {
+            healUnderlyingTypes(type);
+            return;
+        }
+        else if (graphql.isInputObjectType(type)) {
+            healInputFields(type);
+            return;
+        }
+        else if (graphql.isLeafType(type)) {
+            return;
+        }
+        throw new Error(`Unexpected schema type: ${type}`);
+    }
+    function healFields(type) {
+        const fieldMap = type.getFields();
+        for (const [key, field] of Object.entries(fieldMap)) {
+            field.args
+                .map(arg => {
+                arg.type = healType(arg.type);
+                return arg.type === null ? null : arg;
+            })
+                .filter(Boolean);
+            field.type = healType(field.type);
+            if (field.type === null) {
+                delete fieldMap[key];
+            }
+        }
+    }
+    function healInterfaces(type) {
+        if ('getInterfaces' in type) {
+            const interfaces = type.getInterfaces();
+            interfaces.push(...interfaces
+                .splice(0)
+                .map(iface => healType(iface))
+                .filter(Boolean));
+        }
+    }
+    function healInputFields(type) {
+        const fieldMap = type.getFields();
+        for (const [key, field] of Object.entries(fieldMap)) {
+            field.type = healType(field.type);
+            if (field.type === null) {
+                delete fieldMap[key];
+            }
+        }
+    }
+    function healUnderlyingTypes(type) {
+        const types = type.getTypes();
+        types.push(...types
+            .splice(0)
+            .map(t => healType(t))
+            .filter(Boolean));
+    }
+    function healType(type) {
+        // Unwrap the two known wrapper types
+        if (graphql.isListType(type)) {
+            const healedType = healType(type.ofType);
+            return healedType != null ? new graphql.GraphQLList(healedType) : null;
+        }
+        else if (graphql.isNonNullType(type)) {
+            const healedType = healType(type.ofType);
+            return healedType != null ? new graphql.GraphQLNonNull(healedType) : null;
+        }
+        else if (graphql.isNamedType(type)) {
+            // If a type annotation on a field or an argument or a union member is
+            // any `GraphQLNamedType` with a `name`, then it must end up identical
+            // to `schema.getType(name)`, since `schema.getTypeMap()` is the source
+            // of truth for all named schema types.
+            // Note that new types can still be simply added by adding a field, as
+            // the official type will be undefined, not null.
+            const officialType = originalTypeMap[type.name];
+            if (officialType && type !== officialType) {
+                return officialType;
+            }
+        }
+        return type;
+    }
+}
+
+function getResolversFromSchema(schema) {
+    var _a, _b;
+    const resolvers = Object.create(null);
+    const typeMap = schema.getTypeMap();
+    for (const typeName in typeMap) {
+        if (!typeName.startsWith('__')) {
+            const type = typeMap[typeName];
+            if (graphql.isScalarType(type)) {
+                if (!graphql.isSpecifiedScalarType(type)) {
+                    const config = type.toConfig();
+                    delete config.astNode; // avoid AST duplication elsewhere
+                    resolvers[typeName] = new graphql.GraphQLScalarType(config);
+                }
+            }
+            else if (graphql.isEnumType(type)) {
+                resolvers[typeName] = {};
+                const values = type.getValues();
+                for (const value of values) {
+                    resolvers[typeName][value.name] = value.value;
+                }
+            }
+            else if (graphql.isInterfaceType(type)) {
+                if (type.resolveType != null) {
+                    resolvers[typeName] = {
+                        __resolveType: type.resolveType,
+                    };
+                }
+            }
+            else if (graphql.isUnionType(type)) {
+                if (type.resolveType != null) {
+                    resolvers[typeName] = {
+                        __resolveType: type.resolveType,
+                    };
+                }
+            }
+            else if (graphql.isObjectType(type)) {
+                resolvers[typeName] = {};
+                if (type.isTypeOf != null) {
+                    resolvers[typeName].__isTypeOf = type.isTypeOf;
+                }
+                const fields = type.getFields();
+                for (const fieldName in fields) {
+                    const field = fields[fieldName];
+                    if (field.subscribe != null) {
+                        resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
+                        resolvers[typeName][fieldName].subscribe = field.subscribe;
+                    }
+                    if (field.resolve != null &&
+                        ((_a = field.resolve) === null || _a === void 0 ? void 0 : _a.name) !== 'defaultFieldResolver' &&
+                        ((_b = field.resolve) === null || _b === void 0 ? void 0 : _b.name) !== 'defaultMergedResolver') {
+                        resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
+                        resolvers[typeName][fieldName].resolve = field.resolve;
+                    }
+                }
+            }
+        }
+    }
+    return resolvers;
+}
+
+function forEachField(schema, fn) {
+    const typeMap = schema.getTypeMap();
+    for (const typeName in typeMap) {
+        const type = typeMap[typeName];
+        // TODO: maybe have an option to include these?
+        if (!graphql.getNamedType(type).name.startsWith('__') && graphql.isObjectType(type)) {
+            const fields = type.getFields();
+            for (const fieldName in fields) {
+                const field = fields[fieldName];
+                fn(field, typeName, fieldName);
+            }
+        }
+    }
+}
+
+function forEachDefaultValue(schema, fn) {
+    const typeMap = schema.getTypeMap();
+    for (const typeName in typeMap) {
+        const type = typeMap[typeName];
+        if (!graphql.getNamedType(type).name.startsWith('__')) {
+            if (graphql.isObjectType(type)) {
+                const fields = type.getFields();
+                for (const fieldName in fields) {
+                    const field = fields[fieldName];
+                    for (const arg of field.args) {
+                        arg.defaultValue = fn(arg.type, arg.defaultValue);
+                    }
+                }
+            }
+            else if (graphql.isInputObjectType(type)) {
+                const fields = type.getFields();
+                for (const fieldName in fields) {
+                    const field = fields[fieldName];
+                    field.defaultValue = fn(field.type, field.defaultValue);
+                }
+            }
+        }
+    }
+}
+
+// addTypes uses toConfig to create a new schema with a new or replaced
+function addTypes(schema, newTypesOrDirectives) {
+    const config = schema.toConfig();
+    const originalTypeMap = {};
+    for (const type of config.types) {
+        originalTypeMap[type.name] = type;
+    }
+    const originalDirectiveMap = {};
+    for (const directive of config.directives) {
+        originalDirectiveMap[directive.name] = directive;
+    }
+    for (const newTypeOrDirective of newTypesOrDirectives) {
+        if (graphql.isNamedType(newTypeOrDirective)) {
+            originalTypeMap[newTypeOrDirective.name] = newTypeOrDirective;
+        }
+        else if (graphql.isDirective(newTypeOrDirective)) {
+            originalDirectiveMap[newTypeOrDirective.name] = newTypeOrDirective;
+        }
+    }
+    const { typeMap, directives } = rewireTypes(originalTypeMap, Object.values(originalDirectiveMap));
+    return new graphql.GraphQLSchema({
+        ...config,
+        query: getObjectTypeFromTypeMap(typeMap, schema.getQueryType()),
+        mutation: getObjectTypeFromTypeMap(typeMap, schema.getMutationType()),
+        subscription: getObjectTypeFromTypeMap(typeMap, schema.getSubscriptionType()),
+        types: Object.values(typeMap),
+        directives,
+    });
+}
+
+/**
+ * Prunes the provided schema, removing unused and empty types
+ * @param schema The schema to prune
+ * @param options Additional options for removing unused types from the schema
+ */
+function pruneSchema(schema, options = {}) {
+    const { skipEmptyCompositeTypePruning, skipEmptyUnionPruning, skipPruning, skipUnimplementedInterfacesPruning, skipUnusedTypesPruning, } = options;
+    let prunedTypes = []; // Pruned types during mapping
+    let prunedSchema = schema;
+    do {
+        let visited = visitSchema(prunedSchema);
+        // Custom pruning  was defined, so we need to pre-emptively revisit the schema accounting for this
+        if (skipPruning) {
+            const revisit = [];
+            for (const typeName in prunedSchema.getTypeMap()) {
+                if (typeName.startsWith('__')) {
+                    continue;
+                }
+                const type = prunedSchema.getType(typeName);
+                // if we want to skip pruning for this type, add it to the list of types to revisit
+                if (type && skipPruning(type)) {
+                    revisit.push(typeName);
+                }
+            }
+            visited = visitQueue(revisit, prunedSchema, visited); // visit again
+        }
+        prunedTypes = [];
+        prunedSchema = mapSchema(prunedSchema, {
+            [exports.MapperKind.TYPE]: type => {
+                if (!visited.has(type.name) && !graphql.isSpecifiedScalarType(type)) {
+                    if (graphql.isUnionType(type) ||
+                        graphql.isInputObjectType(type) ||
+                        graphql.isInterfaceType(type) ||
+                        graphql.isObjectType(type) ||
+                        graphql.isScalarType(type)) {
+                        // skipUnusedTypesPruning: skip pruning unused types
+                        if (skipUnusedTypesPruning) {
+                            return type;
+                        }
+                        // skipEmptyUnionPruning: skip pruning empty unions
+                        if (graphql.isUnionType(type) && skipEmptyUnionPruning && !Object.keys(type.getTypes()).length) {
+                            return type;
+                        }
+                        if (graphql.isInputObjectType(type) || graphql.isInterfaceType(type) || graphql.isObjectType(type)) {
+                            // skipEmptyCompositeTypePruning: skip pruning object types or interfaces with no fields
+                            if (skipEmptyCompositeTypePruning && !Object.keys(type.getFields()).length) {
+                                return type;
+                            }
+                        }
+                        // skipUnimplementedInterfacesPruning: skip pruning interfaces that are not implemented by any other types
+                        if (graphql.isInterfaceType(type) && skipUnimplementedInterfacesPruning) {
+                            return type;
+                        }
+                    }
+                    prunedTypes.push(type.name);
+                    visited.delete(type.name);
+                    return null;
+                }
+                return type;
+            },
+        });
+    } while (prunedTypes.length); // Might have empty types and need to prune again
+    return prunedSchema;
+}
+function visitSchema(schema) {
+    const queue = []; // queue of nodes to visit
+    // Grab the root types and start there
+    for (const type of getRootTypes(schema)) {
+        queue.push(type.name);
+    }
+    return visitQueue(queue, schema);
+}
+function visitQueue(queue, schema, visited = new Set()) {
+    // Navigate all types starting with pre-queued types (root types)
+    while (queue.length) {
+        const typeName = queue.pop();
+        // Skip types we already visited
+        if (visited.has(typeName)) {
+            continue;
+        }
+        const type = schema.getType(typeName);
+        if (type) {
+            // Get types for union
+            if (graphql.isUnionType(type)) {
+                queue.push(...type.getTypes().map(type => type.name));
+            }
+            // If the type has files visit those field types
+            if ('getFields' in type) {
+                const fields = type.getFields();
+                const entries = Object.entries(fields);
+                if (!entries.length) {
+                    continue;
+                }
+                for (const [, field] of entries) {
+                    if (graphql.isObjectType(type)) {
+                        for (const arg of field.args) {
+                            queue.push(graphql.getNamedType(arg.type).name); // Visit arg types
+                        }
+                    }
+                    queue.push(graphql.getNamedType(field.type).name);
+                }
+            }
+            // Visit interfaces this type is implementing if they haven't been visited yet
+            if ('getInterfaces' in type) {
+                queue.push(...type.getInterfaces().map(iface => iface.name));
+            }
+            visited.add(typeName); // Mark as visited (and therefore it is used and should be kept)
+        }
+    }
+    return visited;
+}
+
+function mergeDeep(sources, respectPrototype = false) {
+    const target = sources[0] || {};
+    const output = {};
+    if (respectPrototype) {
+        Object.setPrototypeOf(output, Object.create(Object.getPrototypeOf(target)));
+    }
+    for (const source of sources) {
+        if (isObject(target) && isObject(source)) {
+            if (respectPrototype) {
+                const outputPrototype = Object.getPrototypeOf(output);
+                const sourcePrototype = Object.getPrototypeOf(source);
+                if (sourcePrototype) {
+                    for (const key of Object.getOwnPropertyNames(sourcePrototype)) {
+                        const descriptor = Object.getOwnPropertyDescriptor(sourcePrototype, key);
+                        if (isSome(descriptor)) {
+                            Object.defineProperty(outputPrototype, key, descriptor);
+                        }
+                    }
+                }
+            }
+            for (const key in source) {
+                if (isObject(source[key])) {
+                    if (!(key in output)) {
+                        Object.assign(output, { [key]: source[key] });
+                    }
+                    else {
+                        output[key] = mergeDeep([output[key], source[key]], respectPrototype);
+                    }
+                }
+                else {
+                    Object.assign(output, { [key]: source[key] });
+                }
+            }
+        }
+    }
+    return output;
+}
+function isObject(item) {
+    return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+function parseSelectionSet(selectionSet, options) {
+    const query = graphql.parse(selectionSet, options).definitions[0];
+    return query.selectionSet;
+}
+
+/**
+ * Get the key under which the result of this resolver will be placed in the response JSON. Basically, just
+ * resolves aliases.
+ * @param info The info argument to the resolver.
+ */
+function getResponseKeyFromInfo(info) {
+    return info.fieldNodes[0].alias != null ? info.fieldNodes[0].alias.value : info.fieldName;
+}
+
+function appendObjectFields(schema, typeName, additionalFields) {
+    if (schema.getType(typeName) == null) {
+        return addTypes(schema, [
+            new graphql.GraphQLObjectType({
+                name: typeName,
+                fields: additionalFields,
+            }),
+        ]);
+    }
+    return mapSchema(schema, {
+        [exports.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                const newFieldConfigMap = {};
+                for (const fieldName in originalFieldConfigMap) {
+                    newFieldConfigMap[fieldName] = originalFieldConfigMap[fieldName];
+                }
+                for (const fieldName in additionalFields) {
+                    newFieldConfigMap[fieldName] = additionalFields[fieldName];
+                }
+                return correctASTNodes(new graphql.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        },
+    });
+}
+function removeObjectFields(schema, typeName, testFn) {
+    const removedFields = {};
+    const newSchema = mapSchema(schema, {
+        [exports.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                const newFieldConfigMap = {};
+                for (const fieldName in originalFieldConfigMap) {
+                    const originalFieldConfig = originalFieldConfigMap[fieldName];
+                    if (testFn(fieldName, originalFieldConfig)) {
+                        removedFields[fieldName] = originalFieldConfig;
+                    }
+                    else {
+                        newFieldConfigMap[fieldName] = originalFieldConfig;
+                    }
+                }
+                return correctASTNodes(new graphql.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        },
+    });
+    return [newSchema, removedFields];
+}
+function selectObjectFields(schema, typeName, testFn) {
+    const selectedFields = {};
+    mapSchema(schema, {
+        [exports.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                for (const fieldName in originalFieldConfigMap) {
+                    const originalFieldConfig = originalFieldConfigMap[fieldName];
+                    if (testFn(fieldName, originalFieldConfig)) {
+                        selectedFields[fieldName] = originalFieldConfig;
+                    }
+                }
+            }
+            return undefined;
+        },
+    });
+    return selectedFields;
+}
+function modifyObjectFields(schema, typeName, testFn, newFields) {
+    const removedFields = {};
+    const newSchema = mapSchema(schema, {
+        [exports.MapperKind.OBJECT_TYPE]: type => {
+            if (type.name === typeName) {
+                const config = type.toConfig();
+                const originalFieldConfigMap = config.fields;
+                const newFieldConfigMap = {};
+                for (const fieldName in originalFieldConfigMap) {
+                    const originalFieldConfig = originalFieldConfigMap[fieldName];
+                    if (testFn(fieldName, originalFieldConfig)) {
+                        removedFields[fieldName] = originalFieldConfig;
+                    }
+                    else {
+                        newFieldConfigMap[fieldName] = originalFieldConfig;
+                    }
+                }
+                for (const fieldName in newFields) {
+                    const fieldConfig = newFields[fieldName];
+                    newFieldConfigMap[fieldName] = fieldConfig;
+                }
+                return correctASTNodes(new graphql.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        },
+    });
+    return [newSchema, removedFields];
+}
+
+function renameType(type, newTypeName) {
+    if (graphql.isObjectType(type)) {
+        return new graphql.GraphQLObjectType({
+            ...type.toConfig(),
+            name: newTypeName,
+            astNode: type.astNode == null
+                ? type.astNode
+                : {
+                    ...type.astNode,
+                    name: {
+                        ...type.astNode.name,
+                        value: newTypeName,
+                    },
+                },
+            extensionASTNodes: type.extensionASTNodes == null
+                ? type.extensionASTNodes
+                : type.extensionASTNodes.map(node => ({
+                    ...node,
+                    name: {
+                        ...node.name,
+                        value: newTypeName,
+                    },
+                })),
+        });
+    }
+    else if (graphql.isInterfaceType(type)) {
+        return new graphql.GraphQLInterfaceType({
+            ...type.toConfig(),
+            name: newTypeName,
+            astNode: type.astNode == null
+                ? type.astNode
+                : {
+                    ...type.astNode,
+                    name: {
+                        ...type.astNode.name,
+                        value: newTypeName,
+                    },
+                },
+            extensionASTNodes: type.extensionASTNodes == null
+                ? type.extensionASTNodes
+                : type.extensionASTNodes.map(node => ({
+                    ...node,
+                    name: {
+                        ...node.name,
+                        value: newTypeName,
+                    },
+                })),
+        });
+    }
+    else if (graphql.isUnionType(type)) {
+        return new graphql.GraphQLUnionType({
+            ...type.toConfig(),
+            name: newTypeName,
+            astNode: type.astNode == null
+                ? type.astNode
+                : {
+                    ...type.astNode,
+                    name: {
+                        ...type.astNode.name,
+                        value: newTypeName,
+                    },
+                },
+            extensionASTNodes: type.extensionASTNodes == null
+                ? type.extensionASTNodes
+                : type.extensionASTNodes.map(node => ({
+                    ...node,
+                    name: {
+                        ...node.name,
+                        value: newTypeName,
+                    },
+                })),
+        });
+    }
+    else if (graphql.isInputObjectType(type)) {
+        return new graphql.GraphQLInputObjectType({
+            ...type.toConfig(),
+            name: newTypeName,
+            astNode: type.astNode == null
+                ? type.astNode
+                : {
+                    ...type.astNode,
+                    name: {
+                        ...type.astNode.name,
+                        value: newTypeName,
+                    },
+                },
+            extensionASTNodes: type.extensionASTNodes == null
+                ? type.extensionASTNodes
+                : type.extensionASTNodes.map(node => ({
+                    ...node,
+                    name: {
+                        ...node.name,
+                        value: newTypeName,
+                    },
+                })),
+        });
+    }
+    else if (graphql.isEnumType(type)) {
+        return new graphql.GraphQLEnumType({
+            ...type.toConfig(),
+            name: newTypeName,
+            astNode: type.astNode == null
+                ? type.astNode
+                : {
+                    ...type.astNode,
+                    name: {
+                        ...type.astNode.name,
+                        value: newTypeName,
+                    },
+                },
+            extensionASTNodes: type.extensionASTNodes == null
+                ? type.extensionASTNodes
+                : type.extensionASTNodes.map(node => ({
+                    ...node,
+                    name: {
+                        ...node.name,
+                        value: newTypeName,
+                    },
+                })),
+        });
+    }
+    else if (graphql.isScalarType(type)) {
+        return new graphql.GraphQLScalarType({
+            ...type.toConfig(),
+            name: newTypeName,
+            astNode: type.astNode == null
+                ? type.astNode
+                : {
+                    ...type.astNode,
+                    name: {
+                        ...type.astNode.name,
+                        value: newTypeName,
+                    },
+                },
+            extensionASTNodes: type.extensionASTNodes == null
+                ? type.extensionASTNodes
+                : type.extensionASTNodes.map(node => ({
+                    ...node,
+                    name: {
+                        ...node.name,
+                        value: newTypeName,
+                    },
+                })),
+        });
+    }
+    throw new Error(`Unknown type ${type}.`);
+}
+
+/**
+ * Given an AsyncIterable and a callback function, return an AsyncIterator
+ * which produces values mapped via calling the callback function.
+ */
+function mapAsyncIterator(iterator, callback, rejectCallback) {
+    let $return;
+    let abruptClose;
+    if (typeof iterator.return === 'function') {
+        $return = iterator.return;
+        abruptClose = (error) => {
+            const rethrow = () => Promise.reject(error);
+            return $return.call(iterator).then(rethrow, rethrow);
+        };
+    }
+    function mapResult(result) {
+        return result.done ? result : asyncMapValue(result.value, callback).then(iteratorResult, abruptClose);
+    }
+    let mapReject;
+    if (rejectCallback) {
+        // Capture rejectCallback to ensure it cannot be null.
+        const reject = rejectCallback;
+        mapReject = (error) => asyncMapValue(error, reject).then(iteratorResult, abruptClose);
+    }
+    return {
+        next() {
+            return iterator.next().then(mapResult, mapReject);
+        },
+        return() {
+            return $return
+                ? $return.call(iterator).then(mapResult, mapReject)
+                : Promise.resolve({ value: undefined, done: true });
+        },
+        throw(error) {
+            if (typeof iterator.throw === 'function') {
+                return iterator.throw(error).then(mapResult, mapReject);
+            }
+            return Promise.reject(error).catch(abruptClose);
+        },
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+    };
+}
+function asyncMapValue(value, callback) {
+    return new Promise(resolve => resolve(callback(value)));
+}
+function iteratorResult(value) {
+    return { value, done: false };
+}
+
+function updateArgument(argumentNodes, variableDefinitionsMap, variableValues, argName, varName, type, value) {
+    argumentNodes[argName] = {
+        kind: graphql.Kind.ARGUMENT,
+        name: {
+            kind: graphql.Kind.NAME,
+            value: argName,
+        },
+        value: {
+            kind: graphql.Kind.VARIABLE,
+            name: {
+                kind: graphql.Kind.NAME,
+                value: varName,
+            },
+        },
+    };
+    variableDefinitionsMap[varName] = {
+        kind: graphql.Kind.VARIABLE_DEFINITION,
+        variable: {
+            kind: graphql.Kind.VARIABLE,
+            name: {
+                kind: graphql.Kind.NAME,
+                value: varName,
+            },
+        },
+        type: astFromType(type),
+    };
+    if (value !== undefined) {
+        variableValues[varName] = value;
+        return;
+    }
+    // including the variable in the map with value of `undefined`
+    // will actually be translated by graphql-js into `null`
+    // see https://github.com/graphql/graphql-js/issues/2533
+    if (varName in variableValues) {
+        delete variableValues[varName];
+    }
+}
+function createVariableNameGenerator(variableDefinitionMap) {
+    let varCounter = 0;
+    return (argName) => {
+        let varName;
+        do {
+            varName = `_v${(varCounter++).toString()}_${argName}`;
+        } while (varName in variableDefinitionMap);
+        return varName;
+    };
+}
+
+function implementsAbstractType(schema, typeA, typeB) {
+    if (typeB == null || typeA == null) {
+        return false;
+    }
+    else if (typeA === typeB) {
+        return true;
+    }
+    else if (graphql.isCompositeType(typeA) && graphql.isCompositeType(typeB)) {
+        return graphql.doTypesOverlap(schema, typeA, typeB);
+    }
+    return false;
+}
+
+function relocatedError(originalError, path) {
+    return new graphql.GraphQLError(originalError.message, originalError.nodes, originalError.source, originalError.positions, path === null ? undefined : path === undefined ? originalError.path : path, originalError.originalError, originalError.extensions);
+}
+
+function observableToAsyncIterable(observable) {
+    const pullQueue = [];
+    const pushQueue = [];
+    let listening = true;
+    const pushValue = (value) => {
+        if (pullQueue.length !== 0) {
+            // It is safe to use the ! operator here as we check the length.
+            pullQueue.shift()({ value, done: false });
+        }
+        else {
+            pushQueue.push({ value, done: false });
+        }
+    };
+    const pushError = (error) => {
+        if (pullQueue.length !== 0) {
+            // It is safe to use the ! operator here as we check the length.
+            pullQueue.shift()({ value: { errors: [error] }, done: false });
+        }
+        else {
+            pushQueue.push({ value: { errors: [error] }, done: false });
+        }
+    };
+    const pushDone = () => {
+        if (pullQueue.length !== 0) {
+            // It is safe to use the ! operator here as we check the length.
+            pullQueue.shift()({ done: true });
+        }
+        else {
+            pushQueue.push({ done: true });
+        }
+    };
+    const pullValue = () => new Promise(resolve => {
+        if (pushQueue.length !== 0) {
+            const element = pushQueue.shift();
+            // either {value: {errors: [...]}} or {value: ...}
+            resolve(element);
+        }
+        else {
+            pullQueue.push(resolve);
+        }
+    });
+    const subscription = observable.subscribe({
+        next(value) {
+            pushValue(value);
+        },
+        error(err) {
+            pushError(err);
+        },
+        complete() {
+            pushDone();
+        },
+    });
+    const emptyQueue = () => {
+        if (listening) {
+            listening = false;
+            subscription.unsubscribe();
+            for (const resolve of pullQueue) {
+                resolve({ value: undefined, done: true });
+            }
+            pullQueue.length = 0;
+            pushQueue.length = 0;
+        }
+    };
+    return {
+        next() {
+            // return is a defined method, so it is safe to call it.
+            return listening ? pullValue() : this.return();
+        },
+        return() {
+            emptyQueue();
+            return Promise.resolve({ value: undefined, done: true });
+        },
+        throw(error) {
+            emptyQueue();
+            return Promise.reject(error);
+        },
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+    };
+}
+
+function getOperationASTFromDocument(documentNode, operationName) {
+    const doc = graphql.getOperationAST(documentNode, operationName);
+    if (!doc) {
+        throw new Error(`Cannot infer operation ${operationName || ''}`);
+    }
+    return doc;
+}
+const getOperationASTFromRequest = memoize1(function getOperationASTFromRequest(request) {
+    return getOperationASTFromDocument(request.document, request.operationName);
+});
+
+// Taken from GraphQL-JS v16 for backwards compat
+function collectFields(schema, fragments, variableValues, runtimeType, selectionSet, fields, visitedFragmentNames) {
+    for (const selection of selectionSet.selections) {
+        switch (selection.kind) {
+            case graphql.Kind.FIELD: {
+                if (!shouldIncludeNode(variableValues, selection)) {
+                    continue;
+                }
+                const name = getFieldEntryKey(selection);
+                const fieldList = fields.get(name);
+                if (fieldList !== undefined) {
+                    fieldList.push(selection);
+                }
+                else {
+                    fields.set(name, [selection]);
+                }
+                break;
+            }
+            case graphql.Kind.INLINE_FRAGMENT: {
+                if (!shouldIncludeNode(variableValues, selection) ||
+                    !doesFragmentConditionMatch(schema, selection, runtimeType)) {
+                    continue;
+                }
+                collectFields(schema, fragments, variableValues, runtimeType, selection.selectionSet, fields, visitedFragmentNames);
+                break;
+            }
+            case graphql.Kind.FRAGMENT_SPREAD: {
+                const fragName = selection.name.value;
+                if (visitedFragmentNames.has(fragName) || !shouldIncludeNode(variableValues, selection)) {
+                    continue;
+                }
+                visitedFragmentNames.add(fragName);
+                const fragment = fragments[fragName];
+                if (!fragment || !doesFragmentConditionMatch(schema, fragment, runtimeType)) {
+                    continue;
+                }
+                collectFields(schema, fragments, variableValues, runtimeType, fragment.selectionSet, fields, visitedFragmentNames);
+                break;
+            }
+        }
+    }
+    return fields;
+}
+/**
+ * Determines if a field should be included based on the `@include` and `@skip`
+ * directives, where `@skip` has higher precedence than `@include`.
+ */
+function shouldIncludeNode(variableValues, node) {
+    const skip = graphql.getDirectiveValues(graphql.GraphQLSkipDirective, node, variableValues);
+    if ((skip === null || skip === void 0 ? void 0 : skip['if']) === true) {
+        return false;
+    }
+    const include = graphql.getDirectiveValues(graphql.GraphQLIncludeDirective, node, variableValues);
+    if ((include === null || include === void 0 ? void 0 : include['if']) === false) {
+        return false;
+    }
+    return true;
+}
+/**
+ * Determines if a fragment is applicable to the given type.
+ */
+function doesFragmentConditionMatch(schema, fragment, type) {
+    const typeConditionNode = fragment.typeCondition;
+    if (!typeConditionNode) {
+        return true;
+    }
+    const conditionalType = graphql.typeFromAST(schema, typeConditionNode);
+    if (conditionalType === type) {
+        return true;
+    }
+    if (graphql.isAbstractType(conditionalType)) {
+        const possibleTypes = schema.getPossibleTypes(conditionalType);
+        return possibleTypes.includes(type);
+    }
+    return false;
+}
+/**
+ * Implements the logic to compute the key of a given field's entry
+ */
+function getFieldEntryKey(node) {
+    return node.alias ? node.alias.value : node.name.value;
+}
+const collectSubFields = memoize5(function collectSubFields(schema, fragments, variableValues, type, fieldNodes) {
+    const subFieldNodes = new Map();
+    const visitedFragmentNames = new Set();
+    for (const fieldNode of fieldNodes) {
+        if (fieldNode.selectionSet) {
+            collectFields(schema, fragments, variableValues, type, fieldNode.selectionSet, subFieldNodes, visitedFragmentNames);
+        }
+    }
+    return subFieldNodes;
+});
+
+function visitData(data, enter, leave) {
+    if (Array.isArray(data)) {
+        return data.map(value => visitData(value, enter, leave));
+    }
+    else if (typeof data === 'object') {
+        const newData = enter != null ? enter(data) : data;
+        if (newData != null) {
+            for (const key in newData) {
+                const value = newData[key];
+                Object.defineProperty(newData, key, {
+                    value: visitData(value, enter, leave),
+                });
+            }
+        }
+        return leave != null ? leave(newData) : newData;
+    }
+    return data;
+}
+function visitErrors(errors, visitor) {
+    return errors.map(error => visitor(error));
+}
+function visitResult(result, request, schema, resultVisitorMap, errorVisitorMap) {
+    const fragments = request.document.definitions.reduce((acc, def) => {
+        if (def.kind === graphql.Kind.FRAGMENT_DEFINITION) {
+            acc[def.name.value] = def;
+        }
+        return acc;
+    }, {});
+    const variableValues = request.variables || {};
+    const errorInfo = {
+        segmentInfoMap: new Map(),
+        unpathedErrors: new Set(),
+    };
+    const data = result.data;
+    const errors = result.errors;
+    const visitingErrors = errors != null && errorVisitorMap != null;
+    const operationDocumentNode = getOperationASTFromRequest(request);
+    if (data != null && operationDocumentNode != null) {
+        result.data = visitRoot(data, operationDocumentNode, schema, fragments, variableValues, resultVisitorMap, visitingErrors ? errors : undefined, errorInfo);
+    }
+    if (errors != null && errorVisitorMap) {
+        result.errors = visitErrorsByType(errors, errorVisitorMap, errorInfo);
+    }
+    return result;
+}
+function visitErrorsByType(errors, errorVisitorMap, errorInfo) {
+    const segmentInfoMap = errorInfo.segmentInfoMap;
+    const unpathedErrors = errorInfo.unpathedErrors;
+    const unpathedErrorVisitor = errorVisitorMap['__unpathed'];
+    return errors.map(originalError => {
+        const pathSegmentsInfo = segmentInfoMap.get(originalError);
+        const newError = pathSegmentsInfo == null
+            ? originalError
+            : pathSegmentsInfo.reduceRight((acc, segmentInfo) => {
+                const typeName = segmentInfo.type.name;
+                const typeVisitorMap = errorVisitorMap[typeName];
+                if (typeVisitorMap == null) {
+                    return acc;
+                }
+                const errorVisitor = typeVisitorMap[segmentInfo.fieldName];
+                return errorVisitor == null ? acc : errorVisitor(acc, segmentInfo.pathIndex);
+            }, originalError);
+        if (unpathedErrorVisitor && unpathedErrors.has(originalError)) {
+            return unpathedErrorVisitor(newError);
+        }
+        return newError;
+    });
+}
+function visitRoot(root, operation, schema, fragments, variableValues, resultVisitorMap, errors, errorInfo) {
+    const operationRootType = graphql.getOperationRootType(schema, operation);
+    const collectedFields = collectFields(schema, fragments, variableValues, operationRootType, operation.selectionSet, new Map(), new Set());
+    return visitObjectValue(root, operationRootType, collectedFields, schema, fragments, variableValues, resultVisitorMap, 0, errors, errorInfo);
+}
+function visitObjectValue(object, type, fieldNodeMap, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo) {
+    var _a;
+    const fieldMap = type.getFields();
+    const typeVisitorMap = resultVisitorMap === null || resultVisitorMap === void 0 ? void 0 : resultVisitorMap[type.name];
+    const enterObject = typeVisitorMap === null || typeVisitorMap === void 0 ? void 0 : typeVisitorMap.__enter;
+    const newObject = enterObject != null ? enterObject(object) : object;
+    let sortedErrors;
+    let errorMap = null;
+    if (errors != null) {
+        sortedErrors = sortErrorsByPathSegment(errors, pathIndex);
+        errorMap = sortedErrors.errorMap;
+        for (const error of sortedErrors.unpathedErrors) {
+            errorInfo.unpathedErrors.add(error);
+        }
+    }
+    for (const [responseKey, subFieldNodes] of fieldNodeMap) {
+        const fieldName = subFieldNodes[0].name.value;
+        const fieldType = fieldName === '__typename' ? graphql.TypeNameMetaFieldDef.type : (_a = fieldMap[fieldName]) === null || _a === void 0 ? void 0 : _a.type;
+        const newPathIndex = pathIndex + 1;
+        let fieldErrors;
+        if (errorMap) {
+            fieldErrors = errorMap[responseKey];
+            if (fieldErrors != null) {
+                delete errorMap[responseKey];
+            }
+            addPathSegmentInfo(type, fieldName, newPathIndex, fieldErrors, errorInfo);
+        }
+        const newValue = visitFieldValue(object[responseKey], fieldType, subFieldNodes, schema, fragments, variableValues, resultVisitorMap, newPathIndex, fieldErrors, errorInfo);
+        updateObject(newObject, responseKey, newValue, typeVisitorMap, fieldName);
+    }
+    const oldTypename = newObject.__typename;
+    if (oldTypename != null) {
+        updateObject(newObject, '__typename', oldTypename, typeVisitorMap, '__typename');
+    }
+    if (errorMap) {
+        for (const errorsKey in errorMap) {
+            const errors = errorMap[errorsKey];
+            for (const error of errors) {
+                errorInfo.unpathedErrors.add(error);
+            }
+        }
+    }
+    const leaveObject = typeVisitorMap === null || typeVisitorMap === void 0 ? void 0 : typeVisitorMap.__leave;
+    return leaveObject != null ? leaveObject(newObject) : newObject;
+}
+function updateObject(object, responseKey, newValue, typeVisitorMap, fieldName) {
+    if (typeVisitorMap == null) {
+        object[responseKey] = newValue;
+        return;
+    }
+    const fieldVisitor = typeVisitorMap[fieldName];
+    if (fieldVisitor == null) {
+        object[responseKey] = newValue;
+        return;
+    }
+    const visitedValue = fieldVisitor(newValue);
+    if (visitedValue === undefined) {
+        delete object[responseKey];
+        return;
+    }
+    object[responseKey] = visitedValue;
+}
+function visitListValue(list, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo) {
+    return list.map(listMember => visitFieldValue(listMember, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex + 1, errors, errorInfo));
+}
+function visitFieldValue(value, returnType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors = [], errorInfo) {
+    if (value == null) {
+        return value;
+    }
+    const nullableType = graphql.getNullableType(returnType);
+    if (graphql.isListType(nullableType)) {
+        return visitListValue(value, nullableType.ofType, fieldNodes, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
+    }
+    else if (graphql.isAbstractType(nullableType)) {
+        const finalType = schema.getType(value.__typename);
+        const collectedFields = collectSubFields(schema, fragments, variableValues, finalType, fieldNodes);
+        return visitObjectValue(value, finalType, collectedFields, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
+    }
+    else if (graphql.isObjectType(nullableType)) {
+        const collectedFields = collectSubFields(schema, fragments, variableValues, nullableType, fieldNodes);
+        return visitObjectValue(value, nullableType, collectedFields, schema, fragments, variableValues, resultVisitorMap, pathIndex, errors, errorInfo);
+    }
+    const typeVisitorMap = resultVisitorMap === null || resultVisitorMap === void 0 ? void 0 : resultVisitorMap[nullableType.name];
+    if (typeVisitorMap == null) {
+        return value;
+    }
+    const visitedValue = typeVisitorMap(value);
+    return visitedValue === undefined ? value : visitedValue;
+}
+function sortErrorsByPathSegment(errors, pathIndex) {
+    var _a;
+    const errorMap = Object.create(null);
+    const unpathedErrors = new Set();
+    for (const error of errors) {
+        const pathSegment = (_a = error.path) === null || _a === void 0 ? void 0 : _a[pathIndex];
+        if (pathSegment == null) {
+            unpathedErrors.add(error);
+            continue;
+        }
+        if (pathSegment in errorMap) {
+            errorMap[pathSegment].push(error);
+        }
+        else {
+            errorMap[pathSegment] = [error];
+        }
+    }
+    return {
+        errorMap,
+        unpathedErrors,
+    };
+}
+function addPathSegmentInfo(type, fieldName, pathIndex, errors = [], errorInfo) {
+    for (const error of errors) {
+        const segmentInfo = {
+            type,
+            fieldName,
+            pathIndex,
+        };
+        const pathSegmentsInfo = errorInfo.segmentInfoMap.get(error);
+        if (pathSegmentsInfo == null) {
+            errorInfo.segmentInfoMap.set(error, [segmentInfo]);
+        }
+        else {
+            pathSegmentsInfo.push(segmentInfo);
+        }
+    }
+}
+
+function valueMatchesCriteria(value, criteria) {
+    if (value == null) {
+        return value === criteria;
+    }
+    else if (Array.isArray(value)) {
+        return Array.isArray(criteria) && value.every((val, index) => valueMatchesCriteria(val, criteria[index]));
+    }
+    else if (typeof value === 'object') {
+        return (typeof criteria === 'object' &&
+            criteria &&
+            Object.keys(criteria).every(propertyName => valueMatchesCriteria(value[propertyName], criteria[propertyName])));
+    }
+    else if (criteria instanceof RegExp) {
+        return criteria.test(value);
+    }
+    return value === criteria;
+}
+
+function isAsyncIterable(value) {
+    return (typeof value === 'object' &&
+        value != null &&
+        Symbol.asyncIterator in value &&
+        typeof value[Symbol.asyncIterator] === 'function');
+}
+
+function isDocumentNode(object) {
+    return object && typeof object === 'object' && 'kind' in object && object.kind === graphql.Kind.DOCUMENT;
+}
+
+async function defaultAsyncIteratorReturn(value) {
+    return { value, done: true };
+}
+const proxyMethodFactory = memoize2(function proxyMethodFactory(target, targetMethod) {
+    return function proxyMethod(...args) {
+        return Reflect.apply(targetMethod, target, args);
+    };
+});
+function getAsyncIteratorWithCancel(asyncIterator, onCancel) {
+    return new Proxy(asyncIterator, {
+        has(asyncIterator, prop) {
+            if (prop === 'return') {
+                return true;
+            }
+            return Reflect.has(asyncIterator, prop);
+        },
+        get(asyncIterator, prop, receiver) {
+            const existingPropValue = Reflect.get(asyncIterator, prop, receiver);
+            if (prop === 'return') {
+                const existingReturn = existingPropValue || defaultAsyncIteratorReturn;
+                return async function returnWithCancel(value) {
+                    const returnValue = await onCancel(value);
+                    return Reflect.apply(existingReturn, asyncIterator, [returnValue]);
+                };
+            }
+            else if (typeof existingPropValue === 'function') {
+                return proxyMethodFactory(asyncIterator, existingPropValue);
+            }
+            return existingPropValue;
+        },
+    });
+}
+function getAsyncIterableWithCancel(asyncIterable, onCancel) {
+    return new Proxy(asyncIterable, {
+        get(asyncIterable, prop, receiver) {
+            const existingPropValue = Reflect.get(asyncIterable, prop, receiver);
+            if (Symbol.asyncIterator === prop) {
+                return function asyncIteratorFactory() {
+                    const asyncIterator = Reflect.apply(existingPropValue, asyncIterable, []);
+                    return getAsyncIteratorWithCancel(asyncIterator, onCancel);
+                };
+            }
+            else if (typeof existingPropValue === 'function') {
+                return proxyMethodFactory(asyncIterable, existingPropValue);
+            }
+            return existingPropValue;
+        },
+    });
+}
+
+function buildFixedSchema(schema, options) {
+    const document = getDocumentNodeFromSchema(schema);
+    return graphql.buildASTSchema(document, {
+        ...(options || {}),
+    });
+}
+function fixSchemaAst(schema, options) {
+    // eslint-disable-next-line no-undef-init
+    let schemaWithValidAst = undefined;
+    if (!schema.astNode || !schema.extensionASTNodes) {
+        schemaWithValidAst = buildFixedSchema(schema, options);
+    }
+    if (!schema.astNode && (schemaWithValidAst === null || schemaWithValidAst === void 0 ? void 0 : schemaWithValidAst.astNode)) {
+        schema.astNode = schemaWithValidAst.astNode;
+    }
+    if (!schema.extensionASTNodes && (schemaWithValidAst === null || schemaWithValidAst === void 0 ? void 0 : schemaWithValidAst.astNode)) {
+        schema.extensionASTNodes = schemaWithValidAst.extensionASTNodes;
+    }
+    return schema;
+}
+
+exports.addTypes = addTypes;
+exports.appendObjectFields = appendObjectFields;
+exports.asArray = asArray;
+exports.assertSome = assertSome;
+exports.astFromArg = astFromArg;
+exports.astFromDirective = astFromDirective;
+exports.astFromEnumType = astFromEnumType;
+exports.astFromEnumValue = astFromEnumValue;
+exports.astFromField = astFromField;
+exports.astFromInputField = astFromInputField;
+exports.astFromInputObjectType = astFromInputObjectType;
+exports.astFromInterfaceType = astFromInterfaceType;
+exports.astFromObjectType = astFromObjectType;
+exports.astFromScalarType = astFromScalarType;
+exports.astFromSchema = astFromSchema;
+exports.astFromUnionType = astFromUnionType;
+exports.astFromValueUntyped = astFromValueUntyped;
+exports.buildOperationNodeForField = buildOperationNodeForField;
+exports.checkValidationErrors = checkValidationErrors;
+exports.collectComment = collectComment;
+exports.collectFields = collectFields;
+exports.collectSubFields = collectSubFields;
+exports.compareNodes = compareNodes;
+exports.compareStrings = compareStrings;
+exports.correctASTNodes = correctASTNodes;
+exports.createDefaultRules = createDefaultRules;
+exports.createNamedStub = createNamedStub;
+exports.createStub = createStub;
+exports.createVariableNameGenerator = createVariableNameGenerator;
+exports.dedentBlockStringValue = dedentBlockStringValue;
+exports.filterSchema = filterSchema;
+exports.fixSchemaAst = fixSchemaAst;
+exports.forEachDefaultValue = forEachDefaultValue;
+exports.forEachField = forEachField;
+exports.getArgumentValues = getArgumentValues;
+exports.getAsyncIterableWithCancel = getAsyncIterableWithCancel;
+exports.getAsyncIteratorWithCancel = getAsyncIteratorWithCancel;
+exports.getBlockStringIndentation = getBlockStringIndentation;
+exports.getBuiltInForStub = getBuiltInForStub;
+exports.getComment = getComment;
+exports.getDefinedRootType = getDefinedRootType;
+exports.getDeprecatableDirectiveNodes = getDeprecatableDirectiveNodes;
+exports.getDescription = getDescription;
+exports.getDirective = getDirective;
+exports.getDirectiveInExtensions = getDirectiveInExtensions;
+exports.getDirectiveNodes = getDirectiveNodes;
+exports.getDirectives = getDirectives;
+exports.getDirectivesInExtensions = getDirectivesInExtensions;
+exports.getDocumentNodeFromSchema = getDocumentNodeFromSchema;
+exports.getFieldsWithDirectives = getFieldsWithDirectives;
+exports.getImplementingTypes = getImplementingTypes;
+exports.getLeadingCommentBlock = getLeadingCommentBlock;
+exports.getOperationASTFromDocument = getOperationASTFromDocument;
+exports.getOperationASTFromRequest = getOperationASTFromRequest;
+exports.getResolversFromSchema = getResolversFromSchema;
+exports.getResponseKeyFromInfo = getResponseKeyFromInfo;
+exports.getRootTypeMap = getRootTypeMap;
+exports.getRootTypeNames = getRootTypeNames;
+exports.getRootTypes = getRootTypes;
+exports.healSchema = healSchema;
+exports.healTypes = healTypes;
+exports.implementsAbstractType = implementsAbstractType;
+exports.inspect = inspect;
+exports.isAggregateError = isAggregateError;
+exports.isAsyncIterable = isAsyncIterable;
+exports.isDescribable = isDescribable;
+exports.isDocumentNode = isDocumentNode;
+exports.isDocumentString = isDocumentString;
+exports.isNamedStub = isNamedStub;
+exports.isSome = isSome;
+exports.isValidPath = isValidPath;
+exports.makeDeprecatedDirective = makeDeprecatedDirective;
+exports.makeDirectiveNode = makeDirectiveNode;
+exports.makeDirectiveNodes = makeDirectiveNodes;
+exports.mapAsyncIterator = mapAsyncIterator;
+exports.mapSchema = mapSchema;
+exports.memoize1 = memoize1;
+exports.memoize2 = memoize2;
+exports.memoize2of4 = memoize2of4;
+exports.memoize3 = memoize3;
+exports.memoize4 = memoize4;
+exports.memoize5 = memoize5;
+exports.mergeDeep = mergeDeep;
+exports.modifyObjectFields = modifyObjectFields;
+exports.nodeToString = nodeToString;
+exports.observableToAsyncIterable = observableToAsyncIterable;
+exports.parseGraphQLJSON = parseGraphQLJSON;
+exports.parseGraphQLSDL = parseGraphQLSDL;
+exports.parseInputValue = parseInputValue;
+exports.parseInputValueLiteral = parseInputValueLiteral;
+exports.parseSelectionSet = parseSelectionSet;
+exports.printComment = printComment;
+exports.printSchemaWithDirectives = printSchemaWithDirectives;
+exports.printWithComments = printWithComments;
+exports.pruneSchema = pruneSchema;
+exports.pushComment = pushComment;
+exports.relocatedError = relocatedError;
+exports.removeObjectFields = removeObjectFields;
+exports.renameType = renameType;
+exports.resetComments = resetComments;
+exports.rewireTypes = rewireTypes;
+exports.selectObjectFields = selectObjectFields;
+exports.serializeInputValue = serializeInputValue;
+exports.transformCommentsToDescriptions = transformCommentsToDescriptions;
+exports.transformInputValue = transformInputValue;
+exports.updateArgument = updateArgument;
+exports.validateGraphQlDocuments = validateGraphQlDocuments;
+exports.valueMatchesCriteria = valueMatchesCriteria;
+exports.visitData = visitData;
+exports.visitErrors = visitErrors;
+exports.visitResult = visitResult;
+exports.withCancel = getAsyncIterableWithCancel;
+
+
+/***/ }),
 /* 665 */,
 /* 666 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -54415,7 +61480,32 @@ function traverseNode(node, opts, scope, state, path, skipKeys) {
 }
 
 /***/ }),
-/* 672 */,
+/* 672 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.forEachField = void 0;
+const graphql_1 = __webpack_require__(232);
+function forEachField(schema, fn) {
+    const typeMap = schema.getTypeMap();
+    for (const typeName in typeMap) {
+        const type = typeMap[typeName];
+        // TODO: maybe have an option to include these?
+        if (!(0, graphql_1.getNamedType)(type).name.startsWith('__') && (0, graphql_1.isObjectType)(type)) {
+            const fields = type.getFields();
+            for (const fieldName in fields) {
+                const field = fields[fieldName];
+                fn(field, typeName, fieldName);
+            }
+        }
+    }
+}
+exports.forEachField = forEachField;
+
+
+/***/ }),
 /* 673 */,
 /* 674 */
 /***/ (function(__unusedmodule, exports) {
@@ -54507,7 +61597,483 @@ function isIdentifierName(name) {
 }
 
 /***/ }),
-/* 675 */,
+/* 675 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.correctASTNodes = exports.mapSchema = void 0;
+const graphql_1 = __webpack_require__(232);
+const getObjectTypeFromTypeMap_js_1 = __webpack_require__(374);
+const Interfaces_js_1 = __webpack_require__(368);
+const rewire_js_1 = __webpack_require__(899);
+const transformInputValue_js_1 = __webpack_require__(144);
+function mapSchema(schema, schemaMapper = {}) {
+    const newTypeMap = mapArguments(mapFields(mapTypes(mapDefaultValues(mapEnumValues(mapTypes(mapDefaultValues(schema.getTypeMap(), schema, transformInputValue_js_1.serializeInputValue), schema, schemaMapper, type => (0, graphql_1.isLeafType)(type)), schema, schemaMapper), schema, transformInputValue_js_1.parseInputValue), schema, schemaMapper, type => !(0, graphql_1.isLeafType)(type)), schema, schemaMapper), schema, schemaMapper);
+    const originalDirectives = schema.getDirectives();
+    const newDirectives = mapDirectives(originalDirectives, schema, schemaMapper);
+    const { typeMap, directives } = (0, rewire_js_1.rewireTypes)(newTypeMap, newDirectives);
+    return new graphql_1.GraphQLSchema({
+        ...schema.toConfig(),
+        query: (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(typeMap, (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(newTypeMap, schema.getQueryType())),
+        mutation: (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(typeMap, (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(newTypeMap, schema.getMutationType())),
+        subscription: (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(typeMap, (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(newTypeMap, schema.getSubscriptionType())),
+        types: Object.values(typeMap),
+        directives,
+    });
+}
+exports.mapSchema = mapSchema;
+function mapTypes(originalTypeMap, schema, schemaMapper, testFn = () => true) {
+    const newTypeMap = {};
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__')) {
+            const originalType = originalTypeMap[typeName];
+            if (originalType == null || !testFn(originalType)) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const typeMapper = getTypeMapper(schema, schemaMapper, typeName);
+            if (typeMapper == null) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const maybeNewType = typeMapper(originalType, schema);
+            if (maybeNewType === undefined) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            newTypeMap[typeName] = maybeNewType;
+        }
+    }
+    return newTypeMap;
+}
+function mapEnumValues(originalTypeMap, schema, schemaMapper) {
+    const enumValueMapper = getEnumValueMapper(schemaMapper);
+    if (!enumValueMapper) {
+        return originalTypeMap;
+    }
+    return mapTypes(originalTypeMap, schema, {
+        [Interfaces_js_1.MapperKind.ENUM_TYPE]: type => {
+            const config = type.toConfig();
+            const originalEnumValueConfigMap = config.values;
+            const newEnumValueConfigMap = {};
+            for (const externalValue in originalEnumValueConfigMap) {
+                const originalEnumValueConfig = originalEnumValueConfigMap[externalValue];
+                const mappedEnumValue = enumValueMapper(originalEnumValueConfig, type.name, schema, externalValue);
+                if (mappedEnumValue === undefined) {
+                    newEnumValueConfigMap[externalValue] = originalEnumValueConfig;
+                }
+                else if (Array.isArray(mappedEnumValue)) {
+                    const [newExternalValue, newEnumValueConfig] = mappedEnumValue;
+                    newEnumValueConfigMap[newExternalValue] =
+                        newEnumValueConfig === undefined ? originalEnumValueConfig : newEnumValueConfig;
+                }
+                else if (mappedEnumValue !== null) {
+                    newEnumValueConfigMap[externalValue] = mappedEnumValue;
+                }
+            }
+            return correctASTNodes(new graphql_1.GraphQLEnumType({
+                ...config,
+                values: newEnumValueConfigMap,
+            }));
+        },
+    }, type => (0, graphql_1.isEnumType)(type));
+}
+function mapDefaultValues(originalTypeMap, schema, fn) {
+    const newTypeMap = mapArguments(originalTypeMap, schema, {
+        [Interfaces_js_1.MapperKind.ARGUMENT]: argumentConfig => {
+            if (argumentConfig.defaultValue === undefined) {
+                return argumentConfig;
+            }
+            const maybeNewType = getNewType(originalTypeMap, argumentConfig.type);
+            if (maybeNewType != null) {
+                return {
+                    ...argumentConfig,
+                    defaultValue: fn(maybeNewType, argumentConfig.defaultValue),
+                };
+            }
+        },
+    });
+    return mapFields(newTypeMap, schema, {
+        [Interfaces_js_1.MapperKind.INPUT_OBJECT_FIELD]: inputFieldConfig => {
+            if (inputFieldConfig.defaultValue === undefined) {
+                return inputFieldConfig;
+            }
+            const maybeNewType = getNewType(newTypeMap, inputFieldConfig.type);
+            if (maybeNewType != null) {
+                return {
+                    ...inputFieldConfig,
+                    defaultValue: fn(maybeNewType, inputFieldConfig.defaultValue),
+                };
+            }
+        },
+    });
+}
+function getNewType(newTypeMap, type) {
+    if ((0, graphql_1.isListType)(type)) {
+        const newType = getNewType(newTypeMap, type.ofType);
+        return newType != null ? new graphql_1.GraphQLList(newType) : null;
+    }
+    else if ((0, graphql_1.isNonNullType)(type)) {
+        const newType = getNewType(newTypeMap, type.ofType);
+        return newType != null ? new graphql_1.GraphQLNonNull(newType) : null;
+    }
+    else if ((0, graphql_1.isNamedType)(type)) {
+        const newType = newTypeMap[type.name];
+        return newType != null ? newType : null;
+    }
+    return null;
+}
+function mapFields(originalTypeMap, schema, schemaMapper) {
+    const newTypeMap = {};
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__')) {
+            const originalType = originalTypeMap[typeName];
+            if (!(0, graphql_1.isObjectType)(originalType) && !(0, graphql_1.isInterfaceType)(originalType) && !(0, graphql_1.isInputObjectType)(originalType)) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const fieldMapper = getFieldMapper(schema, schemaMapper, typeName);
+            if (fieldMapper == null) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const config = originalType.toConfig();
+            const originalFieldConfigMap = config.fields;
+            const newFieldConfigMap = {};
+            for (const fieldName in originalFieldConfigMap) {
+                const originalFieldConfig = originalFieldConfigMap[fieldName];
+                const mappedField = fieldMapper(originalFieldConfig, fieldName, typeName, schema);
+                if (mappedField === undefined) {
+                    newFieldConfigMap[fieldName] = originalFieldConfig;
+                }
+                else if (Array.isArray(mappedField)) {
+                    const [newFieldName, newFieldConfig] = mappedField;
+                    if (newFieldConfig.astNode != null) {
+                        newFieldConfig.astNode = {
+                            ...newFieldConfig.astNode,
+                            name: {
+                                ...newFieldConfig.astNode.name,
+                                value: newFieldName,
+                            },
+                        };
+                    }
+                    newFieldConfigMap[newFieldName] = newFieldConfig === undefined ? originalFieldConfig : newFieldConfig;
+                }
+                else if (mappedField !== null) {
+                    newFieldConfigMap[fieldName] = mappedField;
+                }
+            }
+            if ((0, graphql_1.isObjectType)(originalType)) {
+                newTypeMap[typeName] = correctASTNodes(new graphql_1.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+            else if ((0, graphql_1.isInterfaceType)(originalType)) {
+                newTypeMap[typeName] = correctASTNodes(new graphql_1.GraphQLInterfaceType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+            else {
+                newTypeMap[typeName] = correctASTNodes(new graphql_1.GraphQLInputObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                }));
+            }
+        }
+    }
+    return newTypeMap;
+}
+function mapArguments(originalTypeMap, schema, schemaMapper) {
+    const newTypeMap = {};
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__')) {
+            const originalType = originalTypeMap[typeName];
+            if (!(0, graphql_1.isObjectType)(originalType) && !(0, graphql_1.isInterfaceType)(originalType)) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const argumentMapper = getArgumentMapper(schemaMapper);
+            if (argumentMapper == null) {
+                newTypeMap[typeName] = originalType;
+                continue;
+            }
+            const config = originalType.toConfig();
+            const originalFieldConfigMap = config.fields;
+            const newFieldConfigMap = {};
+            for (const fieldName in originalFieldConfigMap) {
+                const originalFieldConfig = originalFieldConfigMap[fieldName];
+                const originalArgumentConfigMap = originalFieldConfig.args;
+                if (originalArgumentConfigMap == null) {
+                    newFieldConfigMap[fieldName] = originalFieldConfig;
+                    continue;
+                }
+                const argumentNames = Object.keys(originalArgumentConfigMap);
+                if (!argumentNames.length) {
+                    newFieldConfigMap[fieldName] = originalFieldConfig;
+                    continue;
+                }
+                const newArgumentConfigMap = {};
+                for (const argumentName of argumentNames) {
+                    const originalArgumentConfig = originalArgumentConfigMap[argumentName];
+                    const mappedArgument = argumentMapper(originalArgumentConfig, fieldName, typeName, schema);
+                    if (mappedArgument === undefined) {
+                        newArgumentConfigMap[argumentName] = originalArgumentConfig;
+                    }
+                    else if (Array.isArray(mappedArgument)) {
+                        const [newArgumentName, newArgumentConfig] = mappedArgument;
+                        newArgumentConfigMap[newArgumentName] = newArgumentConfig;
+                    }
+                    else if (mappedArgument !== null) {
+                        newArgumentConfigMap[argumentName] = mappedArgument;
+                    }
+                }
+                newFieldConfigMap[fieldName] = {
+                    ...originalFieldConfig,
+                    args: newArgumentConfigMap,
+                };
+            }
+            if ((0, graphql_1.isObjectType)(originalType)) {
+                newTypeMap[typeName] = new graphql_1.GraphQLObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                });
+            }
+            else if ((0, graphql_1.isInterfaceType)(originalType)) {
+                newTypeMap[typeName] = new graphql_1.GraphQLInterfaceType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                });
+            }
+            else {
+                newTypeMap[typeName] = new graphql_1.GraphQLInputObjectType({
+                    ...config,
+                    fields: newFieldConfigMap,
+                });
+            }
+        }
+    }
+    return newTypeMap;
+}
+function mapDirectives(originalDirectives, schema, schemaMapper) {
+    const directiveMapper = getDirectiveMapper(schemaMapper);
+    if (directiveMapper == null) {
+        return originalDirectives.slice();
+    }
+    const newDirectives = [];
+    for (const directive of originalDirectives) {
+        const mappedDirective = directiveMapper(directive, schema);
+        if (mappedDirective === undefined) {
+            newDirectives.push(directive);
+        }
+        else if (mappedDirective !== null) {
+            newDirectives.push(mappedDirective);
+        }
+    }
+    return newDirectives;
+}
+function getTypeSpecifiers(schema, typeName) {
+    var _a, _b, _c;
+    const type = schema.getType(typeName);
+    const specifiers = [Interfaces_js_1.MapperKind.TYPE];
+    if ((0, graphql_1.isObjectType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.COMPOSITE_TYPE, Interfaces_js_1.MapperKind.OBJECT_TYPE);
+        if (typeName === ((_a = schema.getQueryType()) === null || _a === void 0 ? void 0 : _a.name)) {
+            specifiers.push(Interfaces_js_1.MapperKind.ROOT_OBJECT, Interfaces_js_1.MapperKind.QUERY);
+        }
+        else if (typeName === ((_b = schema.getMutationType()) === null || _b === void 0 ? void 0 : _b.name)) {
+            specifiers.push(Interfaces_js_1.MapperKind.ROOT_OBJECT, Interfaces_js_1.MapperKind.MUTATION);
+        }
+        else if (typeName === ((_c = schema.getSubscriptionType()) === null || _c === void 0 ? void 0 : _c.name)) {
+            specifiers.push(Interfaces_js_1.MapperKind.ROOT_OBJECT, Interfaces_js_1.MapperKind.SUBSCRIPTION);
+        }
+    }
+    else if ((0, graphql_1.isInputObjectType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.INPUT_OBJECT_TYPE);
+    }
+    else if ((0, graphql_1.isInterfaceType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.COMPOSITE_TYPE, Interfaces_js_1.MapperKind.ABSTRACT_TYPE, Interfaces_js_1.MapperKind.INTERFACE_TYPE);
+    }
+    else if ((0, graphql_1.isUnionType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.COMPOSITE_TYPE, Interfaces_js_1.MapperKind.ABSTRACT_TYPE, Interfaces_js_1.MapperKind.UNION_TYPE);
+    }
+    else if ((0, graphql_1.isEnumType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.ENUM_TYPE);
+    }
+    else if ((0, graphql_1.isScalarType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.SCALAR_TYPE);
+    }
+    return specifiers;
+}
+function getTypeMapper(schema, schemaMapper, typeName) {
+    const specifiers = getTypeSpecifiers(schema, typeName);
+    let typeMapper;
+    const stack = [...specifiers];
+    while (!typeMapper && stack.length > 0) {
+        // It is safe to use the ! operator here as we check the length.
+        const next = stack.pop();
+        typeMapper = schemaMapper[next];
+    }
+    return typeMapper != null ? typeMapper : null;
+}
+function getFieldSpecifiers(schema, typeName) {
+    var _a, _b, _c;
+    const type = schema.getType(typeName);
+    const specifiers = [Interfaces_js_1.MapperKind.FIELD];
+    if ((0, graphql_1.isObjectType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.COMPOSITE_FIELD, Interfaces_js_1.MapperKind.OBJECT_FIELD);
+        if (typeName === ((_a = schema.getQueryType()) === null || _a === void 0 ? void 0 : _a.name)) {
+            specifiers.push(Interfaces_js_1.MapperKind.ROOT_FIELD, Interfaces_js_1.MapperKind.QUERY_ROOT_FIELD);
+        }
+        else if (typeName === ((_b = schema.getMutationType()) === null || _b === void 0 ? void 0 : _b.name)) {
+            specifiers.push(Interfaces_js_1.MapperKind.ROOT_FIELD, Interfaces_js_1.MapperKind.MUTATION_ROOT_FIELD);
+        }
+        else if (typeName === ((_c = schema.getSubscriptionType()) === null || _c === void 0 ? void 0 : _c.name)) {
+            specifiers.push(Interfaces_js_1.MapperKind.ROOT_FIELD, Interfaces_js_1.MapperKind.SUBSCRIPTION_ROOT_FIELD);
+        }
+    }
+    else if ((0, graphql_1.isInterfaceType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.COMPOSITE_FIELD, Interfaces_js_1.MapperKind.INTERFACE_FIELD);
+    }
+    else if ((0, graphql_1.isInputObjectType)(type)) {
+        specifiers.push(Interfaces_js_1.MapperKind.INPUT_OBJECT_FIELD);
+    }
+    return specifiers;
+}
+function getFieldMapper(schema, schemaMapper, typeName) {
+    const specifiers = getFieldSpecifiers(schema, typeName);
+    let fieldMapper;
+    const stack = [...specifiers];
+    while (!fieldMapper && stack.length > 0) {
+        // It is safe to use the ! operator here as we check the length.
+        const next = stack.pop();
+        // TODO: fix this as unknown cast
+        fieldMapper = schemaMapper[next];
+    }
+    return fieldMapper !== null && fieldMapper !== void 0 ? fieldMapper : null;
+}
+function getArgumentMapper(schemaMapper) {
+    const argumentMapper = schemaMapper[Interfaces_js_1.MapperKind.ARGUMENT];
+    return argumentMapper != null ? argumentMapper : null;
+}
+function getDirectiveMapper(schemaMapper) {
+    const directiveMapper = schemaMapper[Interfaces_js_1.MapperKind.DIRECTIVE];
+    return directiveMapper != null ? directiveMapper : null;
+}
+function getEnumValueMapper(schemaMapper) {
+    const enumValueMapper = schemaMapper[Interfaces_js_1.MapperKind.ENUM_VALUE];
+    return enumValueMapper != null ? enumValueMapper : null;
+}
+function correctASTNodes(type) {
+    if ((0, graphql_1.isObjectType)(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const fields = [];
+            for (const fieldName in config.fields) {
+                const fieldConfig = config.fields[fieldName];
+                if (fieldConfig.astNode != null) {
+                    fields.push(fieldConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                kind: graphql_1.Kind.OBJECT_TYPE_DEFINITION,
+                fields,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                kind: graphql_1.Kind.OBJECT_TYPE_EXTENSION,
+                fields: undefined,
+            }));
+        }
+        return new graphql_1.GraphQLObjectType(config);
+    }
+    else if ((0, graphql_1.isInterfaceType)(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const fields = [];
+            for (const fieldName in config.fields) {
+                const fieldConfig = config.fields[fieldName];
+                if (fieldConfig.astNode != null) {
+                    fields.push(fieldConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                kind: graphql_1.Kind.INTERFACE_TYPE_DEFINITION,
+                fields,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                kind: graphql_1.Kind.INTERFACE_TYPE_EXTENSION,
+                fields: undefined,
+            }));
+        }
+        return new graphql_1.GraphQLInterfaceType(config);
+    }
+    else if ((0, graphql_1.isInputObjectType)(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const fields = [];
+            for (const fieldName in config.fields) {
+                const fieldConfig = config.fields[fieldName];
+                if (fieldConfig.astNode != null) {
+                    fields.push(fieldConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                kind: graphql_1.Kind.INPUT_OBJECT_TYPE_DEFINITION,
+                fields,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                kind: graphql_1.Kind.INPUT_OBJECT_TYPE_EXTENSION,
+                fields: undefined,
+            }));
+        }
+        return new graphql_1.GraphQLInputObjectType(config);
+    }
+    else if ((0, graphql_1.isEnumType)(type)) {
+        const config = type.toConfig();
+        if (config.astNode != null) {
+            const values = [];
+            for (const enumKey in config.values) {
+                const enumValueConfig = config.values[enumKey];
+                if (enumValueConfig.astNode != null) {
+                    values.push(enumValueConfig.astNode);
+                }
+            }
+            config.astNode = {
+                ...config.astNode,
+                values,
+            };
+        }
+        if (config.extensionASTNodes != null) {
+            config.extensionASTNodes = config.extensionASTNodes.map(node => ({
+                ...node,
+                values: undefined,
+            }));
+        }
+        return new graphql_1.GraphQLEnumType(config);
+    }
+    else {
+        return type;
+    }
+}
+exports.correctASTNodes = correctASTNodes;
+
+
+/***/ }),
 /* 676 */
 /***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
 
@@ -54515,33 +62081,75 @@ const fs = __webpack_require__(747).promises;
 const { dirname } = __webpack_require__(622);
 const core = __webpack_require__(470);
 const { gqlPluckFromCodeString } = __webpack_require__(680);
+const { mergeTypeDefs } = __webpack_require__(390);
+const { glob } = __webpack_require__(120);
+const { asyncPipe, asyncMap } = __webpack_require__(564);
 
-async function getContents() {
-  const source = core.getInput('source');
-  core.debug(`Reading from file ${source}`);
-
-  return fs.readFile(source, 'utf8');
+/**
+ * @param {string} source
+ * @returns {Promise<string[]>}
+ */
+async function getFilepaths(source) {
+  return new Promise((resolve, reject) => {
+    glob(source, { nonull: true }, (err, filePaths) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(filePaths);
+      }
+    });
+  });
 }
 
-async function writeContents(content) {
+/**
+ * @param {string} filePath
+ * @returns {Promise<{filePath: string, content: string}>}
+ */
+async function getContent(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
+  return { filePath, content };
+}
+
+/**
+ *
+ * @param {{filePath: string, content: string}} param0
+ * @returns {Promise<string>}
+ */
+async function pluckGQL({ filePath, content }) {
+  const [plucked] = await gqlPluckFromCodeString(filePath, content);
+  return plucked.body;
+}
+
+/**
+ * @param {string[]} schemas
+ * @returns {Promise<string>}
+ */
+async function mergeGql(schemas) {
+  return mergeTypeDefs(schemas);
+}
+
+/**
+ *
+ * @param {string} schema
+ * @returns {Promise<void>}
+ */
+async function writeSchemaToOutput(schema) {
   const output = core.getInput('output');
   core.info(`Writing to file ${output}`);
-
-  await fs.writeFile(output, content);
-  return output;
+  console.log(schema);
+  await fs.writeFile(output, schema);
 }
 
 async function main() {
-  const source = core.getInput('source');
+  await asyncPipe(
+    core.getInput('source'),
+    getFilepaths,
+    asyncMap(getContent, pluckGQL),
+    mergeGql,
+    writeSchemaToOutput
+  )();
 
-  const content = await getContents();
-
-  const [plucked] = await gqlPluckFromCodeString(
-    source, // this parameter is required to detect file type
-    content
-  );
-
-  const output = await writeContents(plucked.body);
+  const output = core.getInput('output');
 
   core.debug(`Setting filepath to ${output}`);
   core.setOutput('filepath', output);
@@ -54861,7 +62469,7 @@ function _interopNamespace(e) {
 
 const parser = __webpack_require__(603);
 const types = __webpack_require__(978);
-const utils = __webpack_require__(416);
+const utils = __webpack_require__(664);
 const traversePkg = _interopDefault(__webpack_require__(167));
 const graphql = __webpack_require__(232);
 
@@ -55491,7 +63099,146 @@ function getLocation(source, position) {
 /* 686 */,
 /* 687 */,
 /* 688 */,
-/* 689 */,
+/* 689 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.pruneSchema = void 0;
+const graphql_1 = __webpack_require__(232);
+const mapSchema_js_1 = __webpack_require__(675);
+const Interfaces_js_1 = __webpack_require__(368);
+const rootTypes_js_1 = __webpack_require__(142);
+const get_implementing_types_js_1 = __webpack_require__(285);
+/**
+ * Prunes the provided schema, removing unused and empty types
+ * @param schema The schema to prune
+ * @param options Additional options for removing unused types from the schema
+ */
+function pruneSchema(schema, options = {}) {
+    const { skipEmptyCompositeTypePruning, skipEmptyUnionPruning, skipPruning, skipUnimplementedInterfacesPruning, skipUnusedTypesPruning, } = options;
+    let prunedTypes = []; // Pruned types during mapping
+    let prunedSchema = schema;
+    do {
+        let visited = visitSchema(prunedSchema);
+        // Custom pruning  was defined, so we need to pre-emptively revisit the schema accounting for this
+        if (skipPruning) {
+            const revisit = [];
+            for (const typeName in prunedSchema.getTypeMap()) {
+                if (typeName.startsWith('__')) {
+                    continue;
+                }
+                const type = prunedSchema.getType(typeName);
+                // if we want to skip pruning for this type, add it to the list of types to revisit
+                if (type && skipPruning(type)) {
+                    revisit.push(typeName);
+                }
+            }
+            visited = visitQueue(revisit, prunedSchema, visited); // visit again
+        }
+        prunedTypes = [];
+        prunedSchema = (0, mapSchema_js_1.mapSchema)(prunedSchema, {
+            [Interfaces_js_1.MapperKind.TYPE]: type => {
+                if (!visited.has(type.name) && !(0, graphql_1.isSpecifiedScalarType)(type)) {
+                    if ((0, graphql_1.isUnionType)(type) ||
+                        (0, graphql_1.isInputObjectType)(type) ||
+                        (0, graphql_1.isInterfaceType)(type) ||
+                        (0, graphql_1.isObjectType)(type) ||
+                        (0, graphql_1.isScalarType)(type)) {
+                        // skipUnusedTypesPruning: skip pruning unused types
+                        if (skipUnusedTypesPruning) {
+                            return type;
+                        }
+                        // skipEmptyUnionPruning: skip pruning empty unions
+                        if ((0, graphql_1.isUnionType)(type) && skipEmptyUnionPruning && !Object.keys(type.getTypes()).length) {
+                            return type;
+                        }
+                        if ((0, graphql_1.isInputObjectType)(type) || (0, graphql_1.isInterfaceType)(type) || (0, graphql_1.isObjectType)(type)) {
+                            // skipEmptyCompositeTypePruning: skip pruning object types or interfaces with no fields
+                            if (skipEmptyCompositeTypePruning && !Object.keys(type.getFields()).length) {
+                                return type;
+                            }
+                        }
+                        // skipUnimplementedInterfacesPruning: skip pruning interfaces that are not implemented by any other types
+                        if ((0, graphql_1.isInterfaceType)(type) && skipUnimplementedInterfacesPruning) {
+                            return type;
+                        }
+                    }
+                    prunedTypes.push(type.name);
+                    visited.delete(type.name);
+                    return null;
+                }
+                return type;
+            },
+        });
+    } while (prunedTypes.length); // Might have empty types and need to prune again
+    return prunedSchema;
+}
+exports.pruneSchema = pruneSchema;
+function visitSchema(schema) {
+    const queue = []; // queue of nodes to visit
+    // Grab the root types and start there
+    for (const type of (0, rootTypes_js_1.getRootTypes)(schema)) {
+        queue.push(type.name);
+    }
+    return visitQueue(queue, schema);
+}
+function visitQueue(queue, schema, visited = new Set()) {
+    // Interfaces encountered that are field return types need to be revisited to add their implementations
+    const revisit = new Map();
+    // Navigate all types starting with pre-queued types (root types)
+    while (queue.length) {
+        const typeName = queue.pop();
+        // Skip types we already visited unless it is an interface type that needs revisiting
+        if (visited.has(typeName) && revisit[typeName] !== true) {
+            continue;
+        }
+        const type = schema.getType(typeName);
+        if (type) {
+            // Get types for union
+            if ((0, graphql_1.isUnionType)(type)) {
+                queue.push(...type.getTypes().map(type => type.name));
+            }
+            // If it is an interface and it is a returned type, grab all implementations so we can use proper __typename in fragments
+            if ((0, graphql_1.isInterfaceType)(type) && revisit[typeName] === true) {
+                queue.push(...(0, get_implementing_types_js_1.getImplementingTypes)(type.name, schema));
+                // No need to revisit this interface again
+                revisit[typeName] = false;
+            }
+            // Visit interfaces this type is implementing if they haven't been visited yet
+            if ('getInterfaces' in type) {
+                // Only pushes to queue to visit but not return types
+                queue.push(...type.getInterfaces().map(iface => iface.name));
+            }
+            // If the type has files visit those field types
+            if ('getFields' in type) {
+                const fields = type.getFields();
+                const entries = Object.entries(fields);
+                if (!entries.length) {
+                    continue;
+                }
+                for (const [, field] of entries) {
+                    if ((0, graphql_1.isObjectType)(type)) {
+                        // Visit arg types
+                        queue.push(...field.args.map(arg => (0, graphql_1.getNamedType)(arg.type).name));
+                    }
+                    const namedType = (0, graphql_1.getNamedType)(field.type);
+                    queue.push(namedType.name);
+                    // Interfaces returned on fields need to be revisited to add their implementations
+                    if ((0, graphql_1.isInterfaceType)(namedType) && !(namedType.name in revisit)) {
+                        revisit[namedType.name] = true;
+                    }
+                }
+            }
+            visited.add(typeName); // Mark as visited (and therefore it is used and should be kept)
+        }
+    }
+    return visited;
+}
+
+
+/***/ }),
 /* 690 */,
 /* 691 */
 /***/ (function(__unusedmodule, exports) {
@@ -57221,7 +64968,78 @@ getBindingIdentifiers.keys = {
 };
 
 /***/ }),
-/* 706 */,
+/* 706 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.defaultStringComparator = exports.CompareVal = exports.printTypeNode = exports.isNonNullTypeNode = exports.isListTypeNode = exports.isWrappingTypeNode = exports.extractType = exports.isSourceTypes = exports.isStringTypes = void 0;
+const graphql_1 = __webpack_require__(232);
+function isStringTypes(types) {
+    return typeof types === 'string';
+}
+exports.isStringTypes = isStringTypes;
+function isSourceTypes(types) {
+    return types instanceof graphql_1.Source;
+}
+exports.isSourceTypes = isSourceTypes;
+function extractType(type) {
+    let visitedType = type;
+    while (visitedType.kind === graphql_1.Kind.LIST_TYPE || visitedType.kind === 'NonNullType') {
+        visitedType = visitedType.type;
+    }
+    return visitedType;
+}
+exports.extractType = extractType;
+function isWrappingTypeNode(type) {
+    return type.kind !== graphql_1.Kind.NAMED_TYPE;
+}
+exports.isWrappingTypeNode = isWrappingTypeNode;
+function isListTypeNode(type) {
+    return type.kind === graphql_1.Kind.LIST_TYPE;
+}
+exports.isListTypeNode = isListTypeNode;
+function isNonNullTypeNode(type) {
+    return type.kind === graphql_1.Kind.NON_NULL_TYPE;
+}
+exports.isNonNullTypeNode = isNonNullTypeNode;
+function printTypeNode(type) {
+    if (isListTypeNode(type)) {
+        return `[${printTypeNode(type.type)}]`;
+    }
+    if (isNonNullTypeNode(type)) {
+        return `${printTypeNode(type.type)}!`;
+    }
+    return type.name.value;
+}
+exports.printTypeNode = printTypeNode;
+var CompareVal;
+(function (CompareVal) {
+    CompareVal[CompareVal["A_SMALLER_THAN_B"] = -1] = "A_SMALLER_THAN_B";
+    CompareVal[CompareVal["A_EQUALS_B"] = 0] = "A_EQUALS_B";
+    CompareVal[CompareVal["A_GREATER_THAN_B"] = 1] = "A_GREATER_THAN_B";
+})(CompareVal = exports.CompareVal || (exports.CompareVal = {}));
+function defaultStringComparator(a, b) {
+    if (a == null && b == null) {
+        return CompareVal.A_EQUALS_B;
+    }
+    if (a == null) {
+        return CompareVal.A_SMALLER_THAN_B;
+    }
+    if (b == null) {
+        return CompareVal.A_GREATER_THAN_B;
+    }
+    if (a < b)
+        return CompareVal.A_SMALLER_THAN_B;
+    if (a > b)
+        return CompareVal.A_GREATER_THAN_B;
+    return CompareVal.A_EQUALS_B;
+}
+exports.defaultStringComparator = defaultStringComparator;
+
+
+/***/ }),
 /* 707 */,
 /* 708 */,
 /* 709 */
@@ -57442,7 +65260,25 @@ const escapeSequences = [
 
 /***/ }),
 /* 711 */,
-/* 712 */,
+/* 712 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getResponseKeyFromInfo = void 0;
+/**
+ * Get the key under which the result of this resolver will be placed in the response JSON. Basically, just
+ * resolves aliases.
+ * @param info The info argument to the resolver.
+ */
+function getResponseKeyFromInfo(info) {
+    return info.fieldNodes[0].alias != null ? info.fieldNodes[0].alias.value : info.fieldName;
+}
+exports.getResponseKeyFromInfo = getResponseKeyFromInfo;
+
+
+/***/ }),
 /* 713 */
 /***/ (function(module) {
 
@@ -57813,7 +65649,116 @@ function getDirectiveLocationForOperation(operation) {
 
 /***/ }),
 /* 720 */,
-/* 721 */,
+/* 721 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getDirective = exports.getDirectives = exports.getDirectiveInExtensions = exports.getDirectivesInExtensions = void 0;
+const getArgumentValues_js_1 = __webpack_require__(112);
+function getDirectivesInExtensions(node, pathToDirectivesInExtensions = ['directives']) {
+    return pathToDirectivesInExtensions.reduce((acc, pathSegment) => (acc == null ? acc : acc[pathSegment]), node === null || node === void 0 ? void 0 : node.extensions);
+}
+exports.getDirectivesInExtensions = getDirectivesInExtensions;
+function _getDirectiveInExtensions(directivesInExtensions, directiveName) {
+    const directiveInExtensions = directivesInExtensions.filter(directiveAnnotation => directiveAnnotation.name === directiveName);
+    if (!directiveInExtensions.length) {
+        return undefined;
+    }
+    return directiveInExtensions.map(directive => { var _a; return (_a = directive.args) !== null && _a !== void 0 ? _a : {}; });
+}
+function getDirectiveInExtensions(node, directiveName, pathToDirectivesInExtensions = ['directives']) {
+    const directivesInExtensions = pathToDirectivesInExtensions.reduce((acc, pathSegment) => (acc == null ? acc : acc[pathSegment]), node === null || node === void 0 ? void 0 : node.extensions);
+    if (directivesInExtensions === undefined) {
+        return undefined;
+    }
+    if (Array.isArray(directivesInExtensions)) {
+        return _getDirectiveInExtensions(directivesInExtensions, directiveName);
+    }
+    // Support condensed format by converting to longer format
+    // The condensed format does not preserve ordering of directives when  repeatable directives are used.
+    // See https://github.com/ardatan/graphql-tools/issues/2534
+    const reformattedDirectivesInExtensions = [];
+    for (const [name, argsOrArrayOfArgs] of Object.entries(directivesInExtensions)) {
+        if (Array.isArray(argsOrArrayOfArgs)) {
+            for (const args of argsOrArrayOfArgs) {
+                reformattedDirectivesInExtensions.push({ name, args });
+            }
+        }
+        else {
+            reformattedDirectivesInExtensions.push({ name, args: argsOrArrayOfArgs });
+        }
+    }
+    return _getDirectiveInExtensions(reformattedDirectivesInExtensions, directiveName);
+}
+exports.getDirectiveInExtensions = getDirectiveInExtensions;
+function getDirectives(schema, node, pathToDirectivesInExtensions = ['directives']) {
+    const directivesInExtensions = getDirectivesInExtensions(node, pathToDirectivesInExtensions);
+    if (directivesInExtensions != null && directivesInExtensions.length > 0) {
+        return directivesInExtensions;
+    }
+    const schemaDirectives = schema && schema.getDirectives ? schema.getDirectives() : [];
+    const schemaDirectiveMap = schemaDirectives.reduce((schemaDirectiveMap, schemaDirective) => {
+        schemaDirectiveMap[schemaDirective.name] = schemaDirective;
+        return schemaDirectiveMap;
+    }, {});
+    let astNodes = [];
+    if (node.astNode) {
+        astNodes.push(node.astNode);
+    }
+    if ('extensionASTNodes' in node && node.extensionASTNodes) {
+        astNodes = [...astNodes, ...node.extensionASTNodes];
+    }
+    const result = [];
+    for (const astNode of astNodes) {
+        if (astNode.directives) {
+            for (const directiveNode of astNode.directives) {
+                const schemaDirective = schemaDirectiveMap[directiveNode.name.value];
+                if (schemaDirective) {
+                    result.push({ name: directiveNode.name.value, args: (0, getArgumentValues_js_1.getArgumentValues)(schemaDirective, directiveNode) });
+                }
+            }
+        }
+    }
+    return result;
+}
+exports.getDirectives = getDirectives;
+function getDirective(schema, node, directiveName, pathToDirectivesInExtensions = ['directives']) {
+    const directiveInExtensions = getDirectiveInExtensions(node, directiveName, pathToDirectivesInExtensions);
+    if (directiveInExtensions != null) {
+        return directiveInExtensions;
+    }
+    const schemaDirective = schema && schema.getDirective ? schema.getDirective(directiveName) : undefined;
+    if (schemaDirective == null) {
+        return undefined;
+    }
+    let astNodes = [];
+    if (node.astNode) {
+        astNodes.push(node.astNode);
+    }
+    if ('extensionASTNodes' in node && node.extensionASTNodes) {
+        astNodes = [...astNodes, ...node.extensionASTNodes];
+    }
+    const result = [];
+    for (const astNode of astNodes) {
+        if (astNode.directives) {
+            for (const directiveNode of astNode.directives) {
+                if (directiveNode.name.value === directiveName) {
+                    result.push((0, getArgumentValues_js_1.getArgumentValues)(schemaDirective, directiveNode));
+                }
+            }
+        }
+    }
+    if (!result.length) {
+        return undefined;
+    }
+    return result;
+}
+exports.getDirective = getDirective;
+
+
+/***/ }),
 /* 722 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -62737,7 +70682,47 @@ Object.defineProperty(module, 'exports', {
 
 
 /***/ }),
-/* 751 */,
+/* 751 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeInputType = void 0;
+const graphql_1 = __webpack_require__(232);
+const fields_js_1 = __webpack_require__(663);
+const directives_js_1 = __webpack_require__(154);
+function mergeInputType(node, existingNode, config) {
+    if (existingNode) {
+        try {
+            return {
+                name: node.name,
+                description: node['description'] || existingNode['description'],
+                kind: (config === null || config === void 0 ? void 0 : config.convertExtensions) ||
+                    node.kind === 'InputObjectTypeDefinition' ||
+                    existingNode.kind === 'InputObjectTypeDefinition'
+                    ? 'InputObjectTypeDefinition'
+                    : 'InputObjectTypeExtension',
+                loc: node.loc,
+                fields: (0, fields_js_1.mergeFields)(node, node.fields, existingNode.fields, config),
+                directives: (0, directives_js_1.mergeDirectives)(node.directives, existingNode.directives, config),
+            };
+        }
+        catch (e) {
+            throw new Error(`Unable to merge GraphQL input type "${node.name.value}": ${e.message}`);
+        }
+    }
+    return (config === null || config === void 0 ? void 0 : config.convertExtensions)
+        ? {
+            ...node,
+            kind: graphql_1.Kind.INPUT_OBJECT_TYPE_DEFINITION,
+        }
+        : node;
+}
+exports.mergeInputType = mergeInputType;
+
+
+/***/ }),
 /* 752 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -63433,7 +71418,134 @@ function clone(node) {
 /***/ }),
 /* 756 */,
 /* 757 */,
-/* 758 */,
+/* 758 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeGraphQLTypes = exports.mergeTypeDefs = void 0;
+const graphql_1 = __webpack_require__(232);
+const utils_js_1 = __webpack_require__(706);
+const merge_nodes_js_1 = __webpack_require__(646);
+const utils_1 = __webpack_require__(971);
+const schema_def_js_1 = __webpack_require__(23);
+function mergeTypeDefs(typeSource, config) {
+    (0, utils_1.resetComments)();
+    const doc = {
+        kind: graphql_1.Kind.DOCUMENT,
+        definitions: mergeGraphQLTypes(typeSource, {
+            useSchemaDefinition: true,
+            forceSchemaDefinition: false,
+            throwOnConflict: false,
+            commentDescriptions: false,
+            ...config,
+        }),
+    };
+    let result;
+    if (config === null || config === void 0 ? void 0 : config.commentDescriptions) {
+        result = (0, utils_1.printWithComments)(doc);
+    }
+    else {
+        result = doc;
+    }
+    (0, utils_1.resetComments)();
+    return result;
+}
+exports.mergeTypeDefs = mergeTypeDefs;
+function visitTypeSources(typeSource, options, allNodes = [], visitedTypeSources = new Set()) {
+    if (typeSource && !visitedTypeSources.has(typeSource)) {
+        visitedTypeSources.add(typeSource);
+        if (typeof typeSource === 'function') {
+            visitTypeSources(typeSource(), options, allNodes, visitedTypeSources);
+        }
+        else if (Array.isArray(typeSource)) {
+            for (const type of typeSource) {
+                visitTypeSources(type, options, allNodes, visitedTypeSources);
+            }
+        }
+        else if ((0, graphql_1.isSchema)(typeSource)) {
+            const documentNode = (0, utils_1.getDocumentNodeFromSchema)(typeSource, options);
+            visitTypeSources(documentNode.definitions, options, allNodes, visitedTypeSources);
+        }
+        else if ((0, utils_js_1.isStringTypes)(typeSource) || (0, utils_js_1.isSourceTypes)(typeSource)) {
+            const documentNode = (0, graphql_1.parse)(typeSource, options);
+            visitTypeSources(documentNode.definitions, options, allNodes, visitedTypeSources);
+        }
+        else if (typeof typeSource === 'object' && (0, graphql_1.isDefinitionNode)(typeSource)) {
+            allNodes.push(typeSource);
+        }
+        else if ((0, utils_1.isDocumentNode)(typeSource)) {
+            visitTypeSources(typeSource.definitions, options, allNodes, visitedTypeSources);
+        }
+        else {
+            throw new Error(`typeDefs must contain only strings, documents, schemas, or functions, got ${typeof typeSource}`);
+        }
+    }
+    return allNodes;
+}
+function mergeGraphQLTypes(typeSource, config) {
+    var _a, _b, _c;
+    (0, utils_1.resetComments)();
+    const allNodes = visitTypeSources(typeSource, config);
+    const mergedNodes = (0, merge_nodes_js_1.mergeGraphQLNodes)(allNodes, config);
+    if (config === null || config === void 0 ? void 0 : config.useSchemaDefinition) {
+        // XXX: right now we don't handle multiple schema definitions
+        const schemaDef = mergedNodes[merge_nodes_js_1.schemaDefSymbol] || {
+            kind: graphql_1.Kind.SCHEMA_DEFINITION,
+            operationTypes: [],
+        };
+        const operationTypes = schemaDef.operationTypes;
+        for (const opTypeDefNodeType in schema_def_js_1.DEFAULT_OPERATION_TYPE_NAME_MAP) {
+            const opTypeDefNode = operationTypes.find(operationType => operationType.operation === opTypeDefNodeType);
+            if (!opTypeDefNode) {
+                const possibleRootTypeName = schema_def_js_1.DEFAULT_OPERATION_TYPE_NAME_MAP[opTypeDefNodeType];
+                const existingPossibleRootType = mergedNodes[possibleRootTypeName];
+                if (existingPossibleRootType != null && existingPossibleRootType.name != null) {
+                    operationTypes.push({
+                        kind: graphql_1.Kind.OPERATION_TYPE_DEFINITION,
+                        type: {
+                            kind: graphql_1.Kind.NAMED_TYPE,
+                            name: existingPossibleRootType.name,
+                        },
+                        operation: opTypeDefNodeType,
+                    });
+                }
+            }
+        }
+        if (((_a = schemaDef === null || schemaDef === void 0 ? void 0 : schemaDef.operationTypes) === null || _a === void 0 ? void 0 : _a.length) != null && schemaDef.operationTypes.length > 0) {
+            mergedNodes[merge_nodes_js_1.schemaDefSymbol] = schemaDef;
+        }
+    }
+    if ((config === null || config === void 0 ? void 0 : config.forceSchemaDefinition) && !((_c = (_b = mergedNodes[merge_nodes_js_1.schemaDefSymbol]) === null || _b === void 0 ? void 0 : _b.operationTypes) === null || _c === void 0 ? void 0 : _c.length)) {
+        mergedNodes[merge_nodes_js_1.schemaDefSymbol] = {
+            kind: graphql_1.Kind.SCHEMA_DEFINITION,
+            operationTypes: [
+                {
+                    kind: graphql_1.Kind.OPERATION_TYPE_DEFINITION,
+                    operation: 'query',
+                    type: {
+                        kind: graphql_1.Kind.NAMED_TYPE,
+                        name: {
+                            kind: graphql_1.Kind.NAME,
+                            value: 'Query',
+                        },
+                    },
+                },
+            ],
+        };
+    }
+    const mergedNodeDefinitions = Object.values(mergedNodes);
+    if (config === null || config === void 0 ? void 0 : config.sort) {
+        const sortFn = typeof config.sort === 'function' ? config.sort : utils_js_1.defaultStringComparator;
+        mergedNodeDefinitions.sort((a, b) => { var _a, _b; return sortFn((_a = a.name) === null || _a === void 0 ? void 0 : _a.value, (_b = b.name) === null || _b === void 0 ? void 0 : _b.value); });
+    }
+    return mergedNodeDefinitions;
+}
+exports.mergeGraphQLTypes = mergeGraphQLTypes;
+
+
+/***/ }),
 /* 759 */,
 /* 760 */,
 /* 761 */
@@ -63604,7 +71716,190 @@ function plural(ms, msAbs, n, name) {
 
 
 /***/ }),
-/* 762 */,
+/* 762 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.healTypes = exports.healSchema = void 0;
+const graphql_1 = __webpack_require__(232);
+// Update any references to named schema types that disagree with the named
+// types found in schema.getTypeMap().
+//
+// healSchema and its callers (visitSchema/visitSchemaDirectives) all modify the schema in place.
+// Therefore, private variables (such as the stored implementation map and the proper root types)
+// are not updated.
+//
+// If this causes issues, the schema could be more aggressively healed as follows:
+//
+// healSchema(schema);
+// const config = schema.toConfig()
+// const healedSchema = new GraphQLSchema({
+//   ...config,
+//   query: schema.getType('<desired new root query type name>'),
+//   mutation: schema.getType('<desired new root mutation type name>'),
+//   subscription: schema.getType('<desired new root subscription type name>'),
+// });
+//
+// One can then also -- if necessary --  assign the correct private variables to the initial schema
+// as follows:
+// Object.assign(schema, healedSchema);
+//
+// These steps are not taken automatically to preserve backwards compatibility with graphql-tools v4.
+// See https://github.com/ardatan/graphql-tools/issues/1462
+//
+// They were briefly taken in v5, but can now be phased out as they were only required when other
+// areas of the codebase were using healSchema and visitSchema more extensively.
+//
+function healSchema(schema) {
+    healTypes(schema.getTypeMap(), schema.getDirectives());
+    return schema;
+}
+exports.healSchema = healSchema;
+function healTypes(originalTypeMap, directives) {
+    const actualNamedTypeMap = Object.create(null);
+    // If any of the .name properties of the GraphQLNamedType objects in
+    // schema.getTypeMap() have changed, the keys of the type map need to
+    // be updated accordingly.
+    for (const typeName in originalTypeMap) {
+        const namedType = originalTypeMap[typeName];
+        if (namedType == null || typeName.startsWith('__')) {
+            continue;
+        }
+        const actualName = namedType.name;
+        if (actualName.startsWith('__')) {
+            continue;
+        }
+        if (actualName in actualNamedTypeMap) {
+            throw new Error(`Duplicate schema type name ${actualName}`);
+        }
+        actualNamedTypeMap[actualName] = namedType;
+        // Note: we are deliberately leaving namedType in the schema by its
+        // original name (which might be different from actualName), so that
+        // references by that name can be healed.
+    }
+    // Now add back every named type by its actual name.
+    for (const typeName in actualNamedTypeMap) {
+        const namedType = actualNamedTypeMap[typeName];
+        originalTypeMap[typeName] = namedType;
+    }
+    // Directive declaration argument types can refer to named types.
+    for (const decl of directives) {
+        decl.args = decl.args.filter(arg => {
+            arg.type = healType(arg.type);
+            return arg.type !== null;
+        });
+    }
+    for (const typeName in originalTypeMap) {
+        const namedType = originalTypeMap[typeName];
+        // Heal all named types, except for dangling references, kept only to redirect.
+        if (!typeName.startsWith('__') && typeName in actualNamedTypeMap) {
+            if (namedType != null) {
+                healNamedType(namedType);
+            }
+        }
+    }
+    for (const typeName in originalTypeMap) {
+        if (!typeName.startsWith('__') && !(typeName in actualNamedTypeMap)) {
+            delete originalTypeMap[typeName];
+        }
+    }
+    function healNamedType(type) {
+        if ((0, graphql_1.isObjectType)(type)) {
+            healFields(type);
+            healInterfaces(type);
+            return;
+        }
+        else if ((0, graphql_1.isInterfaceType)(type)) {
+            healFields(type);
+            if ('getInterfaces' in type) {
+                healInterfaces(type);
+            }
+            return;
+        }
+        else if ((0, graphql_1.isUnionType)(type)) {
+            healUnderlyingTypes(type);
+            return;
+        }
+        else if ((0, graphql_1.isInputObjectType)(type)) {
+            healInputFields(type);
+            return;
+        }
+        else if ((0, graphql_1.isLeafType)(type)) {
+            return;
+        }
+        throw new Error(`Unexpected schema type: ${type}`);
+    }
+    function healFields(type) {
+        const fieldMap = type.getFields();
+        for (const [key, field] of Object.entries(fieldMap)) {
+            field.args
+                .map(arg => {
+                arg.type = healType(arg.type);
+                return arg.type === null ? null : arg;
+            })
+                .filter(Boolean);
+            field.type = healType(field.type);
+            if (field.type === null) {
+                delete fieldMap[key];
+            }
+        }
+    }
+    function healInterfaces(type) {
+        if ('getInterfaces' in type) {
+            const interfaces = type.getInterfaces();
+            interfaces.push(...interfaces
+                .splice(0)
+                .map(iface => healType(iface))
+                .filter(Boolean));
+        }
+    }
+    function healInputFields(type) {
+        const fieldMap = type.getFields();
+        for (const [key, field] of Object.entries(fieldMap)) {
+            field.type = healType(field.type);
+            if (field.type === null) {
+                delete fieldMap[key];
+            }
+        }
+    }
+    function healUnderlyingTypes(type) {
+        const types = type.getTypes();
+        types.push(...types
+            .splice(0)
+            .map(t => healType(t))
+            .filter(Boolean));
+    }
+    function healType(type) {
+        // Unwrap the two known wrapper types
+        if ((0, graphql_1.isListType)(type)) {
+            const healedType = healType(type.ofType);
+            return healedType != null ? new graphql_1.GraphQLList(healedType) : null;
+        }
+        else if ((0, graphql_1.isNonNullType)(type)) {
+            const healedType = healType(type.ofType);
+            return healedType != null ? new graphql_1.GraphQLNonNull(healedType) : null;
+        }
+        else if ((0, graphql_1.isNamedType)(type)) {
+            // If a type annotation on a field or an argument or a union member is
+            // any `GraphQLNamedType` with a `name`, then it must end up identical
+            // to `schema.getType(name)`, since `schema.getTypeMap()` is the source
+            // of truth for all named schema types.
+            // Note that new types can still be simply added by adding a field, as
+            // the official type will be undefined, not null.
+            const officialType = originalTypeMap[type.name];
+            if (officialType && type !== officialType) {
+                return officialType;
+            }
+        }
+        return type;
+    }
+}
+exports.healTypes = healTypes;
+
+
+/***/ }),
 /* 763 */,
 /* 764 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -63734,7 +72029,29 @@ exports.program = program;
 /***/ }),
 /* 767 */,
 /* 768 */,
-/* 769 */,
+/* 769 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getOperationASTFromRequest = exports.getOperationASTFromDocument = void 0;
+const graphql_1 = __webpack_require__(232);
+const memoize_js_1 = __webpack_require__(389);
+function getOperationASTFromDocument(documentNode, operationName) {
+    const doc = (0, graphql_1.getOperationAST)(documentNode, operationName);
+    if (!doc) {
+        throw new Error(`Cannot infer operation ${operationName || ''}`);
+    }
+    return doc;
+}
+exports.getOperationASTFromDocument = getOperationASTFromDocument;
+exports.getOperationASTFromRequest = (0, memoize_js_1.memoize1)(function getOperationASTFromRequest(request) {
+    return getOperationASTFromDocument(request.document, request.operationName);
+});
+
+
+/***/ }),
 /* 770 */,
 /* 771 */,
 /* 772 */,
@@ -64278,7 +72595,67 @@ function cloneDeep(node) {
 /***/ }),
 /* 777 */,
 /* 778 */,
-/* 779 */,
+/* 779 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createVariableNameGenerator = exports.updateArgument = void 0;
+const graphql_1 = __webpack_require__(232);
+const astFromType_js_1 = __webpack_require__(355);
+function updateArgument(argumentNodes, variableDefinitionsMap, variableValues, argName, varName, type, value) {
+    argumentNodes[argName] = {
+        kind: graphql_1.Kind.ARGUMENT,
+        name: {
+            kind: graphql_1.Kind.NAME,
+            value: argName,
+        },
+        value: {
+            kind: graphql_1.Kind.VARIABLE,
+            name: {
+                kind: graphql_1.Kind.NAME,
+                value: varName,
+            },
+        },
+    };
+    variableDefinitionsMap[varName] = {
+        kind: graphql_1.Kind.VARIABLE_DEFINITION,
+        variable: {
+            kind: graphql_1.Kind.VARIABLE,
+            name: {
+                kind: graphql_1.Kind.NAME,
+                value: varName,
+            },
+        },
+        type: (0, astFromType_js_1.astFromType)(type),
+    };
+    if (value !== undefined) {
+        variableValues[varName] = value;
+        return;
+    }
+    // including the variable in the map with value of `undefined`
+    // will actually be translated by graphql-js into `null`
+    // see https://github.com/graphql/graphql-js/issues/2533
+    if (varName in variableValues) {
+        delete variableValues[varName];
+    }
+}
+exports.updateArgument = updateArgument;
+function createVariableNameGenerator(variableDefinitionMap) {
+    let varCounter = 0;
+    return (argName) => {
+        let varName;
+        do {
+            varName = `_v${(varCounter++).toString()}_${argName}`;
+        } while (varName in variableDefinitionMap);
+        return varName;
+    };
+}
+exports.createVariableNameGenerator = createVariableNameGenerator;
+
+
+/***/ }),
 /* 780 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -66318,7 +74695,76 @@ exports.default = SourceMap;
 /* 802 */,
 /* 803 */,
 /* 804 */,
-/* 805 */,
+/* 805 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.extractExtensionsFromSchema = void 0;
+const mapSchema_js_1 = __webpack_require__(675);
+const Interfaces_js_1 = __webpack_require__(368);
+function extractExtensionsFromSchema(schema) {
+    const result = {
+        schemaExtensions: schema.extensions || {},
+        types: {},
+    };
+    (0, mapSchema_js_1.mapSchema)(schema, {
+        [Interfaces_js_1.MapperKind.OBJECT_TYPE]: type => {
+            result.types[type.name] = { fields: {}, type: 'object', extensions: type.extensions || {} };
+            return type;
+        },
+        [Interfaces_js_1.MapperKind.INTERFACE_TYPE]: type => {
+            result.types[type.name] = { fields: {}, type: 'interface', extensions: type.extensions || {} };
+            return type;
+        },
+        [Interfaces_js_1.MapperKind.FIELD]: (field, fieldName, typeName) => {
+            result.types[typeName].fields[fieldName] = {
+                arguments: {},
+                extensions: field.extensions || {},
+            };
+            const args = field.args;
+            if (args != null) {
+                for (const argName in args) {
+                    result.types[typeName].fields[fieldName].arguments[argName] =
+                        args[argName].extensions || {};
+                }
+            }
+            return field;
+        },
+        [Interfaces_js_1.MapperKind.ENUM_TYPE]: type => {
+            result.types[type.name] = { values: {}, type: 'enum', extensions: type.extensions || {} };
+            return type;
+        },
+        [Interfaces_js_1.MapperKind.ENUM_VALUE]: (value, typeName, _schema, valueName) => {
+            result.types[typeName].values[valueName] = value.extensions || {};
+            return value;
+        },
+        [Interfaces_js_1.MapperKind.SCALAR_TYPE]: type => {
+            result.types[type.name] = { type: 'scalar', extensions: type.extensions || {} };
+            return type;
+        },
+        [Interfaces_js_1.MapperKind.UNION_TYPE]: type => {
+            result.types[type.name] = { type: 'union', extensions: type.extensions || {} };
+            return type;
+        },
+        [Interfaces_js_1.MapperKind.INPUT_OBJECT_TYPE]: type => {
+            result.types[type.name] = { fields: {}, type: 'input', extensions: type.extensions || {} };
+            return type;
+        },
+        [Interfaces_js_1.MapperKind.INPUT_OBJECT_FIELD]: (field, fieldName, typeName) => {
+            result.types[typeName].fields[fieldName] = {
+                extensions: field.extensions || {},
+            };
+            return field;
+        },
+    });
+    return result;
+}
+exports.extractExtensionsFromSchema = extractExtensionsFromSchema;
+
+
+/***/ }),
 /* 806 */,
 /* 807 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -67537,7 +75983,329 @@ function serializeObject(outputValue) {
 
 
 /***/ }),
-/* 811 */,
+/* 811 */
+/***/ (function(module) {
+
+/******************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+/* global global, define, System, Reflect, Promise */
+var __extends;
+var __assign;
+var __rest;
+var __decorate;
+var __param;
+var __metadata;
+var __awaiter;
+var __generator;
+var __exportStar;
+var __values;
+var __read;
+var __spread;
+var __spreadArrays;
+var __spreadArray;
+var __await;
+var __asyncGenerator;
+var __asyncDelegator;
+var __asyncValues;
+var __makeTemplateObject;
+var __importStar;
+var __importDefault;
+var __classPrivateFieldGet;
+var __classPrivateFieldSet;
+var __classPrivateFieldIn;
+var __createBinding;
+(function (factory) {
+    var root = typeof global === "object" ? global : typeof self === "object" ? self : typeof this === "object" ? this : {};
+    if (typeof define === "function" && define.amd) {
+        define("tslib", ["exports"], function (exports) { factory(createExporter(root, createExporter(exports))); });
+    }
+    else if ( true && typeof module.exports === "object") {
+        factory(createExporter(root, createExporter(module.exports)));
+    }
+    else {
+        factory(createExporter(root));
+    }
+    function createExporter(exports, previous) {
+        if (exports !== root) {
+            if (typeof Object.create === "function") {
+                Object.defineProperty(exports, "__esModule", { value: true });
+            }
+            else {
+                exports.__esModule = true;
+            }
+        }
+        return function (id, v) { return exports[id] = previous ? previous(id, v) : v; };
+    }
+})
+(function (exporter) {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+
+    __extends = function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+
+    __assign = Object.assign || function (t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+    };
+
+    __rest = function (s, e) {
+        var t = {};
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+            t[p] = s[p];
+        if (s != null && typeof Object.getOwnPropertySymbols === "function")
+            for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+                if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                    t[p[i]] = s[p[i]];
+            }
+        return t;
+    };
+
+    __decorate = function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+
+    __param = function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+
+    __metadata = function (metadataKey, metadataValue) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(metadataKey, metadataValue);
+    };
+
+    __awaiter = function (thisArg, _arguments, P, generator) {
+        function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+        return new (P || (P = Promise))(function (resolve, reject) {
+            function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+            function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+            function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+            step((generator = generator.apply(thisArg, _arguments || [])).next());
+        });
+    };
+
+    __generator = function (thisArg, body) {
+        var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+        return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+        function verb(n) { return function (v) { return step([n, v]); }; }
+        function step(op) {
+            if (f) throw new TypeError("Generator is already executing.");
+            while (_) try {
+                if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+                if (y = 0, t) op = [op[0] & 2, t.value];
+                switch (op[0]) {
+                    case 0: case 1: t = op; break;
+                    case 4: _.label++; return { value: op[1], done: false };
+                    case 5: _.label++; y = op[1]; op = [0]; continue;
+                    case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                    default:
+                        if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                        if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                        if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                        if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                        if (t[2]) _.ops.pop();
+                        _.trys.pop(); continue;
+                }
+                op = body.call(thisArg, _);
+            } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+            if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+        }
+    };
+
+    __exportStar = function(m, o) {
+        for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(o, p)) __createBinding(o, m, p);
+    };
+
+    __createBinding = Object.create ? (function(o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+            desc = { enumerable: true, get: function() { return m[k]; } };
+        }
+        Object.defineProperty(o, k2, desc);
+    }) : (function(o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+    });
+
+    __values = function (o) {
+        var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
+        if (m) return m.call(o);
+        if (o && typeof o.length === "number") return {
+            next: function () {
+                if (o && i >= o.length) o = void 0;
+                return { value: o && o[i++], done: !o };
+            }
+        };
+        throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
+    };
+
+    __read = function (o, n) {
+        var m = typeof Symbol === "function" && o[Symbol.iterator];
+        if (!m) return o;
+        var i = m.call(o), r, ar = [], e;
+        try {
+            while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+        }
+        catch (error) { e = { error: error }; }
+        finally {
+            try {
+                if (r && !r.done && (m = i["return"])) m.call(i);
+            }
+            finally { if (e) throw e.error; }
+        }
+        return ar;
+    };
+
+    /** @deprecated */
+    __spread = function () {
+        for (var ar = [], i = 0; i < arguments.length; i++)
+            ar = ar.concat(__read(arguments[i]));
+        return ar;
+    };
+
+    /** @deprecated */
+    __spreadArrays = function () {
+        for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+        for (var r = Array(s), k = 0, i = 0; i < il; i++)
+            for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+                r[k] = a[j];
+        return r;
+    };
+
+    __spreadArray = function (to, from, pack) {
+        if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+            if (ar || !(i in from)) {
+                if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+                ar[i] = from[i];
+            }
+        }
+        return to.concat(ar || Array.prototype.slice.call(from));
+    };
+
+    __await = function (v) {
+        return this instanceof __await ? (this.v = v, this) : new __await(v);
+    };
+
+    __asyncGenerator = function (thisArg, _arguments, generator) {
+        if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+        var g = generator.apply(thisArg, _arguments || []), i, q = [];
+        return i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i;
+        function verb(n) { if (g[n]) i[n] = function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); }; }
+        function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(q[0][3], e); } }
+        function step(r) { r.value instanceof __await ? Promise.resolve(r.value.v).then(fulfill, reject) : settle(q[0][2], r);  }
+        function fulfill(value) { resume("next", value); }
+        function reject(value) { resume("throw", value); }
+        function settle(f, v) { if (f(v), q.shift(), q.length) resume(q[0][0], q[0][1]); }
+    };
+
+    __asyncDelegator = function (o) {
+        var i, p;
+        return i = {}, verb("next"), verb("throw", function (e) { throw e; }), verb("return"), i[Symbol.iterator] = function () { return this; }, i;
+        function verb(n, f) { i[n] = o[n] ? function (v) { return (p = !p) ? { value: __await(o[n](v)), done: n === "return" } : f ? f(v) : v; } : f; }
+    };
+
+    __asyncValues = function (o) {
+        if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+        var m = o[Symbol.asyncIterator], i;
+        return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+        function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+        function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+    };
+
+    __makeTemplateObject = function (cooked, raw) {
+        if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+        return cooked;
+    };
+
+    var __setModuleDefault = Object.create ? (function(o, v) {
+        Object.defineProperty(o, "default", { enumerable: true, value: v });
+    }) : function(o, v) {
+        o["default"] = v;
+    };
+
+    __importStar = function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+
+    __importDefault = function (mod) {
+        return (mod && mod.__esModule) ? mod : { "default": mod };
+    };
+
+    __classPrivateFieldGet = function (receiver, state, kind, f) {
+        if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+        if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+        return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+    };
+
+    __classPrivateFieldSet = function (receiver, state, value, kind, f) {
+        if (kind === "m") throw new TypeError("Private method is not writable");
+        if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+        if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+        return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+    };
+
+    __classPrivateFieldIn = function (state, receiver) {
+        if (receiver === null || (typeof receiver !== "object" && typeof receiver !== "function")) throw new TypeError("Cannot use 'in' operator on non-object");
+        return typeof state === "function" ? receiver === state : state.has(receiver);
+    };
+
+    exporter("__extends", __extends);
+    exporter("__assign", __assign);
+    exporter("__rest", __rest);
+    exporter("__decorate", __decorate);
+    exporter("__param", __param);
+    exporter("__metadata", __metadata);
+    exporter("__awaiter", __awaiter);
+    exporter("__generator", __generator);
+    exporter("__exportStar", __exportStar);
+    exporter("__createBinding", __createBinding);
+    exporter("__values", __values);
+    exporter("__read", __read);
+    exporter("__spread", __spread);
+    exporter("__spreadArrays", __spreadArrays);
+    exporter("__spreadArray", __spreadArray);
+    exporter("__await", __await);
+    exporter("__asyncGenerator", __asyncGenerator);
+    exporter("__asyncDelegator", __asyncDelegator);
+    exporter("__asyncValues", __asyncValues);
+    exporter("__makeTemplateObject", __makeTemplateObject);
+    exporter("__importStar", __importStar);
+    exporter("__importDefault", __importDefault);
+    exporter("__classPrivateFieldGet", __classPrivateFieldGet);
+    exporter("__classPrivateFieldSet", __classPrivateFieldSet);
+    exporter("__classPrivateFieldIn", __classPrivateFieldIn);
+});
+
+
+/***/ }),
 /* 812 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -70199,7 +78967,53 @@ function evaluate() {
 
 /***/ }),
 /* 841 */,
-/* 842 */,
+/* 842 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeEnumValues = void 0;
+const directives_js_1 = __webpack_require__(154);
+const utils_1 = __webpack_require__(971);
+function mergeEnumValues(first, second, config) {
+    if (config === null || config === void 0 ? void 0 : config.consistentEnumMerge) {
+        const reversed = [];
+        if (first) {
+            reversed.push(...first);
+        }
+        first = second;
+        second = reversed;
+    }
+    const enumValueMap = new Map();
+    if (first) {
+        for (const firstValue of first) {
+            enumValueMap.set(firstValue.name.value, firstValue);
+        }
+    }
+    if (second) {
+        for (const secondValue of second) {
+            const enumValue = secondValue.name.value;
+            if (enumValueMap.has(enumValue)) {
+                const firstValue = enumValueMap.get(enumValue);
+                firstValue.description = secondValue.description || firstValue.description;
+                firstValue.directives = (0, directives_js_1.mergeDirectives)(secondValue.directives, firstValue.directives);
+            }
+            else {
+                enumValueMap.set(enumValue, secondValue);
+            }
+        }
+    }
+    const result = [...enumValueMap.values()];
+    if (config && config.sort) {
+        result.sort(utils_1.compareNodes);
+    }
+    return result;
+}
+exports.mergeEnumValues = mergeEnumValues;
+
+
+/***/ }),
 /* 843 */,
 /* 844 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -70556,7 +79370,22 @@ function is(type, node, opts) {
 
 /***/ }),
 /* 852 */,
-/* 853 */,
+/* 853 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseSelectionSet = void 0;
+const graphql_1 = __webpack_require__(232);
+function parseSelectionSet(selectionSet, options) {
+    const query = (0, graphql_1.parse)(selectionSet, options).definitions[0];
+    return query.selectionSet;
+}
+exports.parseSelectionSet = parseSelectionSet;
+
+
+/***/ }),
 /* 854 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -70653,7 +79482,252 @@ function collectDependencies(selectionSet) {
 
 /***/ }),
 /* 855 */,
-/* 856 */,
+/* 856 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+exports.setopts = setopts
+exports.ownProp = ownProp
+exports.makeAbs = makeAbs
+exports.finish = finish
+exports.mark = mark
+exports.isIgnored = isIgnored
+exports.childrenIgnored = childrenIgnored
+
+function ownProp (obj, field) {
+  return Object.prototype.hasOwnProperty.call(obj, field)
+}
+
+var fs = __webpack_require__(747)
+var path = __webpack_require__(622)
+var minimatch = __webpack_require__(449)
+var isAbsolute = __webpack_require__(622).isAbsolute
+var Minimatch = minimatch.Minimatch
+
+function alphasort (a, b) {
+  return a.localeCompare(b, 'en')
+}
+
+function setupIgnores (self, options) {
+  self.ignore = options.ignore || []
+
+  if (!Array.isArray(self.ignore))
+    self.ignore = [self.ignore]
+
+  if (self.ignore.length) {
+    self.ignore = self.ignore.map(ignoreMap)
+  }
+}
+
+// ignore patterns are always in dot:true mode.
+function ignoreMap (pattern) {
+  var gmatcher = null
+  if (pattern.slice(-3) === '/**') {
+    var gpattern = pattern.replace(/(\/\*\*)+$/, '')
+    gmatcher = new Minimatch(gpattern, { dot: true })
+  }
+
+  return {
+    matcher: new Minimatch(pattern, { dot: true }),
+    gmatcher: gmatcher
+  }
+}
+
+function setopts (self, pattern, options) {
+  if (!options)
+    options = {}
+
+  // base-matching: just use globstar for that.
+  if (options.matchBase && -1 === pattern.indexOf("/")) {
+    if (options.noglobstar) {
+      throw new Error("base matching requires globstar")
+    }
+    pattern = "**/" + pattern
+  }
+
+  self.silent = !!options.silent
+  self.pattern = pattern
+  self.strict = options.strict !== false
+  self.realpath = !!options.realpath
+  self.realpathCache = options.realpathCache || Object.create(null)
+  self.follow = !!options.follow
+  self.dot = !!options.dot
+  self.mark = !!options.mark
+  self.nodir = !!options.nodir
+  if (self.nodir)
+    self.mark = true
+  self.sync = !!options.sync
+  self.nounique = !!options.nounique
+  self.nonull = !!options.nonull
+  self.nosort = !!options.nosort
+  self.nocase = !!options.nocase
+  self.stat = !!options.stat
+  self.noprocess = !!options.noprocess
+  self.absolute = !!options.absolute
+  self.fs = options.fs || fs
+
+  self.maxLength = options.maxLength || Infinity
+  self.cache = options.cache || Object.create(null)
+  self.statCache = options.statCache || Object.create(null)
+  self.symlinks = options.symlinks || Object.create(null)
+
+  setupIgnores(self, options)
+
+  self.changedCwd = false
+  var cwd = process.cwd()
+  if (!ownProp(options, "cwd"))
+    self.cwd = path.resolve(cwd)
+  else {
+    self.cwd = path.resolve(options.cwd)
+    self.changedCwd = self.cwd !== cwd
+  }
+
+  self.root = options.root || path.resolve(self.cwd, "/")
+  self.root = path.resolve(self.root)
+
+  // TODO: is an absolute `cwd` supposed to be resolved against `root`?
+  // e.g. { cwd: '/test', root: __dirname } === path.join(__dirname, '/test')
+  self.cwdAbs = isAbsolute(self.cwd) ? self.cwd : makeAbs(self, self.cwd)
+  self.nomount = !!options.nomount
+
+  if (process.platform === "win32") {
+    self.root = self.root.replace(/\\/g, "/")
+    self.cwd = self.cwd.replace(/\\/g, "/")
+    self.cwdAbs = self.cwdAbs.replace(/\\/g, "/")
+  }
+
+  // disable comments and negation in Minimatch.
+  // Note that they are not supported in Glob itself anyway.
+  options.nonegate = true
+  options.nocomment = true
+  // always treat \ in patterns as escapes, not path separators
+  options.allowWindowsEscape = true
+
+  self.minimatch = new Minimatch(pattern, options)
+  self.options = self.minimatch.options
+}
+
+function finish (self) {
+  var nou = self.nounique
+  var all = nou ? [] : Object.create(null)
+
+  for (var i = 0, l = self.matches.length; i < l; i ++) {
+    var matches = self.matches[i]
+    if (!matches || Object.keys(matches).length === 0) {
+      if (self.nonull) {
+        // do like the shell, and spit out the literal glob
+        var literal = self.minimatch.globSet[i]
+        if (nou)
+          all.push(literal)
+        else
+          all[literal] = true
+      }
+    } else {
+      // had matches
+      var m = Object.keys(matches)
+      if (nou)
+        all.push.apply(all, m)
+      else
+        m.forEach(function (m) {
+          all[m] = true
+        })
+    }
+  }
+
+  if (!nou)
+    all = Object.keys(all)
+
+  if (!self.nosort)
+    all = all.sort(alphasort)
+
+  // at *some* point we statted all of these
+  if (self.mark) {
+    for (var i = 0; i < all.length; i++) {
+      all[i] = self._mark(all[i])
+    }
+    if (self.nodir) {
+      all = all.filter(function (e) {
+        var notDir = !(/\/$/.test(e))
+        var c = self.cache[e] || self.cache[makeAbs(self, e)]
+        if (notDir && c)
+          notDir = c !== 'DIR' && !Array.isArray(c)
+        return notDir
+      })
+    }
+  }
+
+  if (self.ignore.length)
+    all = all.filter(function(m) {
+      return !isIgnored(self, m)
+    })
+
+  self.found = all
+}
+
+function mark (self, p) {
+  var abs = makeAbs(self, p)
+  var c = self.cache[abs]
+  var m = p
+  if (c) {
+    var isDir = c === 'DIR' || Array.isArray(c)
+    var slash = p.slice(-1) === '/'
+
+    if (isDir && !slash)
+      m += '/'
+    else if (!isDir && slash)
+      m = m.slice(0, -1)
+
+    if (m !== p) {
+      var mabs = makeAbs(self, m)
+      self.statCache[mabs] = self.statCache[abs]
+      self.cache[mabs] = self.cache[abs]
+    }
+  }
+
+  return m
+}
+
+// lotta situps...
+function makeAbs (self, f) {
+  var abs = f
+  if (f.charAt(0) === '/') {
+    abs = path.join(self.root, f)
+  } else if (isAbsolute(f) || f === '') {
+    abs = f
+  } else if (self.changedCwd) {
+    abs = path.resolve(self.cwd, f)
+  } else {
+    abs = path.resolve(f)
+  }
+
+  if (process.platform === 'win32')
+    abs = abs.replace(/\\/g, '/')
+
+  return abs
+}
+
+
+// Return true, if pattern ends with globstar '**', for the accompanying parent directory.
+// Ex:- If node_modules/** is the pattern, add 'node_modules' to ignore list along with it's contents
+function isIgnored (self, path) {
+  if (!self.ignore.length)
+    return false
+
+  return self.ignore.some(function(item) {
+    return item.matcher.match(path) || !!(item.gmatcher && item.gmatcher.match(path))
+  })
+}
+
+function childrenIgnored (self, path) {
+  if (!self.ignore.length)
+    return false
+
+  return self.ignore.some(function(item) {
+    return !!(item.gmatcher && item.gmatcher.match(path))
+  })
+}
+
+
+/***/ }),
 /* 857 */
 /***/ (function(__unusedmodule, exports) {
 
@@ -71428,7 +80502,75 @@ function groupBy(list, keyFn) {
 /***/ }),
 /* 882 */,
 /* 883 */,
-/* 884 */,
+/* 884 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+// addTypes uses toConfig to create a new schema with a new or replaced
+// type or directive. Rewiring is employed so that the replaced type can be
+// reconnected with the existing types.
+//
+// Rewiring is employed even for new types or directives as a convenience, so
+// that type references within the new type or directive do not have to be to
+// the identical objects within the original schema.
+//
+// In fact, the type references could even be stub types with entirely different
+// fields, as long as the type references share the same name as the desired
+// type within the original schema's type map.
+//
+// This makes it easy to perform simple schema operations (e.g. adding a new
+// type with a fiew fields removed from an existing type) that could normally be
+// performed by using toConfig directly, but is blocked if any intervening
+// more advanced schema operations have caused the types to be recreated via
+// rewiring.
+//
+// Type recreation happens, for example, with every use of mapSchema, as the
+// types are always rewired. If fields are selected and removed using
+// mapSchema, adding those fields to a new type can no longer be simply done
+// by toConfig, as the types are not the identical JavaScript objects, and
+// schema creation will fail with errors referencing multiple types with the
+// same names.
+//
+// enhanceSchema can fill this gap by adding an additional round of rewiring.
+//
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.addTypes = void 0;
+const graphql_1 = __webpack_require__(232);
+const getObjectTypeFromTypeMap_js_1 = __webpack_require__(374);
+const rewire_js_1 = __webpack_require__(899);
+function addTypes(schema, newTypesOrDirectives) {
+    const config = schema.toConfig();
+    const originalTypeMap = {};
+    for (const type of config.types) {
+        originalTypeMap[type.name] = type;
+    }
+    const originalDirectiveMap = {};
+    for (const directive of config.directives) {
+        originalDirectiveMap[directive.name] = directive;
+    }
+    for (const newTypeOrDirective of newTypesOrDirectives) {
+        if ((0, graphql_1.isNamedType)(newTypeOrDirective)) {
+            originalTypeMap[newTypeOrDirective.name] = newTypeOrDirective;
+        }
+        else if ((0, graphql_1.isDirective)(newTypeOrDirective)) {
+            originalDirectiveMap[newTypeOrDirective.name] = newTypeOrDirective;
+        }
+    }
+    const { typeMap, directives } = (0, rewire_js_1.rewireTypes)(originalTypeMap, Object.values(originalDirectiveMap));
+    return new graphql_1.GraphQLSchema({
+        ...config,
+        query: (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(typeMap, schema.getQueryType()),
+        mutation: (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(typeMap, schema.getMutationType()),
+        subscription: (0, getObjectTypeFromTypeMap_js_1.getObjectTypeFromTypeMap)(typeMap, schema.getSubscriptionType()),
+        types: Object.values(typeMap),
+        directives,
+    });
+}
+exports.addTypes = addTypes;
+
+
+/***/ }),
 /* 885 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -71491,7 +80633,23 @@ function ScalarLeafsRule(context) {
 
 
 /***/ }),
-/* 886 */,
+/* 886 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isAsyncIterable = void 0;
+function isAsyncIterable(value) {
+    return (typeof value === 'object' &&
+        value != null &&
+        Symbol.asyncIterator in value &&
+        typeof value[Symbol.asyncIterator] === 'function');
+}
+exports.isAsyncIterable = isAsyncIterable;
+
+
+/***/ }),
 /* 887 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -71970,7 +81128,15 @@ function KnownArgumentNamesOnDirectivesRule(context) {
 
 
 /***/ }),
-/* 892 */,
+/* 892 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+
+
+/***/ }),
 /* 893 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -72002,7 +81168,40 @@ function isType(nodeType, targetType) {
 
 /***/ }),
 /* 894 */,
-/* 895 */,
+/* 895 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeEnum = void 0;
+const graphql_1 = __webpack_require__(232);
+const directives_js_1 = __webpack_require__(154);
+const enum_values_js_1 = __webpack_require__(842);
+function mergeEnum(e1, e2, config) {
+    if (e2) {
+        return {
+            name: e1.name,
+            description: e1['description'] || e2['description'],
+            kind: (config === null || config === void 0 ? void 0 : config.convertExtensions) || e1.kind === 'EnumTypeDefinition' || e2.kind === 'EnumTypeDefinition'
+                ? 'EnumTypeDefinition'
+                : 'EnumTypeExtension',
+            loc: e1.loc,
+            directives: (0, directives_js_1.mergeDirectives)(e1.directives, e2.directives, config),
+            values: (0, enum_values_js_1.mergeEnumValues)(e1.values, e2.values, config),
+        };
+    }
+    return (config === null || config === void 0 ? void 0 : config.convertExtensions)
+        ? {
+            ...e1,
+            kind: graphql_1.Kind.ENUM_TYPE_DEFINITION,
+        }
+        : e1;
+}
+exports.mergeEnum = mergeEnum;
+
+
+/***/ }),
 /* 896 */,
 /* 897 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
@@ -77367,7 +86566,172 @@ function commaSeparator() {
 }
 
 /***/ }),
-/* 899 */,
+/* 899 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.rewireTypes = void 0;
+const graphql_1 = __webpack_require__(232);
+const stub_js_1 = __webpack_require__(277);
+function rewireTypes(originalTypeMap, directives) {
+    const referenceTypeMap = Object.create(null);
+    for (const typeName in originalTypeMap) {
+        referenceTypeMap[typeName] = originalTypeMap[typeName];
+    }
+    const newTypeMap = Object.create(null);
+    for (const typeName in referenceTypeMap) {
+        const namedType = referenceTypeMap[typeName];
+        if (namedType == null || typeName.startsWith('__')) {
+            continue;
+        }
+        const newName = namedType.name;
+        if (newName.startsWith('__')) {
+            continue;
+        }
+        if (newTypeMap[newName] != null) {
+            throw new Error(`Duplicate schema type name ${newName}`);
+        }
+        newTypeMap[newName] = namedType;
+    }
+    for (const typeName in newTypeMap) {
+        newTypeMap[typeName] = rewireNamedType(newTypeMap[typeName]);
+    }
+    const newDirectives = directives.map(directive => rewireDirective(directive));
+    return {
+        typeMap: newTypeMap,
+        directives: newDirectives,
+    };
+    function rewireDirective(directive) {
+        if ((0, graphql_1.isSpecifiedDirective)(directive)) {
+            return directive;
+        }
+        const directiveConfig = directive.toConfig();
+        directiveConfig.args = rewireArgs(directiveConfig.args);
+        return new graphql_1.GraphQLDirective(directiveConfig);
+    }
+    function rewireArgs(args) {
+        const rewiredArgs = {};
+        for (const argName in args) {
+            const arg = args[argName];
+            const rewiredArgType = rewireType(arg.type);
+            if (rewiredArgType != null) {
+                arg.type = rewiredArgType;
+                rewiredArgs[argName] = arg;
+            }
+        }
+        return rewiredArgs;
+    }
+    function rewireNamedType(type) {
+        if ((0, graphql_1.isObjectType)(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                fields: () => rewireFields(config.fields),
+                interfaces: () => rewireNamedTypes(config.interfaces),
+            };
+            return new graphql_1.GraphQLObjectType(newConfig);
+        }
+        else if ((0, graphql_1.isInterfaceType)(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                fields: () => rewireFields(config.fields),
+            };
+            if ('interfaces' in newConfig) {
+                newConfig.interfaces = () => rewireNamedTypes(config.interfaces);
+            }
+            return new graphql_1.GraphQLInterfaceType(newConfig);
+        }
+        else if ((0, graphql_1.isUnionType)(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                types: () => rewireNamedTypes(config.types),
+            };
+            return new graphql_1.GraphQLUnionType(newConfig);
+        }
+        else if ((0, graphql_1.isInputObjectType)(type)) {
+            const config = type.toConfig();
+            const newConfig = {
+                ...config,
+                fields: () => rewireInputFields(config.fields),
+            };
+            return new graphql_1.GraphQLInputObjectType(newConfig);
+        }
+        else if ((0, graphql_1.isEnumType)(type)) {
+            const enumConfig = type.toConfig();
+            return new graphql_1.GraphQLEnumType(enumConfig);
+        }
+        else if ((0, graphql_1.isScalarType)(type)) {
+            if ((0, graphql_1.isSpecifiedScalarType)(type)) {
+                return type;
+            }
+            const scalarConfig = type.toConfig();
+            return new graphql_1.GraphQLScalarType(scalarConfig);
+        }
+        throw new Error(`Unexpected schema type: ${type}`);
+    }
+    function rewireFields(fields) {
+        const rewiredFields = {};
+        for (const fieldName in fields) {
+            const field = fields[fieldName];
+            const rewiredFieldType = rewireType(field.type);
+            if (rewiredFieldType != null && field.args) {
+                field.type = rewiredFieldType;
+                field.args = rewireArgs(field.args);
+                rewiredFields[fieldName] = field;
+            }
+        }
+        return rewiredFields;
+    }
+    function rewireInputFields(fields) {
+        const rewiredFields = {};
+        for (const fieldName in fields) {
+            const field = fields[fieldName];
+            const rewiredFieldType = rewireType(field.type);
+            if (rewiredFieldType != null) {
+                field.type = rewiredFieldType;
+                rewiredFields[fieldName] = field;
+            }
+        }
+        return rewiredFields;
+    }
+    function rewireNamedTypes(namedTypes) {
+        const rewiredTypes = [];
+        for (const namedType of namedTypes) {
+            const rewiredType = rewireType(namedType);
+            if (rewiredType != null) {
+                rewiredTypes.push(rewiredType);
+            }
+        }
+        return rewiredTypes;
+    }
+    function rewireType(type) {
+        if ((0, graphql_1.isListType)(type)) {
+            const rewiredType = rewireType(type.ofType);
+            return rewiredType != null ? new graphql_1.GraphQLList(rewiredType) : null;
+        }
+        else if ((0, graphql_1.isNonNullType)(type)) {
+            const rewiredType = rewireType(type.ofType);
+            return rewiredType != null ? new graphql_1.GraphQLNonNull(rewiredType) : null;
+        }
+        else if ((0, graphql_1.isNamedType)(type)) {
+            let rewiredType = referenceTypeMap[type.name];
+            if (rewiredType === undefined) {
+                rewiredType = (0, stub_js_1.isNamedStub)(type) ? (0, stub_js_1.getBuiltInForStub)(type) : rewireNamedType(type);
+                newTypeMap[rewiredType.name] = referenceTypeMap[type.name] = rewiredType;
+            }
+            return rewiredType != null ? newTypeMap[rewiredType.name] : null;
+        }
+        return null;
+    }
+}
+exports.rewireTypes = rewireTypes;
+
+
+/***/ }),
 /* 900 */,
 /* 901 */,
 /* 902 */,
@@ -77916,12 +87280,310 @@ function isImmutable(node) {
 
 /***/ }),
 /* 913 */,
-/* 914 */,
+/* 914 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+var balanced = __webpack_require__(621);
+
+module.exports = expandTop;
+
+var escSlash = '\0SLASH'+Math.random()+'\0';
+var escOpen = '\0OPEN'+Math.random()+'\0';
+var escClose = '\0CLOSE'+Math.random()+'\0';
+var escComma = '\0COMMA'+Math.random()+'\0';
+var escPeriod = '\0PERIOD'+Math.random()+'\0';
+
+function numeric(str) {
+  return parseInt(str, 10) == str
+    ? parseInt(str, 10)
+    : str.charCodeAt(0);
+}
+
+function escapeBraces(str) {
+  return str.split('\\\\').join(escSlash)
+            .split('\\{').join(escOpen)
+            .split('\\}').join(escClose)
+            .split('\\,').join(escComma)
+            .split('\\.').join(escPeriod);
+}
+
+function unescapeBraces(str) {
+  return str.split(escSlash).join('\\')
+            .split(escOpen).join('{')
+            .split(escClose).join('}')
+            .split(escComma).join(',')
+            .split(escPeriod).join('.');
+}
+
+
+// Basically just str.split(","), but handling cases
+// where we have nested braced sections, which should be
+// treated as individual members, like {a,{b,c},d}
+function parseCommaParts(str) {
+  if (!str)
+    return [''];
+
+  var parts = [];
+  var m = balanced('{', '}', str);
+
+  if (!m)
+    return str.split(',');
+
+  var pre = m.pre;
+  var body = m.body;
+  var post = m.post;
+  var p = pre.split(',');
+
+  p[p.length-1] += '{' + body + '}';
+  var postParts = parseCommaParts(post);
+  if (post.length) {
+    p[p.length-1] += postParts.shift();
+    p.push.apply(p, postParts);
+  }
+
+  parts.push.apply(parts, p);
+
+  return parts;
+}
+
+function expandTop(str) {
+  if (!str)
+    return [];
+
+  // I don't know why Bash 4.3 does this, but it does.
+  // Anything starting with {} will have the first two bytes preserved
+  // but *only* at the top level, so {},a}b will not expand to anything,
+  // but a{},b}c will be expanded to [a}c,abc].
+  // One could argue that this is a bug in Bash, but since the goal of
+  // this module is to match Bash's rules, we escape a leading {}
+  if (str.substr(0, 2) === '{}') {
+    str = '\\{\\}' + str.substr(2);
+  }
+
+  return expand(escapeBraces(str), true).map(unescapeBraces);
+}
+
+function embrace(str) {
+  return '{' + str + '}';
+}
+function isPadded(el) {
+  return /^-?0\d/.test(el);
+}
+
+function lte(i, y) {
+  return i <= y;
+}
+function gte(i, y) {
+  return i >= y;
+}
+
+function expand(str, isTop) {
+  var expansions = [];
+
+  var m = balanced('{', '}', str);
+  if (!m) return [str];
+
+  // no need to expand pre, since it is guaranteed to be free of brace-sets
+  var pre = m.pre;
+  var post = m.post.length
+    ? expand(m.post, false)
+    : [''];
+
+  if (/\$$/.test(m.pre)) {    
+    for (var k = 0; k < post.length; k++) {
+      var expansion = pre+ '{' + m.body + '}' + post[k];
+      expansions.push(expansion);
+    }
+  } else {
+    var isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body);
+    var isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body);
+    var isSequence = isNumericSequence || isAlphaSequence;
+    var isOptions = m.body.indexOf(',') >= 0;
+    if (!isSequence && !isOptions) {
+      // {a},b}
+      if (m.post.match(/,.*\}/)) {
+        str = m.pre + '{' + m.body + escClose + m.post;
+        return expand(str);
+      }
+      return [str];
+    }
+
+    var n;
+    if (isSequence) {
+      n = m.body.split(/\.\./);
+    } else {
+      n = parseCommaParts(m.body);
+      if (n.length === 1) {
+        // x{{a,b}}y ==> x{a}y x{b}y
+        n = expand(n[0], false).map(embrace);
+        if (n.length === 1) {
+          return post.map(function(p) {
+            return m.pre + n[0] + p;
+          });
+        }
+      }
+    }
+
+    // at this point, n is the parts, and we know it's not a comma set
+    // with a single entry.
+    var N;
+
+    if (isSequence) {
+      var x = numeric(n[0]);
+      var y = numeric(n[1]);
+      var width = Math.max(n[0].length, n[1].length)
+      var incr = n.length == 3
+        ? Math.abs(numeric(n[2]))
+        : 1;
+      var test = lte;
+      var reverse = y < x;
+      if (reverse) {
+        incr *= -1;
+        test = gte;
+      }
+      var pad = n.some(isPadded);
+
+      N = [];
+
+      for (var i = x; test(i, y); i += incr) {
+        var c;
+        if (isAlphaSequence) {
+          c = String.fromCharCode(i);
+          if (c === '\\')
+            c = '';
+        } else {
+          c = String(i);
+          if (pad) {
+            var need = width - c.length;
+            if (need > 0) {
+              var z = new Array(need + 1).join('0');
+              if (i < 0)
+                c = '-' + z + c.slice(1);
+              else
+                c = z + c;
+            }
+          }
+        }
+        N.push(c);
+      }
+    } else {
+      N = [];
+
+      for (var j = 0; j < n.length; j++) {
+        N.push.apply(N, expand(n[j], false));
+      }
+    }
+
+    for (var j = 0; j < N.length; j++) {
+      for (var k = 0; k < post.length; k++) {
+        var expansion = pre + N[j] + post[k];
+        if (!isTop || isSequence || expansion)
+          expansions.push(expansion);
+      }
+    }
+  }
+
+  return expansions;
+}
+
+
+
+/***/ }),
 /* 915 */,
 /* 916 */,
 /* 917 */,
 /* 918 */,
-/* 919 */,
+/* 919 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isDescribable = exports.transformCommentsToDescriptions = exports.parseGraphQLSDL = void 0;
+const graphql_1 = __webpack_require__(232);
+const comments_js_1 = __webpack_require__(233);
+function parseGraphQLSDL(location, rawSDL, options = {}) {
+    let document;
+    try {
+        if (options.commentDescriptions && rawSDL.includes('#')) {
+            document = transformCommentsToDescriptions(rawSDL, options);
+            // If noLocation=true, we need to make sure to print and parse it again, to remove locations,
+            // since `transformCommentsToDescriptions` must have locations set in order to transform the comments
+            // into descriptions.
+            if (options.noLocation) {
+                document = (0, graphql_1.parse)((0, graphql_1.print)(document), options);
+            }
+        }
+        else {
+            document = (0, graphql_1.parse)(new graphql_1.Source(rawSDL, location), options);
+        }
+    }
+    catch (e) {
+        if (e.message.includes('EOF') && rawSDL.replace(/(\#[^*]*)/g, '').trim() === '') {
+            document = {
+                kind: graphql_1.Kind.DOCUMENT,
+                definitions: [],
+            };
+        }
+        else {
+            throw e;
+        }
+    }
+    return {
+        location,
+        document,
+    };
+}
+exports.parseGraphQLSDL = parseGraphQLSDL;
+function transformCommentsToDescriptions(sourceSdl, options = {}) {
+    const parsedDoc = (0, graphql_1.parse)(sourceSdl, {
+        ...options,
+        noLocation: false,
+    });
+    const modifiedDoc = (0, graphql_1.visit)(parsedDoc, {
+        leave: (node) => {
+            if (isDescribable(node)) {
+                const rawValue = (0, comments_js_1.getLeadingCommentBlock)(node);
+                if (rawValue !== undefined) {
+                    const commentsBlock = (0, comments_js_1.dedentBlockStringValue)('\n' + rawValue);
+                    const isBlock = commentsBlock.includes('\n');
+                    if (!node.description) {
+                        return {
+                            ...node,
+                            description: {
+                                kind: graphql_1.Kind.STRING,
+                                value: commentsBlock,
+                                block: isBlock,
+                            },
+                        };
+                    }
+                    else {
+                        return {
+                            ...node,
+                            description: {
+                                ...node.description,
+                                value: node.description.value + '\n' + commentsBlock,
+                                block: true,
+                            },
+                        };
+                    }
+                }
+            }
+        },
+    });
+    return modifiedDoc;
+}
+exports.transformCommentsToDescriptions = transformCommentsToDescriptions;
+function isDescribable(node) {
+    return ((0, graphql_1.isTypeSystemDefinitionNode)(node) ||
+        node.kind === graphql_1.Kind.FIELD_DEFINITION ||
+        node.kind === graphql_1.Kind.INPUT_VALUE_DEFINITION ||
+        node.kind === graphql_1.Kind.ENUM_VALUE_DEFINITION);
+}
+exports.isDescribable = isDescribable;
+
+
+/***/ }),
 /* 920 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -78036,7 +87698,34 @@ exports.default = Binding;
 /* 926 */,
 /* 927 */,
 /* 928 */,
-/* 929 */,
+/* 929 */
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.valueMatchesCriteria = void 0;
+function valueMatchesCriteria(value, criteria) {
+    if (value == null) {
+        return value === criteria;
+    }
+    else if (Array.isArray(value)) {
+        return Array.isArray(criteria) && value.every((val, index) => valueMatchesCriteria(val, criteria[index]));
+    }
+    else if (typeof value === 'object') {
+        return (typeof criteria === 'object' &&
+            criteria &&
+            Object.keys(criteria).every(propertyName => valueMatchesCriteria(value[propertyName], criteria[propertyName])));
+    }
+    else if (criteria instanceof RegExp) {
+        return criteria.test(value);
+    }
+    return value === criteria;
+}
+exports.valueMatchesCriteria = valueMatchesCriteria;
+
+
+/***/ }),
 /* 930 */,
 /* 931 */,
 /* 932 */
@@ -78123,7 +87812,21 @@ exports.default = _default;
 
 /***/ }),
 /* 937 */,
-/* 938 */,
+/* 938 */
+/***/ (function(module, __unusedexports, __webpack_require__) {
+
+try {
+  var util = __webpack_require__(669);
+  /* istanbul ignore next */
+  if (typeof util.inherits !== 'function') throw '';
+  module.exports = util.inherits;
+} catch (e) {
+  /* istanbul ignore next */
+  module.exports = __webpack_require__(566);
+}
+
+
+/***/ }),
 /* 939 */,
 /* 940 */,
 /* 941 */,
@@ -78215,7 +87918,30 @@ function isObjectLike(value) {
 
 
 /***/ }),
-/* 948 */,
+/* 948 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = __webpack_require__(811);
+tslib_1.__exportStar(__webpack_require__(125), exports);
+tslib_1.__exportStar(__webpack_require__(154), exports);
+tslib_1.__exportStar(__webpack_require__(842), exports);
+tslib_1.__exportStar(__webpack_require__(895), exports);
+tslib_1.__exportStar(__webpack_require__(663), exports);
+tslib_1.__exportStar(__webpack_require__(751), exports);
+tslib_1.__exportStar(__webpack_require__(18), exports);
+tslib_1.__exportStar(__webpack_require__(242), exports);
+tslib_1.__exportStar(__webpack_require__(646), exports);
+tslib_1.__exportStar(__webpack_require__(758), exports);
+tslib_1.__exportStar(__webpack_require__(294), exports);
+tslib_1.__exportStar(__webpack_require__(604), exports);
+tslib_1.__exportStar(__webpack_require__(536), exports);
+tslib_1.__exportStar(__webpack_require__(706), exports);
+
+
+/***/ }),
 /* 949 */,
 /* 950 */
 /***/ (function(__unusedmodule, exports) {
@@ -78580,7 +88306,30 @@ function getFieldEntryKey(node) {
 
 
 /***/ }),
-/* 963 */,
+/* 963 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.implementsAbstractType = void 0;
+const graphql_1 = __webpack_require__(232);
+function implementsAbstractType(schema, typeA, typeB) {
+    if (typeB == null || typeA == null) {
+        return false;
+    }
+    else if (typeA === typeB) {
+        return true;
+    }
+    else if ((0, graphql_1.isCompositeType)(typeA) && (0, graphql_1.isCompositeType)(typeB)) {
+        return (0, graphql_1.doTypesOverlap)(schema, typeA, typeB);
+    }
+    return false;
+}
+exports.implementsAbstractType = implementsAbstractType;
+
+
+/***/ }),
 /* 964 */,
 /* 965 */,
 /* 966 */
@@ -78835,7 +88584,67 @@ function mergePair(dest, src) {
 /* 968 */,
 /* 969 */,
 /* 970 */,
-/* 971 */,
+/* 971 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+const tslib_1 = __webpack_require__(164);
+tslib_1.__exportStar(__webpack_require__(373), exports);
+tslib_1.__exportStar(__webpack_require__(602), exports);
+tslib_1.__exportStar(__webpack_require__(721), exports);
+tslib_1.__exportStar(__webpack_require__(440), exports);
+tslib_1.__exportStar(__webpack_require__(285), exports);
+tslib_1.__exportStar(__webpack_require__(478), exports);
+tslib_1.__exportStar(__webpack_require__(440), exports);
+tslib_1.__exportStar(__webpack_require__(450), exports);
+tslib_1.__exportStar(__webpack_require__(270), exports);
+tslib_1.__exportStar(__webpack_require__(919), exports);
+tslib_1.__exportStar(__webpack_require__(361), exports);
+tslib_1.__exportStar(__webpack_require__(94), exports);
+tslib_1.__exportStar(__webpack_require__(178), exports);
+tslib_1.__exportStar(__webpack_require__(762), exports);
+tslib_1.__exportStar(__webpack_require__(306), exports);
+tslib_1.__exportStar(__webpack_require__(672), exports);
+tslib_1.__exportStar(__webpack_require__(551), exports);
+tslib_1.__exportStar(__webpack_require__(675), exports);
+tslib_1.__exportStar(__webpack_require__(884), exports);
+tslib_1.__exportStar(__webpack_require__(899), exports);
+tslib_1.__exportStar(__webpack_require__(689), exports);
+tslib_1.__exportStar(__webpack_require__(216), exports);
+tslib_1.__exportStar(__webpack_require__(368), exports);
+tslib_1.__exportStar(__webpack_require__(277), exports);
+tslib_1.__exportStar(__webpack_require__(853), exports);
+tslib_1.__exportStar(__webpack_require__(712), exports);
+tslib_1.__exportStar(__webpack_require__(63), exports);
+tslib_1.__exportStar(__webpack_require__(418), exports);
+tslib_1.__exportStar(__webpack_require__(144), exports);
+tslib_1.__exportStar(__webpack_require__(407), exports);
+tslib_1.__exportStar(__webpack_require__(779), exports);
+tslib_1.__exportStar(__webpack_require__(963), exports);
+tslib_1.__exportStar(__webpack_require__(403), exports);
+tslib_1.__exportStar(__webpack_require__(394), exports);
+tslib_1.__exportStar(__webpack_require__(0), exports);
+tslib_1.__exportStar(__webpack_require__(112), exports);
+tslib_1.__exportStar(__webpack_require__(929), exports);
+tslib_1.__exportStar(__webpack_require__(886), exports);
+tslib_1.__exportStar(__webpack_require__(244), exports);
+tslib_1.__exportStar(__webpack_require__(576), exports);
+tslib_1.__exportStar(__webpack_require__(892), exports);
+tslib_1.__exportStar(__webpack_require__(489), exports);
+tslib_1.__exportStar(__webpack_require__(265), exports);
+tslib_1.__exportStar(__webpack_require__(142), exports);
+tslib_1.__exportStar(__webpack_require__(233), exports);
+tslib_1.__exportStar(__webpack_require__(481), exports);
+tslib_1.__exportStar(__webpack_require__(524), exports);
+tslib_1.__exportStar(__webpack_require__(389), exports);
+tslib_1.__exportStar(__webpack_require__(483), exports);
+tslib_1.__exportStar(__webpack_require__(769), exports);
+tslib_1.__exportStar(__webpack_require__(805), exports);
+
+
+/***/ }),
 /* 972 */
 /***/ (function(__unusedmodule, exports, __webpack_require__) {
 
@@ -80070,7 +89879,315 @@ exports.react = react;
 /***/ }),
 /* 979 */,
 /* 980 */,
-/* 981 */,
+/* 981 */
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var pathModule = __webpack_require__(622);
+var isWindows = process.platform === 'win32';
+var fs = __webpack_require__(747);
+
+// JavaScript implementation of realpath, ported from node pre-v6
+
+var DEBUG = process.env.NODE_DEBUG && /fs/.test(process.env.NODE_DEBUG);
+
+function rethrow() {
+  // Only enable in debug mode. A backtrace uses ~1000 bytes of heap space and
+  // is fairly slow to generate.
+  var callback;
+  if (DEBUG) {
+    var backtrace = new Error;
+    callback = debugCallback;
+  } else
+    callback = missingCallback;
+
+  return callback;
+
+  function debugCallback(err) {
+    if (err) {
+      backtrace.message = err.message;
+      err = backtrace;
+      missingCallback(err);
+    }
+  }
+
+  function missingCallback(err) {
+    if (err) {
+      if (process.throwDeprecation)
+        throw err;  // Forgot a callback but don't know where? Use NODE_DEBUG=fs
+      else if (!process.noDeprecation) {
+        var msg = 'fs: missing callback ' + (err.stack || err.message);
+        if (process.traceDeprecation)
+          console.trace(msg);
+        else
+          console.error(msg);
+      }
+    }
+  }
+}
+
+function maybeCallback(cb) {
+  return typeof cb === 'function' ? cb : rethrow();
+}
+
+var normalize = pathModule.normalize;
+
+// Regexp that finds the next partion of a (partial) path
+// result is [base_with_slash, base], e.g. ['somedir/', 'somedir']
+if (isWindows) {
+  var nextPartRe = /(.*?)(?:[\/\\]+|$)/g;
+} else {
+  var nextPartRe = /(.*?)(?:[\/]+|$)/g;
+}
+
+// Regex to find the device root, including trailing slash. E.g. 'c:\\'.
+if (isWindows) {
+  var splitRootRe = /^(?:[a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/][^\\\/]+)?[\\\/]*/;
+} else {
+  var splitRootRe = /^[\/]*/;
+}
+
+exports.realpathSync = function realpathSync(p, cache) {
+  // make p is absolute
+  p = pathModule.resolve(p);
+
+  if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
+    return cache[p];
+  }
+
+  var original = p,
+      seenLinks = {},
+      knownHard = {};
+
+  // current character position in p
+  var pos;
+  // the partial path so far, including a trailing slash if any
+  var current;
+  // the partial path without a trailing slash (except when pointing at a root)
+  var base;
+  // the partial path scanned in the previous round, with slash
+  var previous;
+
+  start();
+
+  function start() {
+    // Skip over roots
+    var m = splitRootRe.exec(p);
+    pos = m[0].length;
+    current = m[0];
+    base = m[0];
+    previous = '';
+
+    // On windows, check that the root exists. On unix there is no need.
+    if (isWindows && !knownHard[base]) {
+      fs.lstatSync(base);
+      knownHard[base] = true;
+    }
+  }
+
+  // walk down the path, swapping out linked pathparts for their real
+  // values
+  // NB: p.length changes.
+  while (pos < p.length) {
+    // find the next part
+    nextPartRe.lastIndex = pos;
+    var result = nextPartRe.exec(p);
+    previous = current;
+    current += result[0];
+    base = previous + result[1];
+    pos = nextPartRe.lastIndex;
+
+    // continue if not a symlink
+    if (knownHard[base] || (cache && cache[base] === base)) {
+      continue;
+    }
+
+    var resolvedLink;
+    if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
+      // some known symbolic link.  no need to stat again.
+      resolvedLink = cache[base];
+    } else {
+      var stat = fs.lstatSync(base);
+      if (!stat.isSymbolicLink()) {
+        knownHard[base] = true;
+        if (cache) cache[base] = base;
+        continue;
+      }
+
+      // read the link if it wasn't read before
+      // dev/ino always return 0 on windows, so skip the check.
+      var linkTarget = null;
+      if (!isWindows) {
+        var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+        if (seenLinks.hasOwnProperty(id)) {
+          linkTarget = seenLinks[id];
+        }
+      }
+      if (linkTarget === null) {
+        fs.statSync(base);
+        linkTarget = fs.readlinkSync(base);
+      }
+      resolvedLink = pathModule.resolve(previous, linkTarget);
+      // track this, if given a cache.
+      if (cache) cache[base] = resolvedLink;
+      if (!isWindows) seenLinks[id] = linkTarget;
+    }
+
+    // resolve the link, then start over
+    p = pathModule.resolve(resolvedLink, p.slice(pos));
+    start();
+  }
+
+  if (cache) cache[original] = p;
+
+  return p;
+};
+
+
+exports.realpath = function realpath(p, cache, cb) {
+  if (typeof cb !== 'function') {
+    cb = maybeCallback(cache);
+    cache = null;
+  }
+
+  // make p is absolute
+  p = pathModule.resolve(p);
+
+  if (cache && Object.prototype.hasOwnProperty.call(cache, p)) {
+    return process.nextTick(cb.bind(null, null, cache[p]));
+  }
+
+  var original = p,
+      seenLinks = {},
+      knownHard = {};
+
+  // current character position in p
+  var pos;
+  // the partial path so far, including a trailing slash if any
+  var current;
+  // the partial path without a trailing slash (except when pointing at a root)
+  var base;
+  // the partial path scanned in the previous round, with slash
+  var previous;
+
+  start();
+
+  function start() {
+    // Skip over roots
+    var m = splitRootRe.exec(p);
+    pos = m[0].length;
+    current = m[0];
+    base = m[0];
+    previous = '';
+
+    // On windows, check that the root exists. On unix there is no need.
+    if (isWindows && !knownHard[base]) {
+      fs.lstat(base, function(err) {
+        if (err) return cb(err);
+        knownHard[base] = true;
+        LOOP();
+      });
+    } else {
+      process.nextTick(LOOP);
+    }
+  }
+
+  // walk down the path, swapping out linked pathparts for their real
+  // values
+  function LOOP() {
+    // stop if scanned past end of path
+    if (pos >= p.length) {
+      if (cache) cache[original] = p;
+      return cb(null, p);
+    }
+
+    // find the next part
+    nextPartRe.lastIndex = pos;
+    var result = nextPartRe.exec(p);
+    previous = current;
+    current += result[0];
+    base = previous + result[1];
+    pos = nextPartRe.lastIndex;
+
+    // continue if not a symlink
+    if (knownHard[base] || (cache && cache[base] === base)) {
+      return process.nextTick(LOOP);
+    }
+
+    if (cache && Object.prototype.hasOwnProperty.call(cache, base)) {
+      // known symbolic link.  no need to stat again.
+      return gotResolvedLink(cache[base]);
+    }
+
+    return fs.lstat(base, gotStat);
+  }
+
+  function gotStat(err, stat) {
+    if (err) return cb(err);
+
+    // if not a symlink, skip to the next path part
+    if (!stat.isSymbolicLink()) {
+      knownHard[base] = true;
+      if (cache) cache[base] = base;
+      return process.nextTick(LOOP);
+    }
+
+    // stat & read the link if not read before
+    // call gotTarget as soon as the link target is known
+    // dev/ino always return 0 on windows, so skip the check.
+    if (!isWindows) {
+      var id = stat.dev.toString(32) + ':' + stat.ino.toString(32);
+      if (seenLinks.hasOwnProperty(id)) {
+        return gotTarget(null, seenLinks[id], base);
+      }
+    }
+    fs.stat(base, function(err) {
+      if (err) return cb(err);
+
+      fs.readlink(base, function(err, target) {
+        if (!isWindows) seenLinks[id] = target;
+        gotTarget(err, target);
+      });
+    });
+  }
+
+  function gotTarget(err, target, base) {
+    if (err) return cb(err);
+
+    var resolvedLink = pathModule.resolve(previous, target);
+    if (cache) cache[base] = resolvedLink;
+    gotResolvedLink(resolvedLink);
+  }
+
+  function gotResolvedLink(resolvedLink) {
+    // resolve the link, then start over
+    p = pathModule.resolve(resolvedLink, p.slice(pos));
+    start();
+  }
+};
+
+
+/***/ }),
 /* 982 */,
 /* 983 */,
 /* 984 */,

--- a/dist/index.js
+++ b/dist/index.js
@@ -62125,6 +62125,7 @@ async function pluckGQL({ filePath, content }) {
  * @returns {Promise<string>}
  */
 async function mergeGql(schemas) {
+  console.log(schemas);
   return mergeTypeDefs(schemas);
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -62083,7 +62083,7 @@ const core = __webpack_require__(470);
 const { gqlPluckFromCodeString } = __webpack_require__(680);
 const { mergeTypeDefs } = __webpack_require__(390);
 const { glob } = __webpack_require__(120);
-const { asyncPipe, asyncMap } = __webpack_require__(564);
+const { asyncPipe, asyncMap, asyncFilter } = __webpack_require__(564);
 
 /**
  * @param {string} source
@@ -62117,7 +62117,6 @@ async function getContent(filePath) {
  */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
-  console.log(plucked);
   return plucked.body;
 }
 
@@ -62147,6 +62146,7 @@ async function main() {
     core.getInput('source'),
     getFilepaths,
     asyncMap(getContent),
+    asyncFilter(Boolean),
     asyncMap(pluckGQL),
     mergeGql,
     writeSchemaToOutput

--- a/dist/index.js
+++ b/dist/index.js
@@ -62147,7 +62147,7 @@ async function main() {
     asyncMap(getContent, pluckGQL),
     mergeGql,
     writeSchemaToOutput
-  )();
+  );
 
   const output = core.getInput('output');
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -62117,6 +62117,7 @@ async function getContent(filePath) {
  */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
+  console.log(plucked);
   return plucked.body;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -62117,7 +62117,7 @@ async function getContent(filePath) {
  */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
-  return plucked.body;
+  return plucked && plucked.body;
 }
 
 /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -62211,7 +62211,6 @@ const pluckSchema = __webpack_require__(891);
 async function main() {
   const source = core.getInput('source');
   const schema = await pluckSchema(source);
-  console.log(schema);
 
   const output = core.getInput('output');
   await fs.writeFile(core.getInput('output'), schema);
@@ -81073,8 +81072,9 @@ const fs = __webpack_require__(747).promises;
 const { gqlPluckFromCodeString } = __webpack_require__(680);
 const { mergeTypeDefs } = __webpack_require__(390);
 const { glob } = __webpack_require__(120);
-const { asyncMap, asyncFilter, asyncFlow } = __webpack_require__(564);
+const { asyncMap: map, asyncFilter: filter, asyncFlow: flow } = __webpack_require__(564);
 const { print } = __webpack_require__(232);
+
 /**
  * @param {string} source
  * @returns {Promise<string[]>}
@@ -81127,11 +81127,11 @@ async function extractSchemaString(schemaDocumentNode) {
   return print(schemaDocumentNode);
 }
 
-const pluckSchema = asyncFlow(
+const pluckSchema = flow(
   getFilepaths,
-  asyncMap(getContent),
-  asyncMap(pluckGQL),
-  asyncFilter(Boolean),
+  map(getContent),
+  map(pluckGQL),
+  filter(Boolean),
   mergeGql,
   extractSchemaString
 );

--- a/dist/index.js
+++ b/dist/index.js
@@ -81075,10 +81075,6 @@ const { glob } = __webpack_require__(120);
 const { asyncMap: map, asyncFilter: filter, asyncFlow: flow } = __webpack_require__(564);
 const { print } = __webpack_require__(232);
 
-/**
- * @param {string} source
- * @returns {Promise<string[]>}
- */
 async function getFilepaths(source) {
   return new Promise((resolve, reject) => {
     glob(source, { nonull: true }, (err, filePaths) => {
@@ -81091,38 +81087,20 @@ async function getFilepaths(source) {
   });
 }
 
-/**
- * @param {string} filePath
- * @returns {Promise<{filePath: string, content: string}>}
- */
 async function getContent(filePath) {
   const content = await fs.readFile(filePath, 'utf8');
   return { filePath, content };
 }
 
-/**
- *
- * @param {{filePath: string, content: string}} param0
- * @returns {Promise<string>}
- */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
   return plucked && plucked.body;
 }
 
-/**
- * @param {string[]} schemas
- * @returns {Promise<string>}
- */
 async function mergeGql(schemas) {
   return mergeTypeDefs(schemas);
 }
 
-/**
- *
- * @param {DocumentNode} schemaDocumentNode
- * @returns {Promise<string>}
- */
 async function extractSchemaString(schemaDocumentNode) {
   return print(schemaDocumentNode);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -62146,8 +62146,8 @@ async function main() {
     core.getInput('source'),
     getFilepaths,
     asyncMap(getContent),
-    asyncFilter(Boolean),
     asyncMap(pluckGQL),
+    asyncFilter(Boolean),
     mergeGql,
     writeSchemaToOutput
   );

--- a/dist/index.js
+++ b/dist/index.js
@@ -62145,7 +62145,8 @@ async function main() {
   await asyncPipe(
     core.getInput('source'),
     getFilepaths,
-    asyncMap(getContent, pluckGQL),
+    asyncMap(getContent),
+    asyncMap(pluckGQL),
     mergeGql,
     writeSchemaToOutput
   );

--- a/dist/index.js
+++ b/dist/index.js
@@ -62211,6 +62211,7 @@ const pluckSchema = __webpack_require__(891);
 async function main() {
   const source = core.getInput('source');
   const schema = await pluckSchema(source);
+  console.log(schema);
 
   const output = core.getInput('output');
   await fs.writeFile(core.getInput('output'), schema);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@graphql-tools/merge": "^8.3.3",
     "fp-async-utils": "^2.0.1",
     "glob": "^8.0.3",
-    "graphql": "^16.4.0"
+    "graphql": "^16.5.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",
@@ -35,7 +35,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.1.5",
     "eslint-plugin-prettier": "4.0.0",
-    "jest": "^28.0.3",
+    "jest": "^28.1.3",
     "prettier": "2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "dependencies": {
     "@actions/core": "^1.7.0",
     "@graphql-tools/graphql-tag-pluck": "^7.2.6",
+    "@graphql-tools/merge": "^8.3.3",
+    "fp-async-utils": "^2.0.1",
+    "glob": "^8.0.3",
     "graphql": "^16.4.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ async function getContent(filePath) {
  */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
+  console.log(plucked);
   return plucked.body;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ async function getContent(filePath) {
  */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
-  return plucked.body;
+  return plucked && plucked.body;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const core = require('@actions/core');
 const { gqlPluckFromCodeString } = require('@graphql-tools/graphql-tag-pluck');
 const { mergeTypeDefs } = require('@graphql-tools/merge');
 const { glob } = require('glob');
-const { asyncPipe, asyncMap } = require('fp-async-utils');
+const { asyncPipe, asyncMap, asyncFilter } = require('fp-async-utils');
 
 /**
  * @param {string} source
@@ -38,7 +38,6 @@ async function getContent(filePath) {
  */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
-  console.log(plucked);
   return plucked.body;
 }
 
@@ -68,6 +67,7 @@ async function main() {
     core.getInput('source'),
     getFilepaths,
     asyncMap(getContent),
+    asyncFilter(Boolean),
     asyncMap(pluckGQL),
     mergeGql,
     writeSchemaToOutput

--- a/src/index.js
+++ b/src/index.js
@@ -67,8 +67,8 @@ async function main() {
     core.getInput('source'),
     getFilepaths,
     asyncMap(getContent),
-    asyncFilter(Boolean),
     asyncMap(pluckGQL),
+    asyncFilter(Boolean),
     mergeGql,
     writeSchemaToOutput
   );

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ const pluckSchema = require('./pluck-schema');
 async function main() {
   const source = core.getInput('source');
   const schema = await pluckSchema(source);
-  console.log(schema);
 
   const output = core.getInput('output');
   await fs.writeFile(core.getInput('output'), schema);

--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,16 @@ async function pluckGQL({ filePath, content }) {
  * @returns {Promise<string>}
  */
 async function mergeGql(schemas) {
-  console.log(schemas);
   return mergeTypeDefs(schemas);
+}
+
+/**
+ *
+ * @param {DocumentNode} schemaDocumentNode
+ * @returns {Promise<string>}
+ */
+async function extractSchemaString(schemaDocumentNode) {
+  return schemaDocumentNode.loc.source.body;
 }
 
 /**
@@ -58,7 +66,6 @@ async function mergeGql(schemas) {
 async function writeSchemaToOutput(schema) {
   const output = core.getInput('output');
   core.info(`Writing to file ${output}`);
-  console.log(schema);
   await fs.writeFile(output, schema);
 }
 
@@ -70,6 +77,7 @@ async function main() {
     asyncMap(pluckGQL),
     asyncFilter(Boolean),
     mergeGql,
+    extractSchemaString,
     writeSchemaToOutput
   );
 

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ async function main() {
     asyncMap(getContent, pluckGQL),
     mergeGql,
     writeSchemaToOutput
-  )();
+  );
 
   const output = core.getInput('output');
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,8 @@ async function main() {
   await asyncPipe(
     core.getInput('source'),
     getFilepaths,
-    asyncMap(getContent, pluckGQL),
+    asyncMap(getContent),
+    asyncMap(pluckGQL),
     mergeGql,
     writeSchemaToOutput
   );

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const pluckSchema = require('./pluck-schema');
 async function main() {
   const source = core.getInput('source');
   const schema = await pluckSchema(source);
+  console.log(schema);
 
   const output = core.getInput('output');
   await fs.writeFile(core.getInput('output'), schema);

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ async function pluckGQL({ filePath, content }) {
  * @returns {Promise<string>}
  */
 async function mergeGql(schemas) {
+  console.log(schemas);
   return mergeTypeDefs(schemas);
 }
 

--- a/src/pluck-schema.js
+++ b/src/pluck-schema.js
@@ -4,6 +4,7 @@ const { mergeTypeDefs } = require('@graphql-tools/merge');
 const { glob } = require('glob');
 const { asyncMap, asyncFilter, asyncFlow } = require('fp-async-utils');
 const { print } = require('graphql');
+
 /**
  * @param {string} source
  * @returns {Promise<string[]>}

--- a/src/pluck-schema.js
+++ b/src/pluck-schema.js
@@ -5,10 +5,6 @@ const { glob } = require('glob');
 const { asyncMap: map, asyncFilter: filter, asyncFlow: flow } = require('fp-async-utils');
 const { print } = require('graphql');
 
-/**
- * @param {string} source
- * @returns {Promise<string[]>}
- */
 async function getFilepaths(source) {
   return new Promise((resolve, reject) => {
     glob(source, { nonull: true }, (err, filePaths) => {
@@ -21,38 +17,20 @@ async function getFilepaths(source) {
   });
 }
 
-/**
- * @param {string} filePath
- * @returns {Promise<{filePath: string, content: string}>}
- */
 async function getContent(filePath) {
   const content = await fs.readFile(filePath, 'utf8');
   return { filePath, content };
 }
 
-/**
- *
- * @param {{filePath: string, content: string}} param0
- * @returns {Promise<string>}
- */
 async function pluckGQL({ filePath, content }) {
   const [plucked] = await gqlPluckFromCodeString(filePath, content);
   return plucked && plucked.body;
 }
 
-/**
- * @param {string[]} schemas
- * @returns {Promise<string>}
- */
 async function mergeGql(schemas) {
   return mergeTypeDefs(schemas);
 }
 
-/**
- *
- * @param {DocumentNode} schemaDocumentNode
- * @returns {Promise<string>}
- */
 async function extractSchemaString(schemaDocumentNode) {
   return print(schemaDocumentNode);
 }

--- a/src/pluck-schema.js
+++ b/src/pluck-schema.js
@@ -35,13 +35,19 @@ async function extractSchemaString(schemaDocumentNode) {
   return print(schemaDocumentNode);
 }
 
+// https://github.com/apollographql/federation/issues/1875
+async function handleQueryQueryFederation2Bug(schema) {
+  return schema.replace('query: Query', '');
+}
+
 const pluckSchema = flow(
   getFilepaths,
   map(getContent),
   map(pluckGQL),
   filter(Boolean),
   mergeGql,
-  extractSchemaString
+  extractSchemaString,
+  handleQueryQueryFederation2Bug
 );
 
 module.exports = pluckSchema;

--- a/src/pluck-schema.js
+++ b/src/pluck-schema.js
@@ -2,7 +2,7 @@ const fs = require('fs').promises;
 const { gqlPluckFromCodeString } = require('@graphql-tools/graphql-tag-pluck');
 const { mergeTypeDefs } = require('@graphql-tools/merge');
 const { glob } = require('glob');
-const { asyncMap, asyncFilter, asyncFlow } = require('fp-async-utils');
+const { asyncMap: map, asyncFilter: filter, asyncFlow: flow } = require('fp-async-utils');
 const { print } = require('graphql');
 
 /**
@@ -57,11 +57,11 @@ async function extractSchemaString(schemaDocumentNode) {
   return print(schemaDocumentNode);
 }
 
-const pluckSchema = asyncFlow(
+const pluckSchema = flow(
   getFilepaths,
-  asyncMap(getContent),
-  asyncMap(pluckGQL),
-  asyncFilter(Boolean),
+  map(getContent),
+  map(pluckGQL),
+  filter(Boolean),
   mergeGql,
   extractSchemaString
 );

--- a/src/pluck-schema.js
+++ b/src/pluck-schema.js
@@ -1,0 +1,68 @@
+const fs = require('fs').promises;
+const { gqlPluckFromCodeString } = require('@graphql-tools/graphql-tag-pluck');
+const { mergeTypeDefs } = require('@graphql-tools/merge');
+const { glob } = require('glob');
+const { asyncMap, asyncFilter, asyncFlow } = require('fp-async-utils');
+const { print } = require('graphql');
+/**
+ * @param {string} source
+ * @returns {Promise<string[]>}
+ */
+async function getFilepaths(source) {
+  return new Promise((resolve, reject) => {
+    glob(source, { nonull: true }, (err, filePaths) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(filePaths);
+      }
+    });
+  });
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Promise<{filePath: string, content: string}>}
+ */
+async function getContent(filePath) {
+  const content = await fs.readFile(filePath, 'utf8');
+  return { filePath, content };
+}
+
+/**
+ *
+ * @param {{filePath: string, content: string}} param0
+ * @returns {Promise<string>}
+ */
+async function pluckGQL({ filePath, content }) {
+  const [plucked] = await gqlPluckFromCodeString(filePath, content);
+  return plucked && plucked.body;
+}
+
+/**
+ * @param {string[]} schemas
+ * @returns {Promise<string>}
+ */
+async function mergeGql(schemas) {
+  return mergeTypeDefs(schemas);
+}
+
+/**
+ *
+ * @param {DocumentNode} schemaDocumentNode
+ * @returns {Promise<string>}
+ */
+async function extractSchemaString(schemaDocumentNode) {
+  return print(schemaDocumentNode);
+}
+
+const pluckSchema = asyncFlow(
+  getFilepaths,
+  asyncMap(getContent),
+  asyncMap(pluckGQL),
+  asyncFilter(Boolean),
+  mergeGql,
+  extractSchemaString
+);
+
+module.exports = pluckSchema;

--- a/test/pluck-schema.test.js
+++ b/test/pluck-schema.test.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-undef */
+const pluckSchema = require('../src/pluck-schema');
+
+describe('pluck-schema', () => {
+  it('should work', async () => {
+    const result = await pluckSchema('test/schema/**/*.js');
+    const areQueriesMerged = result.match(/type Query/g).length === 1;
+    expect(areQueriesMerged).toBe(true);
+  });
+});

--- a/test/pluck-schema.test.js
+++ b/test/pluck-schema.test.js
@@ -16,4 +16,11 @@ describe('pluck-schema', () => {
     const areQueriesMerged = result.match(/type Query/g).length === 1;
     expect(includesQuery1 && includesQuery2 && areQueriesMerged).toBe(true);
   });
+
+  // https://github.com/apollographql/federation/issues/1875
+  it('handles query: Query bug in federation 2', async () => {
+    const result = await pluckSchema('test/schema-federation-2/**/*.js');
+    const doesNotIncludeQueryQueryInSchema1 = result.match(/query: Query/g) === null;
+    expect(doesNotIncludeQueryQueryInSchema1).toBe(true);
+  });
 });

--- a/test/pluck-schema.test.js
+++ b/test/pluck-schema.test.js
@@ -2,9 +2,18 @@
 const pluckSchema = require('../src/pluck-schema');
 
 describe('pluck-schema', () => {
-  it('should work', async () => {
-    const result = await pluckSchema('test/schema/**/*.js');
+  it('works with single files', async () => {
+    const result = await pluckSchema('test/schema/schema1.js');
+    const includesQuery1 = result.match(/query1/g).length === 1;
+    const doesNotIncludeQuery3 = result.match(/query3/g) === null;
     const areQueriesMerged = result.match(/type Query/g).length === 1;
-    expect(areQueriesMerged).toBe(true);
+    expect(includesQuery1 && doesNotIncludeQuery3 && areQueriesMerged).toBe(true);
+  });
+  it('works with globs', async () => {
+    const result = await pluckSchema('test/schema/**/*.js');
+    const includesQuery1 = result.match(/query1/g).length === 1;
+    const includesQuery2 = result.match(/query3/g).length === 1;
+    const areQueriesMerged = result.match(/type Query/g).length === 1;
+    expect(includesQuery1 && includesQuery2 && areQueriesMerged).toBe(true);
   });
 });

--- a/test/schema-federation-2/federation-spec.js
+++ b/test/schema-federation-2/federation-spec.js
@@ -1,0 +1,9 @@
+var gql;
+
+gql`
+  extend schema
+    @link(
+      url: "https://specs.apollo.dev/federation/v2.0"
+      import: ["@key", "@shareable"]
+    )
+`;

--- a/test/schema-federation-2/schema1.js
+++ b/test/schema-federation-2/schema1.js
@@ -1,0 +1,15 @@
+var gql;
+
+gql`
+  type TheInput1 {
+    someField: String!
+  }
+
+  type Query {
+    query1(input: TheInput1): String
+  }
+
+  type Mutation {
+    mutation1(input: TheInput1): String
+  }
+`;

--- a/test/schema-federation-2/schema2.js
+++ b/test/schema-federation-2/schema2.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-unused-vars
+var noSchemaInHere = true;

--- a/test/schema-federation-2/schema3.js
+++ b/test/schema-federation-2/schema3.js
@@ -1,0 +1,15 @@
+var gql;
+
+gql`
+  type TheInput3 {
+    someField: String!
+  }
+
+  type Query {
+    query3(input: TheInput3): String
+  }
+
+  type Mutation {
+    mutation3(input: TheInput3): String
+  }
+`;

--- a/test/schema/schema1.js
+++ b/test/schema/schema1.js
@@ -1,0 +1,11 @@
+var gql;
+
+gql`
+  type TheInput1 {
+    someField: String!
+  }
+
+  type Query {
+    query1(input: TheInput1): String
+  }
+`;

--- a/test/schema/schema2.js
+++ b/test/schema/schema2.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-unused-vars
+var noSchemaInHere = true;

--- a/test/schema/schema3.js
+++ b/test/schema/schema3.js
@@ -1,0 +1,11 @@
+var gql;
+
+gql`
+  type TheInput3 {
+    someField: String!
+  }
+
+  type Query {
+    query3(input: TheInput3): String
+  }
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,110 +378,110 @@
   resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/console@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/console/-/console-28.0.2.tgz#d11e8b43ae431ae9b3112656848417ae4008fcad"
-  integrity sha512-tiRpnMeeyQuuzgL5UNSeiqMwF8UOWPbAE5rzcu/1zyq4oPG2Ox6xm4YCOruwbp10F8odWc+XwVxTyGzMSLMqxA==
+"@jest/console@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-28.1.3.tgz#2030606ec03a18c31803b8a36382762e447655df"
+  integrity sha512-QPAkP5EwKdK/bxIr6C1I4Vs0rm2nHiANzj/Z5X2JQkrZo6IqvC4ldZ9K95tF0HdidhA8Bo6egxSzUFPYKcEXLw==
   dependencies:
-    "@jest/types" "^28.0.2"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^28.0.2"
-    jest-util "^28.0.2"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
     slash "^3.0.0"
 
-"@jest/core@^28.0.3":
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/@jest/core/-/core-28.0.3.tgz#2b8223914ef6ae16ff740e65235ef8ef49c46d52"
-  integrity sha512-cCQW06vEZ+5r50SB06pOnSWsOBs7F+lswPYnKKfBz1ncLlj1sMqmvjgam8q40KhlZ8Ut4eNAL2Hvfx4BKIO2FA==
+"@jest/core@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-28.1.3.tgz#0ebf2bd39840f1233cd5f2d1e6fc8b71bd5a1ac7"
+  integrity sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==
   dependencies:
-    "@jest/console" "^28.0.2"
-    "@jest/reporters" "^28.0.3"
-    "@jest/test-result" "^28.0.2"
-    "@jest/transform" "^28.0.3"
-    "@jest/types" "^28.0.2"
+    "@jest/console" "^28.1.3"
+    "@jest/reporters" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     exit "^0.1.2"
     graceful-fs "^4.2.9"
-    jest-changed-files "^28.0.2"
-    jest-config "^28.0.3"
-    jest-haste-map "^28.0.2"
-    jest-message-util "^28.0.2"
+    jest-changed-files "^28.1.3"
+    jest-config "^28.1.3"
+    jest-haste-map "^28.1.3"
+    jest-message-util "^28.1.3"
     jest-regex-util "^28.0.2"
-    jest-resolve "^28.0.3"
-    jest-resolve-dependencies "^28.0.3"
-    jest-runner "^28.0.3"
-    jest-runtime "^28.0.3"
-    jest-snapshot "^28.0.3"
-    jest-util "^28.0.2"
-    jest-validate "^28.0.2"
-    jest-watcher "^28.0.2"
+    jest-resolve "^28.1.3"
+    jest-resolve-dependencies "^28.1.3"
+    jest-runner "^28.1.3"
+    jest-runtime "^28.1.3"
+    jest-snapshot "^28.1.3"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
+    jest-watcher "^28.1.3"
     micromatch "^4.0.4"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
     rimraf "^3.0.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/environment/-/environment-28.0.2.tgz#a865949d876b2d364b979bbc0a46338ffd23de26"
-  integrity sha512-IvI7dEfqVEffDYlw9FQfVBt6kXt/OI38V7QUIur0ulOQgzpKYJDVvLzj4B1TVmHWTGW5tcnJdlZ3hqzV6/I9Qg==
+"@jest/environment@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-28.1.3.tgz#abed43a6b040a4c24fdcb69eab1f97589b2d663e"
+  integrity sha512-1bf40cMFTEkKyEf585R9Iz1WayDjHoHqvts0XFYEqyKM3cFWDpeMoqKKTAF9LSYQModPUlh8FKptoM2YcMWAXA==
   dependencies:
-    "@jest/fake-timers" "^28.0.2"
-    "@jest/types" "^28.0.2"
+    "@jest/fake-timers" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
-    jest-mock "^28.0.2"
+    jest-mock "^28.1.3"
 
-"@jest/expect-utils@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.0.2.tgz#0a055868d225261eac82a12013e2e0735238774d"
-  integrity sha512-YryfH2zN5c7M8eLtn9oTBRj1sfD+X4cHNXJnTejqCveOS33wADEZUxJ7de5++lRvByNpRpfAnc8zTK7yrUJqgA==
+"@jest/expect-utils@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-28.1.3.tgz#58561ce5db7cd253a7edddbc051fb39dda50f525"
+  integrity sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==
   dependencies:
     jest-get-type "^28.0.2"
 
-"@jest/expect@^28.0.3":
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/@jest/expect/-/expect-28.0.3.tgz#80e0233bee62586e1112f904d28b904dd1143ef2"
-  integrity sha512-VEzZr85bqNomgayQkR7hWG5HnbZYWYWagQriZsixhLmOzU6PCpMP61aeVhkCoRrg7ri5f7JDpeTPzDAajIwFHw==
+"@jest/expect@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-28.1.3.tgz#9ac57e1d4491baca550f6bdbd232487177ad6a72"
+  integrity sha512-lzc8CpUbSoE4dqT0U+g1qODQjBRHPpCPXissXD4mS9+sWQdmmpeJ9zSH1rS1HEkrsMN0fb7nKrJ9giAR1d3wBw==
   dependencies:
-    expect "^28.0.2"
-    jest-snapshot "^28.0.3"
+    expect "^28.1.3"
+    jest-snapshot "^28.1.3"
 
-"@jest/fake-timers@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-28.0.2.tgz#d36e62bc58f39d65ea6adac1ff7749e63aff05f3"
-  integrity sha512-R75yUv+WeybPa4ZVhX9C+8XN0TKjUoceUX+/QEaDVQGxZZOK50eD74cs7iMDTtpodh00d8iLlc9197vgF6oZjA==
+"@jest/fake-timers@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-28.1.3.tgz#230255b3ad0a3d4978f1d06f70685baea91c640e"
+  integrity sha512-D/wOkL2POHv52h+ok5Oj/1gOG9HSywdoPtFsRCUmlCILXNn5eIWmcnd3DIiWlJnpGvQtmajqBP95Ei0EimxfLw==
   dependencies:
-    "@jest/types" "^28.0.2"
-    "@sinonjs/fake-timers" "^9.1.1"
+    "@jest/types" "^28.1.3"
+    "@sinonjs/fake-timers" "^9.1.2"
     "@types/node" "*"
-    jest-message-util "^28.0.2"
-    jest-mock "^28.0.2"
-    jest-util "^28.0.2"
+    jest-message-util "^28.1.3"
+    jest-mock "^28.1.3"
+    jest-util "^28.1.3"
 
-"@jest/globals@^28.0.3":
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/@jest/globals/-/globals-28.0.3.tgz#70f68a06c863d1c9d14aea151c69b9690e3efeb4"
-  integrity sha512-q/zXYI6CKtTSIt1WuTHBYizJhH7K8h+xG5PE3C0oawLlPIvUMDYmpj0JX0XsJwPRLCsz/fYXHZVG46AaEhSPmw==
+"@jest/globals@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-28.1.3.tgz#a601d78ddc5fdef542728309894895b4a42dc333"
+  integrity sha512-XFU4P4phyryCXu1pbcqMO0GSQcYe1IsalYCDzRNyhetyeyxMcIxa11qPNDpVNLeretItNqEmYYQn1UYz/5x1NA==
   dependencies:
-    "@jest/environment" "^28.0.2"
-    "@jest/expect" "^28.0.3"
-    "@jest/types" "^28.0.2"
+    "@jest/environment" "^28.1.3"
+    "@jest/expect" "^28.1.3"
+    "@jest/types" "^28.1.3"
 
-"@jest/reporters@^28.0.3":
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/@jest/reporters/-/reporters-28.0.3.tgz#9996189e5552e37fcdffe0f41c07754f5d2ea854"
-  integrity sha512-xrbIc7J/xwo+D7AY3enAR9ZWYCmJ8XIkstTukTGpKDph0gLl/TJje9jl3dssvE4KJzYqMKiSrnE5Nt68I4fTEg==
+"@jest/reporters@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-28.1.3.tgz#9adf6d265edafc5fc4a434cfb31e2df5a67a369a"
+  integrity sha512-JuAy7wkxQZVNU/V6g9xKzCGC5LVXx9FDcABKsSXp5MiKPEE2144a/vXTEDoyzjUpZKfVwp08Wqg5A4WfTMAzjg==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^28.0.2"
-    "@jest/test-result" "^28.0.2"
-    "@jest/transform" "^28.0.3"
-    "@jest/types" "^28.0.2"
-    "@jridgewell/trace-mapping" "^0.3.7"
+    "@jest/console" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    "@jridgewell/trace-mapping" "^0.3.13"
     "@types/node" "*"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
@@ -493,76 +493,78 @@
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.1.3"
-    jest-util "^28.0.2"
-    jest-worker "^28.0.2"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
+    jest-worker "^28.1.3"
     slash "^3.0.0"
     string-length "^4.0.1"
+    strip-ansi "^6.0.0"
     terminal-link "^2.0.0"
-    v8-to-istanbul "^9.0.0"
+    v8-to-istanbul "^9.0.1"
 
-"@jest/schemas@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz#08c30df6a8d07eafea0aef9fb222c5e26d72e613"
-  integrity sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==
+"@jest/schemas@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-28.1.3.tgz#ad8b86a66f11f33619e3d7e1dcddd7f2d40ff905"
+  integrity sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==
   dependencies:
-    "@sinclair/typebox" "^0.23.3"
+    "@sinclair/typebox" "^0.24.1"
 
-"@jest/source-map@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/source-map/-/source-map-28.0.2.tgz#914546f4410b67b1d42c262a1da7e0406b52dc90"
-  integrity sha512-Y9dxC8ZpN3kImkk0LkK5XCEneYMAXlZ8m5bflmSL5vrwyeUpJfentacCUg6fOb8NOpOO7hz2+l37MV77T6BFPw==
+"@jest/source-map@^28.1.2":
+  version "28.1.2"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-28.1.2.tgz#7fe832b172b497d6663cdff6c13b0a920e139e24"
+  integrity sha512-cV8Lx3BeStJb8ipPHnqVw/IM2VCMWO3crWZzYodSIkxXnRcXJipCdx1JCK0K5MsJJouZQTH73mzf4vgxRaH9ww==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.7"
+    "@jridgewell/trace-mapping" "^0.3.13"
     callsites "^3.0.0"
     graceful-fs "^4.2.9"
 
-"@jest/test-result@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/test-result/-/test-result-28.0.2.tgz#bc8e15a95347e3c2149572ae06a5a6fed939c522"
-  integrity sha512-4EUqgjq9VzyUiVTvZfI9IRJD6t3NYBNP4f+Eq8Zr93+hkJ0RrGU4OBTw8tfNzidKX+bmuYzn8FxqpxOPIGGCMA==
+"@jest/test-result@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-28.1.3.tgz#5eae945fd9f4b8fcfce74d239e6f725b6bf076c5"
+  integrity sha512-kZAkxnSE+FqE8YjW8gNuoVkkC9I7S1qmenl8sGcDOLropASP+BkcGKwhXoyqQuGOGeYY0y/ixjrd/iERpEXHNg==
   dependencies:
-    "@jest/console" "^28.0.2"
-    "@jest/types" "^28.0.2"
+    "@jest/console" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-28.0.2.tgz#7669b7d8ff2aa7a8221b11bb37cce552de81b1bb"
-  integrity sha512-zhnZ8ydkZQTPL7YucB86eOlD79zPy5EGSUKiR2Iv93RVEDU6OEP33kwDBg70ywOcxeJGDRhyo09q7TafNCBiIg==
+"@jest/test-sequencer@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz#9d0c283d906ac599c74bde464bc0d7e6a82886c3"
+  integrity sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==
   dependencies:
-    "@jest/test-result" "^28.0.2"
+    "@jest/test-result" "^28.1.3"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.0.2"
+    jest-haste-map "^28.1.3"
     slash "^3.0.0"
 
-"@jest/transform@^28.0.3":
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/@jest/transform/-/transform-28.0.3.tgz#591fb5ebc1d84db5c5f21e1225c7406c35f5eb1e"
-  integrity sha512-+Y0ikI7SwoW/YbK8t9oKwC70h4X2Gd0OVuz5tctRvSV/EDQU00AAkoqevXgPSSFimUmp/sp7Yl8s/1bExDqOIg==
+"@jest/transform@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-28.1.3.tgz#59d8098e50ab07950e0f2fc0fc7ec462371281b0"
+  integrity sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/types" "^28.0.2"
-    "@jridgewell/trace-mapping" "^0.3.7"
+    "@jest/types" "^28.1.3"
+    "@jridgewell/trace-mapping" "^0.3.13"
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.0.2"
+    jest-haste-map "^28.1.3"
     jest-regex-util "^28.0.2"
-    jest-util "^28.0.2"
+    jest-util "^28.1.3"
     micromatch "^4.0.4"
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
 
-"@jest/types@^28.0.2":
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz#70b9538c1863fb060b2f438ca008b5563d00c5b4"
-  integrity sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==
+"@jest/types@^28.1.3":
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.3.tgz#b05de80996ff12512bc5ceb1d208285a7d11748b"
+  integrity sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==
   dependencies:
-    "@jest/schemas" "^28.0.2"
+    "@jest/schemas" "^28.1.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -592,7 +594,15 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.12.tgz#7ed98f6fa525ffb7c56a2cbecb5f7bb91abd2baf"
   integrity sha512-az/NhpIwP3K33ILr0T2bso+k2E/SLf8Yidd8mHl0n6sCQ4YdyC8qDhZA6kOPDNDBA56ZnIjngVl0U3jREA0BUA==
 
-"@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13":
+  version "0.3.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz#aba35c48a38d3fd84b37e66c9c0423f9744f9774"
+  integrity sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
@@ -621,10 +631,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sinclair/typebox@^0.23.3":
-  version "0.23.5"
-  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz#93f7b9f4e3285a7a9ade7557d9a8d36809cbc47d"
-  integrity sha512-AFBVi/iT4g20DHoujvMH1aEDn8fGJh4xsRGCP6d8RpLPMqsNPvW01Jcn0QysXTsg++/xj25NmJsGyH9xug/wKg==
+"@sinclair/typebox@^0.24.1":
+  version "0.24.27"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.27.tgz#d55643516a1546174e10da681a8aaa81e757452d"
+  integrity sha512-K7C7IlQ3zLePEZleUN21ceBA2aLcMnLHTLph8QWk1JK37L90obdpY+QGY8bXMKxf1ht1Z0MNewvXxWv0oGDYFg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -633,9 +643,9 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^9.1.1":
+"@sinonjs/fake-timers@^9.1.2":
   version "9.1.2"
-  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz#4eaab737fab77332ab132d396a3c0d364bd0ea8c"
   integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
@@ -884,15 +894,15 @@ array.prototype.flat@^1.2.5:
     es-abstract "^1.19.2"
     es-shim-unscopables "^1.0.0"
 
-babel-jest@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-28.0.3.tgz#843dc170da5b9671d4054ada9fdcd28f85f92a6e"
-  integrity sha512-S0ADyYdcrt5fp9YldRYWCUHdk1BKt9AkvBkLWBoNAEV9NoWZPIj5+MYhPcGgTS65mfv3a+Ymf2UqgWoAVd41cA==
+babel-jest@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-28.1.3.tgz#c1187258197c099072156a0a121c11ee1e3917d5"
+  integrity sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==
   dependencies:
-    "@jest/transform" "^28.0.3"
+    "@jest/transform" "^28.1.3"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
-    babel-preset-jest "^28.0.2"
+    babel-preset-jest "^28.1.3"
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     slash "^3.0.0"
@@ -908,10 +918,10 @@ babel-plugin-istanbul@^6.1.1:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.0.2.tgz#9307d03a633be6fc4b1a6bc5c3a87e22bd01dd3b"
-  integrity sha512-Kizhn/ZL+68ZQHxSnHyuvJv8IchXD62KQxV77TBDV/xoBFBOfgRAk97GNs6hXdTTCiVES9nB2I6+7MXXrk5llQ==
+babel-plugin-jest-hoist@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-28.1.3.tgz#1952c4d0ea50f2d6d794353762278d1d8cca3fbe"
+  integrity sha512-Ys3tUKAmfnkRUpPdpa98eYrAR0nV+sSFUZZEGuQ2EbFd1y4SOLtD5QDNHAq+bb9a+bbXvYQC4b+ID/THIMcU6Q==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -936,12 +946,12 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
-babel-preset-jest@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-28.0.2.tgz#d8210fe4e46c1017e9fa13d7794b166e93aa9f89"
-  integrity sha512-sYzXIdgIXXroJTFeB3S6sNDWtlJ2dllCdTEsnZ65ACrMojj3hVNFRmnJ1HZtomGi+Be7aqpY/HJ92fr8OhKVkQ==
+babel-preset-jest@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-28.1.3.tgz#5dfc20b99abed5db994406c2b9ab94c73aaa419d"
+  integrity sha512-L+fupJvlWAHbQfn74coNX3zf60LXMJsezNvvx8eIh7iOR1luJ1poxYgQk1F8PYtNq/6QODDHCqsSnTFSWC491A==
   dependencies:
-    babel-plugin-jest-hoist "^28.0.2"
+    babel-plugin-jest-hoist "^28.1.3"
     babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
@@ -1167,10 +1177,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz#40f8d4ffa081acbd8902ba35c798458d0ff1af41"
-  integrity sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==
+diff-sequences@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-28.1.1.tgz#9989dc731266dc2903457a70e996f3a041913ac6"
+  integrity sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1468,16 +1478,16 @@ exit@^0.1.2:
   resolved "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expect@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/expect/-/expect-28.0.2.tgz#86f0d6fa971bc533faf68d4d103d00f343d6a4b3"
-  integrity sha512-X0qIuI/zKv98k34tM+uGeOgAC73lhs4vROF9MkPk94C1zujtwv4Cla8SxhWn0G1OwvG9gLLL7RjFBkwGVaZ83w==
+expect@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-28.1.3.tgz#90a7c1a124f1824133dd4533cce2d2bdcb6603ec"
+  integrity sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==
   dependencies:
-    "@jest/expect-utils" "^28.0.2"
+    "@jest/expect-utils" "^28.1.3"
     jest-get-type "^28.0.2"
-    jest-matcher-utils "^28.0.2"
-    jest-message-util "^28.0.2"
-    jest-util "^28.0.2"
+    jest-matcher-utils "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -1694,10 +1704,10 @@ graceful-fs@^4.2.9:
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphql@^16.4.0:
-  version "16.4.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-16.4.0.tgz#bb10b1b4683045dedcb67000eb4ad134a36c59e6"
-  integrity sha512-tYDNcRvKCcfHREZYje3v33NSrSD/ZpbWWdPtBtUUuXx9NCo/2QDxYzNqCnMvfsrnbwRpEHMovVrPu/ERoLrIRg==
+graphql@^16.5.0:
+  version "16.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
+  integrity sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==
 
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
@@ -1964,188 +1974,188 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-changed-files@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-28.0.2.tgz#7d7810660a5bd043af9e9cfbe4d58adb05e91531"
-  integrity sha512-QX9u+5I2s54ZnGoMEjiM2WeBvJR2J7w/8ZUmH2um/WLAuGAYFQcsVXY9+1YL6k0H/AGUdH8pXUAv6erDqEsvIA==
+jest-changed-files@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-28.1.3.tgz#d9aeee6792be3686c47cb988a8eaf82ff4238831"
+  integrity sha512-esaOfUWJXk2nfZt9SPyC8gA1kNfdKLkQWyzsMlqq8msYSlNKfmZxfRgZn4Cd4MGVUF+7v6dBs0d5TOAKa7iIiA==
   dependencies:
     execa "^5.0.0"
-    throat "^6.0.1"
+    p-limit "^3.1.0"
 
-jest-circus@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-circus/-/jest-circus-28.0.3.tgz#45f77090b4b9fe5c1b84f72816868c9d4c0f57b1"
-  integrity sha512-HJ3rUCm3A3faSy7KVH5MFCncqJLtrjEFkTPn9UIcs4Kq77+TXqHsOaI+/k73aHe6DJQigLUXq9rCYj3MYFlbIw==
+jest-circus@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-28.1.3.tgz#d14bd11cf8ee1a03d69902dc47b6bd4634ee00e4"
+  integrity sha512-cZ+eS5zc79MBwt+IhQhiEp0OeBddpc1n8MBo1nMB8A7oPMKEO+Sre+wHaLJexQUj9Ya/8NOBY0RESUgYjB6fow==
   dependencies:
-    "@jest/environment" "^28.0.2"
-    "@jest/expect" "^28.0.3"
-    "@jest/test-result" "^28.0.2"
-    "@jest/types" "^28.0.2"
+    "@jest/environment" "^28.1.3"
+    "@jest/expect" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
     dedent "^0.7.0"
     is-generator-fn "^2.0.0"
-    jest-each "^28.0.2"
-    jest-matcher-utils "^28.0.2"
-    jest-message-util "^28.0.2"
-    jest-runtime "^28.0.3"
-    jest-snapshot "^28.0.3"
-    jest-util "^28.0.2"
-    pretty-format "^28.0.2"
+    jest-each "^28.1.3"
+    jest-matcher-utils "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-runtime "^28.1.3"
+    jest-snapshot "^28.1.3"
+    jest-util "^28.1.3"
+    p-limit "^3.1.0"
+    pretty-format "^28.1.3"
     slash "^3.0.0"
     stack-utils "^2.0.3"
-    throat "^6.0.1"
 
-jest-cli@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-28.0.3.tgz#4a4e55078ec772e0ea2583dd4c4b38fb306dc556"
-  integrity sha512-NCPTEONCnhYGo1qzPP4OOcGF04YasM5GZSwQLI1HtEluxa3ct4U65IbZs6DSRt8XN1Rq0jhXwv02m5lHB28Uyg==
+jest-cli@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-28.1.3.tgz#558b33c577d06de55087b8448d373b9f654e46b2"
+  integrity sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==
   dependencies:
-    "@jest/core" "^28.0.3"
-    "@jest/test-result" "^28.0.2"
-    "@jest/types" "^28.0.2"
+    "@jest/core" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/types" "^28.1.3"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.9"
     import-local "^3.0.2"
-    jest-config "^28.0.3"
-    jest-util "^28.0.2"
-    jest-validate "^28.0.2"
+    jest-config "^28.1.3"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
     prompts "^2.0.1"
     yargs "^17.3.1"
 
-jest-config@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-config/-/jest-config-28.0.3.tgz#9c0556d60d692153a6bc8652974182c22db9244f"
-  integrity sha512-3gWOEHwGpNhyYOk9vnUMv94x15QcdjACm7A3lERaluwnyD6d1WZWe9RFCShgIXVOHzRfG1hWxsI2U0gKKSGgDQ==
+jest-config@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-28.1.3.tgz#e315e1f73df3cac31447eed8b8740a477392ec60"
+  integrity sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/test-sequencer" "^28.0.2"
-    "@jest/types" "^28.0.2"
-    babel-jest "^28.0.3"
+    "@jest/test-sequencer" "^28.1.3"
+    "@jest/types" "^28.1.3"
+    babel-jest "^28.1.3"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
-    jest-circus "^28.0.3"
-    jest-environment-node "^28.0.2"
+    jest-circus "^28.1.3"
+    jest-environment-node "^28.1.3"
     jest-get-type "^28.0.2"
     jest-regex-util "^28.0.2"
-    jest-resolve "^28.0.3"
-    jest-runner "^28.0.3"
-    jest-util "^28.0.2"
-    jest-validate "^28.0.2"
+    jest-resolve "^28.1.3"
+    jest-runner "^28.1.3"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
     micromatch "^4.0.4"
     parse-json "^5.2.0"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-28.0.2.tgz#a543c90082560cd6cb14c5f28c39e6d4618ad7a6"
-  integrity sha512-33Rnf821Y54OAloav0PGNWHlbtEorXpjwchnToyyWbec10X74FOW7hGfvrXLGz7xOe2dz0uo9JVFAHHj/2B5pg==
+jest-diff@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-28.1.3.tgz#948a192d86f4e7a64c5264ad4da4877133d8792f"
+  integrity sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==
   dependencies:
     chalk "^4.0.0"
-    diff-sequences "^28.0.2"
+    diff-sequences "^28.1.1"
     jest-get-type "^28.0.2"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
 
-jest-docblock@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-28.0.2.tgz#3cab8abea53275c9d670cdca814fc89fba1298c2"
-  integrity sha512-FH10WWw5NxLoeSdQlJwu+MTiv60aXV/t8KEwIRGEv74WARE1cXIqh1vGdy2CraHuWOOrnzTWj/azQKqW4fO7xg==
+jest-docblock@^28.1.1:
+  version "28.1.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-28.1.1.tgz#6f515c3bf841516d82ecd57a62eed9204c2f42a8"
+  integrity sha512-3wayBVNiOYx0cwAbl9rwm5kKFP8yHH3d/fkEaL02NPTkDojPtheGB7HZSFY4wzX+DxyrvhXz0KSCVksmCknCuA==
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-each/-/jest-each-28.0.2.tgz#fcf6843e9afe5a3f2d0b1c02aab1f41889d92f1d"
-  integrity sha512-/W5Wc0b+ipR36kDaLngdVEJ/5UYPOITK7rW0djTlCCQdMuWpCFJweMW4TzAoJ6GiRrljPL8FwiyOSoSHKrda2w==
+jest-each@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-28.1.3.tgz#bdd1516edbe2b1f3569cfdad9acd543040028f81"
+  integrity sha512-arT1z4sg2yABU5uogObVPvSlSMQlDA48owx07BDPAiasW0yYpYHYOo4HHLz9q0BVzDVU4hILFjzJw0So9aCL/g==
   dependencies:
-    "@jest/types" "^28.0.2"
+    "@jest/types" "^28.1.3"
     chalk "^4.0.0"
     jest-get-type "^28.0.2"
-    jest-util "^28.0.2"
-    pretty-format "^28.0.2"
+    jest-util "^28.1.3"
+    pretty-format "^28.1.3"
 
-jest-environment-node@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-28.0.2.tgz#bd58e192b8f36a37e52c52fac812bd24b360c0b9"
-  integrity sha512-o9u5UHZ+NCuIoa44KEF0Behhsz/p1wMm0WumsZfWR1k4IVoWSt3aN0BavSC5dd26VxSGQvkrCnJxxOzhhUEG3Q==
+jest-environment-node@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-28.1.3.tgz#7e74fe40eb645b9d56c0c4b70ca4357faa349be5"
+  integrity sha512-ugP6XOhEpjAEhGYvp5Xj989ns5cB1K6ZdjBYuS30umT4CQEETaxSiPcZ/E1kFktX4GkrcM4qu07IIlDYX1gp+A==
   dependencies:
-    "@jest/environment" "^28.0.2"
-    "@jest/fake-timers" "^28.0.2"
-    "@jest/types" "^28.0.2"
+    "@jest/environment" "^28.1.3"
+    "@jest/fake-timers" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
-    jest-mock "^28.0.2"
-    jest-util "^28.0.2"
+    jest-mock "^28.1.3"
+    jest-util "^28.1.3"
 
 jest-get-type@^28.0.2:
   version "28.0.2"
   resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
   integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
 
-jest-haste-map@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz#0c768f43680013cfd2a4471a3ec76c47bfb9e7c6"
-  integrity sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==
+jest-haste-map@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-28.1.3.tgz#abd5451129a38d9841049644f34b034308944e2b"
+  integrity sha512-3S+RQWDXccXDKSWnkHa/dPwt+2qwA8CJzR61w3FoYCvoo3Pn8tvGcysmMF0Bj0EX5RYvAI2EIvC57OmotfdtKA==
   dependencies:
-    "@jest/types" "^28.0.2"
+    "@jest/types" "^28.1.3"
     "@types/graceful-fs" "^4.1.3"
     "@types/node" "*"
     anymatch "^3.0.3"
     fb-watchman "^2.0.0"
     graceful-fs "^4.2.9"
     jest-regex-util "^28.0.2"
-    jest-util "^28.0.2"
-    jest-worker "^28.0.2"
+    jest-util "^28.1.3"
+    jest-worker "^28.1.3"
     micromatch "^4.0.4"
-    walker "^1.0.7"
+    walker "^1.0.8"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-leak-detector@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.0.2.tgz#cbde3d22d09bd690ececdc2ed01c608435328456"
-  integrity sha512-UGaSPYtxKXl/YKacq6juRAKmMp1z2os8NaU8PSC+xvNikmu3wF6QFrXrihMM4hXeMr9HuNotBrQZHmzDY8KIBQ==
+jest-leak-detector@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz#a6685d9b074be99e3adee816ce84fd30795e654d"
+  integrity sha512-WFVJhnQsiKtDEo5lG2mM0v40QWnBM+zMdHHyJs8AWZ7J0QZJS59MsyKeJHWhpBZBH32S48FOVvGyOFT1h0DlqA==
   dependencies:
     jest-get-type "^28.0.2"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
 
-jest-matcher-utils@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.0.2.tgz#eb461af204b6d0f05281e9228094f0ab7e9e8537"
-  integrity sha512-SxtTiI2qLJHFtOz/bySStCnwCvISAuxQ/grS+74dfTy5AuJw3Sgj9TVUvskcnImTfpzLoMCDJseRaeRrVYbAOA==
+jest-matcher-utils@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz#5a77f1c129dd5ba3b4d7fc20728806c78893146e"
+  integrity sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==
   dependencies:
     chalk "^4.0.0"
-    jest-diff "^28.0.2"
+    jest-diff "^28.1.3"
     jest-get-type "^28.0.2"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
 
-jest-message-util@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz#f3cf36be72be4c4c4058cb34bd6673996d26dee3"
-  integrity sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==
+jest-message-util@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-28.1.3.tgz#232def7f2e333f1eecc90649b5b94b0055e7c43d"
+  integrity sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^28.0.2"
+    "@jest/types" "^28.1.3"
     "@types/stack-utils" "^2.0.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     micromatch "^4.0.4"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-28.0.2.tgz#059b500b34c1dd76474ebcdeccc249fe4dd0249f"
-  integrity sha512-vfnJ4zXRB0i24jOTGtQJyl26JKsgBKtqRlCnsrORZbG06FToSSn33h2x/bmE8XxqxkLWdZBRo+/65l8Vi3nD+g==
+jest-mock@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-28.1.3.tgz#d4e9b1fc838bea595c77ab73672ebf513ab249da"
+  integrity sha512-o3J2jr6dMMWYVH4Lh/NKmDXdosrsJgi4AviS8oXLujcjpCMBb1FMsblDnOXKZKfSiHLxYub1eS0IHuRXsio9eA==
   dependencies:
-    "@jest/types" "^28.0.2"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.2:
@@ -2158,168 +2168,169 @@ jest-regex-util@^28.0.2:
   resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz#afdc377a3b25fb6e80825adcf76c854e5bf47ead"
   integrity sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==
 
-jest-resolve-dependencies@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-28.0.3.tgz#76d8f59f7e76ba36d76a1677eeaaed24560da7e0"
-  integrity sha512-lCgHMm0/5p0qHemrOzm7kI6JDei28xJwIf7XOEcv1HeAVHnsON8B8jO/woqlU+/GcOXb58ymieYqhk3zjGWnvQ==
+jest-resolve-dependencies@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-28.1.3.tgz#8c65d7583460df7275c6ea2791901fa975c1fe66"
+  integrity sha512-qa0QO2Q0XzQoNPouMbCc7Bvtsem8eQgVPNkwn9LnS+R2n8DaVDPL/U1gngC0LTl1RYXJU0uJa2BMC2DbTfFrHA==
   dependencies:
     jest-regex-util "^28.0.2"
-    jest-snapshot "^28.0.3"
+    jest-snapshot "^28.1.3"
 
-jest-resolve@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.0.3.tgz#63f8e6b53e40f265b3ca9116195221dd43e3d16d"
-  integrity sha512-lfgjd9JhEjpjIN3HLUfdysdK+A7ePQoYmd7WL9DUEWqdnngb1rF56eee6iDXJxl/3eSolpP43VD7VrhjL3NsoQ==
+jest-resolve@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-28.1.3.tgz#cfb36100341ddbb061ec781426b3c31eb51aa0a8"
+  integrity sha512-Z1W3tTjE6QaNI90qo/BJpfnvpxtaFTFw5CDgwpyE/Kz8U/06N1Hjf4ia9quUhCh39qIGWF1ZuxFiBiJQwSEYKQ==
   dependencies:
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.0.2"
+    jest-haste-map "^28.1.3"
     jest-pnp-resolver "^1.2.2"
-    jest-util "^28.0.2"
-    jest-validate "^28.0.2"
+    jest-util "^28.1.3"
+    jest-validate "^28.1.3"
     resolve "^1.20.0"
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
-jest-runner@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-28.0.3.tgz#a8a409c685ad3081a44b149b2eb04bc4d47faaf9"
-  integrity sha512-4OsHMjBLtYUWCENucAQ4Za0jGfEbOFi/Fusv6dzUuaweqx8apb4+5p2LR2yvgF4StFulmxyC238tGLftfu+zBA==
+jest-runner@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-28.1.3.tgz#5eee25febd730b4713a2cdfd76bdd5557840f9a1"
+  integrity sha512-GkMw4D/0USd62OVO0oEgjn23TM+YJa2U2Wu5zz9xsQB1MxWKDOlrnykPxnMsN0tnJllfLPinHTka61u0QhaxBA==
   dependencies:
-    "@jest/console" "^28.0.2"
-    "@jest/environment" "^28.0.2"
-    "@jest/test-result" "^28.0.2"
-    "@jest/transform" "^28.0.3"
-    "@jest/types" "^28.0.2"
+    "@jest/console" "^28.1.3"
+    "@jest/environment" "^28.1.3"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
     chalk "^4.0.0"
     emittery "^0.10.2"
     graceful-fs "^4.2.9"
-    jest-docblock "^28.0.2"
-    jest-environment-node "^28.0.2"
-    jest-haste-map "^28.0.2"
-    jest-leak-detector "^28.0.2"
-    jest-message-util "^28.0.2"
-    jest-resolve "^28.0.3"
-    jest-runtime "^28.0.3"
-    jest-util "^28.0.2"
-    jest-watcher "^28.0.2"
-    jest-worker "^28.0.2"
+    jest-docblock "^28.1.1"
+    jest-environment-node "^28.1.3"
+    jest-haste-map "^28.1.3"
+    jest-leak-detector "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-resolve "^28.1.3"
+    jest-runtime "^28.1.3"
+    jest-util "^28.1.3"
+    jest-watcher "^28.1.3"
+    jest-worker "^28.1.3"
+    p-limit "^3.1.0"
     source-map-support "0.5.13"
-    throat "^6.0.1"
 
-jest-runtime@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-runtime/-/jest-runtime-28.0.3.tgz#02346a34de0ac61d23bdb0e8c035ad973d7bb087"
-  integrity sha512-7FtPUmvbZEHLOdjsF6dyHg5Pe4E0DU+f3Vvv8BPzVR7mQA6nFR4clQYLAPyJGnsUvN8WRWn+b5a5SVwnj1WaGg==
+jest-runtime@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-28.1.3.tgz#a57643458235aa53e8ec7821949e728960d0605f"
+  integrity sha512-NU+881ScBQQLc1JHG5eJGU7Ui3kLKrmwCPPtYsJtBykixrM2OhVQlpMmFWJjMyDfdkGgBMNjXCGB/ebzsgNGQw==
   dependencies:
-    "@jest/environment" "^28.0.2"
-    "@jest/fake-timers" "^28.0.2"
-    "@jest/globals" "^28.0.3"
-    "@jest/source-map" "^28.0.2"
-    "@jest/test-result" "^28.0.2"
-    "@jest/transform" "^28.0.3"
-    "@jest/types" "^28.0.2"
+    "@jest/environment" "^28.1.3"
+    "@jest/fake-timers" "^28.1.3"
+    "@jest/globals" "^28.1.3"
+    "@jest/source-map" "^28.1.2"
+    "@jest/test-result" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
     execa "^5.0.0"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.0.2"
-    jest-message-util "^28.0.2"
-    jest-mock "^28.0.2"
+    jest-haste-map "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-mock "^28.1.3"
     jest-regex-util "^28.0.2"
-    jest-resolve "^28.0.3"
-    jest-snapshot "^28.0.3"
-    jest-util "^28.0.2"
+    jest-resolve "^28.1.3"
+    jest-snapshot "^28.1.3"
+    jest-util "^28.1.3"
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
-jest-snapshot@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-28.0.3.tgz#9a768d0c617d070e87c1bd37240f22b344616154"
-  integrity sha512-nVzAAIlAbrMuvVUrS1YxmAeo1TfSsDDU+K5wv/Ow56MBp+L+Y71ksAbwRp3kGCgZAz4oOXcAMPAwtT9Yh1hlQQ==
+jest-snapshot@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-28.1.3.tgz#17467b3ab8ddb81e2f605db05583d69388fc0668"
+  integrity sha512-4lzMgtiNlc3DU/8lZfmqxN3AYD6GGLbl+72rdBpXvcV+whX7mDrREzkPdp2RnmfIiWBg1YbuFSkXduF2JcafJg==
   dependencies:
     "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.3.3"
-    "@jest/expect-utils" "^28.0.2"
-    "@jest/transform" "^28.0.3"
-    "@jest/types" "^28.0.2"
+    "@jest/expect-utils" "^28.1.3"
+    "@jest/transform" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/babel__traverse" "^7.0.6"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^28.0.2"
+    expect "^28.1.3"
     graceful-fs "^4.2.9"
-    jest-diff "^28.0.2"
+    jest-diff "^28.1.3"
     jest-get-type "^28.0.2"
-    jest-haste-map "^28.0.2"
-    jest-matcher-utils "^28.0.2"
-    jest-message-util "^28.0.2"
-    jest-util "^28.0.2"
+    jest-haste-map "^28.1.3"
+    jest-matcher-utils "^28.1.3"
+    jest-message-util "^28.1.3"
+    jest-util "^28.1.3"
     natural-compare "^1.4.0"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
     semver "^7.3.5"
 
-jest-util@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz#8e22cdd6e0549e0a393055f0e2da7eacc334b143"
-  integrity sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==
+jest-util@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.3.tgz#f4f932aa0074f0679943220ff9cbba7e497028b0"
+  integrity sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==
   dependencies:
-    "@jest/types" "^28.0.2"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-validate@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-validate/-/jest-validate-28.0.2.tgz#58bb7e826c054a8bb3b54c05f73758d96cf6dbef"
-  integrity sha512-nr0UOvCTtxP0YPdsk01Gk7e7c0xIiEe2nncAe3pj0wBfUvAykTVrMrdeASlAJnlEQCBuwN/GF4hKoCzbkGNCNw==
+jest-validate@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-28.1.3.tgz#e322267fd5e7c64cea4629612c357bbda96229df"
+  integrity sha512-SZbOGBWEsaTxBGCOpsRWlXlvNkvTkY0XxRfh7zYmvd8uL5Qzyg0CHAXiXKROflh801quA6+/DsT4ODDthOC/OA==
   dependencies:
-    "@jest/types" "^28.0.2"
+    "@jest/types" "^28.1.3"
     camelcase "^6.2.0"
     chalk "^4.0.0"
     jest-get-type "^28.0.2"
     leven "^3.1.0"
-    pretty-format "^28.0.2"
+    pretty-format "^28.1.3"
 
-jest-watcher@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.0.2.tgz#649fa24df531d4071be5784b6274d494d788c88b"
-  integrity sha512-uIVJLpQ/5VTGQWBiBatHsi7jrCqHjHl0e0dFHMWzwuIfUbdW/muk0DtSr0fteY2T7QTFylv+7a5Rm8sBKrE12Q==
+jest-watcher@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-28.1.3.tgz#c6023a59ba2255e3b4c57179fc94164b3e73abd4"
+  integrity sha512-t4qcqj9hze+jviFPUN3YAtAEeFnr/azITXQEMARf5cMwKY2SMBRnCQTXLixTl20OR6mLh9KLMrgVJgJISym+1g==
   dependencies:
-    "@jest/test-result" "^28.0.2"
-    "@jest/types" "^28.0.2"
+    "@jest/test-result" "^28.1.3"
+    "@jest/types" "^28.1.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     emittery "^0.10.2"
-    jest-util "^28.0.2"
+    jest-util "^28.1.3"
     string-length "^4.0.1"
 
-jest-worker@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz#75f7e5126541289ba02e9c1a67e46349ddb8141d"
-  integrity sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==
+jest-worker@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-28.1.3.tgz#7e3c4ce3fa23d1bb6accb169e7f396f98ed4bb98"
+  integrity sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^28.0.3:
-  version "28.0.3"
-  resolved "https://registry.npmjs.org/jest/-/jest-28.0.3.tgz#92a7d6ee097b61de4ba2db7f3ab723e81a99b32d"
-  integrity sha512-uS+T5J3w5xyzd1KSJCGKhCo8WTJXbNl86f5SW11wgssbandJOVLRKKUxmhdFfmKxhPeksl1hHZ0HaA8VBzp7xA==
+jest@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-28.1.3.tgz#e9c6a7eecdebe3548ca2b18894a50f45b36dfc6b"
+  integrity sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==
   dependencies:
-    "@jest/core" "^28.0.3"
+    "@jest/core" "^28.1.3"
+    "@jest/types" "^28.1.3"
     import-local "^3.0.2"
-    jest-cli "^28.0.3"
+    jest-cli "^28.1.3"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2590,6 +2601,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -2700,12 +2718,12 @@ prettier@2.6.2:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
-pretty-format@^28.0.2:
-  version "28.0.2"
-  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz#6a24d71cbb61a5e5794ba7513fe22101675481bc"
-  integrity sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==
+pretty-format@^28.1.3:
+  version "28.1.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-28.1.3.tgz#c9fba8cedf99ce50963a11b27d982a9ae90970d5"
+  integrity sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==
   dependencies:
-    "@jest/schemas" "^28.0.2"
+    "@jest/schemas" "^28.1.3"
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
@@ -2989,11 +3007,6 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-throat@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
-  integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
-
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -3092,18 +3105,18 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-v8-to-istanbul@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.0.tgz#be0dae58719fc53cb97e5c7ac1d7e6d4f5b19511"
-  integrity sha512-HcvgY/xaRm7isYmyx+lFKA4uQmfUbN0J4M0nNItvzTvH/iQ9kW5j/t4YSR+Ge323/lrgDAWJoF46tzGQHwBHFw==
+v8-to-istanbul@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz#b6f994b0b5d4ef255e17a0d17dc444a9f5132fa4"
+  integrity sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.7"
+    "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
-walker@^1.0.7:
+walker@^1.0.8:
   version "1.0.8"
-  resolved "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
@@ -3180,3 +3193,8 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,6 +326,21 @@
     "@graphql-tools/utils" "8.6.9"
     tslib "~2.3.0"
 
+"@graphql-tools/merge@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.3.tgz#74dd4816c3fc7af38730fc59d1cba6e687d7fb2d"
+  integrity sha512-EfULshN2s2s2mhBwbV9WpGnoehRLe7eIMdZrKfHhxlBWOvtNUd3KSCN0PUdAMd7lj1jXUW9KYdn624JrVn6qzg==
+  dependencies:
+    "@graphql-tools/utils" "8.10.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/utils@8.10.0":
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.10.0.tgz#8e76db7487e19b60cf99fb90c2d6343b2105b331"
+  integrity sha512-yI+V373FdXQbYfqdarehn9vRWDZZYuvyQ/xwiv5ez2BbobHrqsexF7qs56plLRaQ8ESYpVAjMQvJWe9s23O0Jg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@graphql-tools/utils@8.6.9":
   version "8.6.9"
   resolved "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.6.9.tgz#fe1b81df29c9418b41b7a1ffe731710b93d3a1fe"
@@ -942,6 +957,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -1544,6 +1566,11 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
+fp-async-utils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fp-async-utils/-/fp-async-utils-2.0.1.tgz#073428581b58815ab7cc466023988cde4d35e3b0"
+  integrity sha512-mzGPHB14YeVeY71hJu4GPvIRYaINkOhQzCGSgLqdKttJEX1yzVl0Qq3OPqHgbBb8RB7jGKQTkclsZU9RklzaHA==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1626,6 +1653,17 @@ glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -2429,6 +2467,13 @@ minimatch@^3.0.4, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
@@ -2980,6 +3025,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@~2.3.0:
   version "2.3.1"


### PR DESCRIPTION
If a graph has a large schema, we may want to split the type definitions of that schema into multiple files.

This change uses the `glob` library to parse the source input, and works with either a single file or a glob. The `glob` library outputs an array of filepaths over which we can iterate to extract the schemas, merge those schemas into a single `DocumentNode`, and the print it to a string.

Also added some tests to make sure it was working with globs and single files. 
