### PR TITLE
Fix trailing bracket bug

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -81114,7 +81114,10 @@ async function removeEmptySchemaContent(schema) {
   const lines = schema.match(/[^\r\n]+/g);
 
   const schemaTokenIndex = lines.findIndex((line) => line.includes('schema {'));
-  const schemaContentEmpty = schemaTokenIndex !== -1 && lines[schemaTokenIndex + 1] === '  ';
+  const schemaContentEmpty =
+    schemaTokenIndex !== -1 &&
+    lines[schemaTokenIndex + 1].trim() === '' &&
+    lines[schemaTokenIndex + 2].trim() === '}';
   if (schemaContentEmpty) {
     lines.splice(schemaTokenIndex, 3);
     return lines.join('\n');

--- a/src/pluck-schema.js
+++ b/src/pluck-schema.js
@@ -44,7 +44,10 @@ async function removeEmptySchemaContent(schema) {
   const lines = schema.match(/[^\r\n]+/g);
 
   const schemaTokenIndex = lines.findIndex((line) => line.includes('schema {'));
-  const schemaContentEmpty = schemaTokenIndex !== -1 && lines[schemaTokenIndex + 1] === '  ';
+  const schemaContentEmpty =
+    schemaTokenIndex !== -1 &&
+    lines[schemaTokenIndex + 1].trim() === '' &&
+    lines[schemaTokenIndex + 2].trim() === '}';
   if (schemaContentEmpty) {
     lines.splice(schemaTokenIndex, 3);
     return lines.join('\n');

--- a/test/pluck-schema.test.js
+++ b/test/pluck-schema.test.js
@@ -1,6 +1,10 @@
 /* eslint-disable no-undef */
 const pluckSchema = require('../src/pluck-schema');
 
+function getLines(str) {
+  return str.match(/[^\r\n]+/g);
+}
+
 describe('pluck-schema', () => {
   it('works with single files', async () => {
     const result = await pluckSchema('test/schema/schema1.js');
@@ -32,9 +36,18 @@ describe('pluck-schema', () => {
   });
   it('removes empty "schema <..> { }" when "query: Query" is removed with federation 2 composition', async () => {
     const result = await pluckSchema('test/schema-federation-2_no_mutation/**/*.js');
-    const lines = result.match(/[^\r\n]+/g);
+    const lines = getLines(result);
     const index = lines.findIndex((line) => line.includes('extend schema @link('));
     const hasBrackets = lines[index].includes('{');
     expect(hasBrackets).toBe(false);
+  });
+
+  it('doesnt leave trailing brackets', async () => {
+    const result = await pluckSchema('test/schema/**/*.js');
+    const lines = getLines(result);
+    const penultimateLine = lines[lines.length - 2].trim();
+    const lastLine = lines[lines.length - 1].trim();
+    const bothLinesAreBrackets = penultimateLine === '}' && lastLine === '}';
+    expect(bothLinesAreBrackets).not.toBe(true);
   });
 });

--- a/test/schema/schema4.js
+++ b/test/schema/schema4.js
@@ -1,0 +1,11 @@
+var gql;
+
+gql`
+  type TheInput4 {
+    someField: String!
+  }
+
+  type Mutation {
+    mutation(input: TheInput4): String
+  }
+`;


### PR DESCRIPTION
## Changes

After removing `query: Query` from a `schema` declaration to fix the Federation 2 bug, we also need to check for `mutation: Mutation`. If the latter exists, the schema is not empty and is therefore valid.