### PR TITLE
fix: Fix trailing brackets with federation 2 schema

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -81125,7 +81125,9 @@ async function removeEmptySchemaContent(schema) {
 
   const fed2SchemaTokenIndex = lines.findIndex((line) => line.includes('extend schema @link('));
   const fed2SchemaContentEmpty =
-    fed2SchemaTokenIndex !== -1 && lines[fed2SchemaTokenIndex + 1] === '  ';
+    fed2SchemaTokenIndex !== -1 &&
+    lines[fed2SchemaTokenIndex + 1].trim() === '' &&
+    lines[fed2SchemaTokenIndex + 2].trim() === '}';
   if (fed2SchemaContentEmpty) {
     lines.splice(fed2SchemaTokenIndex + 1, 2);
     return lines

--- a/src/pluck-schema.js
+++ b/src/pluck-schema.js
@@ -55,7 +55,9 @@ async function removeEmptySchemaContent(schema) {
 
   const fed2SchemaTokenIndex = lines.findIndex((line) => line.includes('extend schema @link('));
   const fed2SchemaContentEmpty =
-    fed2SchemaTokenIndex !== -1 && lines[fed2SchemaTokenIndex + 1] === '  ';
+    fed2SchemaTokenIndex !== -1 &&
+    lines[fed2SchemaTokenIndex + 1].trim() === '' &&
+    lines[fed2SchemaTokenIndex + 2].trim() === '}';
   if (fed2SchemaContentEmpty) {
     lines.splice(fed2SchemaTokenIndex + 1, 2);
     return lines

--- a/test/pluck-schema.test.js
+++ b/test/pluck-schema.test.js
@@ -42,12 +42,21 @@ describe('pluck-schema', () => {
     expect(hasBrackets).toBe(false);
   });
 
-  it('doesnt leave trailing brackets', async () => {
+  it('doesnt leave trailing brackets with federation 1 schema', async () => {
     const result = await pluckSchema('test/schema/**/*.js');
     const lines = getLines(result);
     const penultimateLine = lines[lines.length - 2].trim();
     const lastLine = lines[lines.length - 1].trim();
     const bothLinesAreBrackets = penultimateLine === '}' && lastLine === '}';
     expect(bothLinesAreBrackets).not.toBe(true);
+  });
+
+  it('doesnt leave trailing brackets with federation 2 schema', async () => {
+    const result = await pluckSchema('test/schema-federation-2/**/*.js');
+    const lines = getLines(result);
+    const index = lines.findIndex((line) => line.includes('extend schema @link('));
+    const nextLine = lines[index + 1].trim();
+    const nextLineIsNotABracket = nextLine === '}';
+    expect(nextLineIsNotABracket).not.toBe(true);
   });
 });


### PR DESCRIPTION
## Changes
- Fixes a bug where a trailing bracket is left in Federation 2 schemas with both Queries and Mutations.